### PR TITLE
add support for building Bisheng JDK8/11 on Linux_x64/aarch64

### DIFF
--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -1,12 +1,12 @@
 targetConfigurations = [
         "x64Mac"        : [    "hotspot",    "openj9"                    ],
-        "x64Linux"      : [    "hotspot",    "openj9",    "dragonwell",    "corretto"    ],
+        "x64Linux"      : [    "hotspot",    "openj9",    "dragonwell",    "corretto",    "bisheng"    ],
         "x64Windows"    : [    "hotspot",    "openj9",    "dragonwell"            ],
         "x32Windows"    : [    "hotspot"                            ],
         "ppc64Aix"      : [    "hotspot",    "openj9"                    ],
         "ppc64leLinux"  : [    "hotspot",    "openj9"                    ],
         "s390xLinux"    : [    "hotspot",    "openj9"                    ],
-        "aarch64Linux"  : [    "hotspot",    "openj9",    "dragonwell"            ],
+        "aarch64Linux"  : [    "hotspot",    "openj9",    "dragonwell",    "bisheng"     ],
         "arm32Linux"    : [    "hotspot"                            ],
         "riscv64Linux"  : [			"openj9"			]
 ]

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -33,7 +33,8 @@ class Config11 {
                         "hotspot"     : '--enable-dtrace=auto',
                         "corretto"    : '--enable-dtrace=auto',
                         "SapMachine"  : '--enable-dtrace=auto',
-                        "dragonwell"  : '--enable-dtrace=auto --enable-unlimited-crypto --with-jvm-variants=server --with-zlib=system --with-jvm-features=zgc'
+                        "dragonwell"  : '--enable-dtrace=auto --enable-unlimited-crypto --with-jvm-variants=server --with-zlib=system --with-jvm-features=zgc',
+                        "bisheng"     : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server --disable-warnings-as-errors'
                 ]
         ],
 
@@ -129,7 +130,8 @@ class Config11 {
                         "hotspot" : '--enable-dtrace=auto',
                         "openj9" : '--enable-dtrace=auto',
                         "corretto" : '--enable-dtrace=auto',
-                        "dragonwell" : "--enable-dtrace=auto --with-extra-cflags=\"-march=armv8.2-a+crypto\" --with-extra-cxxflags=\"-march=armv8.2-a+crypto\""
+                        "dragonwell" : "--enable-dtrace=auto --with-extra-cflags=\"-march=armv8.2-a+crypto\" --with-extra-cxxflags=\"-march=armv8.2-a+crypto\"",
+                        "bisheng" : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server'
                 ]
         ],
 

--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -7,7 +7,8 @@ targetConfigurations = [
                 "hotspot",
                 "openj9",
                 "corretto",
-                "dragonwell"
+                "dragonwell",
+                "bisheng"
         ],
         "x32Windows"    : [
                 "hotspot",
@@ -33,7 +34,8 @@ targetConfigurations = [
         "aarch64Linux"  : [
                 "hotspot",
                 "openj9",
-                "dragonwell"
+                "dragonwell",
+                "bisheng"
         ],
         "arm32Linux"  : [
                 "hotspot"
@@ -50,7 +52,8 @@ weekly_release_scmReferences=[
         "hotspot"        : "",
         "openj9"         : "",
         "corretto"       : "",
-        "dragonwell"     : ""
+        "dragonwell"     : "",
+        "bisheng"        : ""
 ]
 
 return this


### PR DESCRIPTION
@sxa Since bisheng jdk 8/11 is supported by the build farm on Linux_x64/aarch64, we hope they can also be added to the pipeline. Could you help me for this? 