### PR TITLE
Revert "Pipeline Triggers instead of triggers" for Jenkinsfile

### DIFF
--- a/tools/code-tools/Jenkinsfile
+++ b/tools/code-tools/Jenkinsfile
@@ -5,14 +5,8 @@ NODE_LABEL = "dockerBuild&&linux&&x64"
 pipeline {
     agent none
 
-    properties {
-        pipelineTriggers {
-            triggers {
-                cron {
-                    spec(CRON_SETTINGS)
-                }
-            }
-        }
+    triggers {
+        cron(CRON_SETTINGS)
     }
 
     stages {


### PR DESCRIPTION
* Properties and pipelineTriggers does not exist for this type of job

Signed-off-by: Morgan Davies <morgandavies2020@gmail.com>