### PR TITLE
Remove bisheng from jdk11u nightly build until we have reliable infra to run it on

### DIFF
--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -8,7 +8,7 @@ targetConfigurations = [
         "s390xLinux"    : [    "hotspot",    "openj9"                    ],
         "aarch64Linux"  : [    "hotspot",    "openj9",    "dragonwell"            ],
         "arm32Linux"    : [    "hotspot"                            ],
-        "riscv64Linux"  : [			"openj9",			"bisheng"	]
+        "riscv64Linux"  : [			"openj9"			]
 ]
 
 // 18:05 Tue, Thur
@@ -21,8 +21,7 @@ weekly_release_scmReferences=[
         "hotspot"        : "",
         "openj9"         : "",
         "corretto"       : "",
-        "dragonwell"     : "",
-        "bisheng"        : ""
+        "dragonwell"     : ""
 ]
 
 return this


### PR DESCRIPTION
test-gdams-debian10-riscv64-1 is not reliable enough for nightly builds, so removing jdk11u riscv64-bisheng from the nightly builds until we fix this issue: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/2113

Signed-off-by: Andrew Leonard <anleonar@redhat.com>