### PR TITLE
Disable jdk8u sparcv9 solaris builds due to no available nodes

### DIFF
--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -37,9 +37,6 @@ targetConfigurations = [
         ],
         "arm32Linux"  : [
                 "hotspot"
-        ],
-        "sparcv9Solaris": [
-                "hotspot"
         ]
 ]
 


### PR DESCRIPTION
Signed-off-by: Andrew Leonard <anleonar@redhat.com>