### PR TITLE
Run weekend trial Release builds

### DIFF
--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -18,8 +18,8 @@ triggerSchedule_weekly="TZ=UTC\n05 17 * * 6"
 
 // scmReferences to use for weekly release build
 weekly_release_scmReferences=[
-        "hotspot"        : "",
-        "openj9"         : "",
+        "hotspot"        : "release",
+        "openj9"         : "v0.26.0-release",
         "corretto"       : "",
         "dragonwell"     : ""
 ]

--- a/pipelines/jobs/configurations/jdk16u.groovy
+++ b/pipelines/jobs/configurations/jdk16u.groovy
@@ -45,8 +45,8 @@ triggerSchedule_weekly="TZ=UTC\n30 04 * * 7"
 
 // scmReferences to use for weekly release build
 weekly_release_scmReferences=[
-        "hotspot"        : "",
-        "openj9"         : "",
+        "hotspot"        : "release",
+        "openj9"         : "v0.26.0-release",
         "corretto"       : "",
         "dragonwell"     : ""
 ]

--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -50,8 +50,8 @@ triggerSchedule_weekly="TZ=UTC\n05 12 * * 6"
 
 // scmReferences to use for weekly release build
 weekly_release_scmReferences=[
-        "hotspot"        : "",
-        "openj9"         : "",
+        "hotspot"        : "release",
+        "openj9"         : "v0.26.0-release",
         "corretto"       : "",
         "dragonwell"     : ""
 ]


### PR DESCRIPTION
In preparation for April quarterly update we are running trial release builds over the weekend.

**Note:**
Hotspot builds "release" branch, which is last merged jdk tag with Adopt patches:
- jdk8u282-b08
- jdk-11.0.11+8
- jdk-16+36

OpenJ9 builds their "release" branch:
- v0.26.0-release

Signed-off-by: Andrew Leonard <anleonar@redhat.com>