### PR TITLE
Enable bisheng risc-v from jdk11u nightly build through cross-compile

### DIFF
--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -6,9 +6,9 @@ targetConfigurations = [
         "ppc64Aix"      : [    "hotspot",    "openj9"                    ],
         "ppc64leLinux"  : [    "hotspot",    "openj9"                    ],
         "s390xLinux"    : [    "hotspot",    "openj9"                    ],
-        "aarch64Linux"  : [    "hotspot",    "openj9",    "dragonwell",    "bisheng"     ],
+        "aarch64Linux"  : [    "hotspot",    "openj9",    "dragonwell",                   "bisheng"    ],
         "arm32Linux"    : [    "hotspot"                            ],
-        "riscv64Linux"  : [			"openj9"			]
+        "riscv64Linux"  : [                  "openj9",                                    "bisheng"    ]
 ]
 
 // 18:05 Tue, Thur
@@ -21,7 +21,8 @@ weekly_release_scmReferences=[
         "hotspot"        : "",
         "openj9"         : "",
         "corretto"       : "",
-        "dragonwell"     : ""
+        "dragonwell"     : "",
+        "bisheng"        : ""
 ]
 
 return this

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -172,17 +172,21 @@ class Config11 {
         riscv64Linux      :  [
                 os                   : 'linux',
                 dockerImage          : [
-                        "openj9" : 'adoptopenjdk/centos6_build_image',
+                        "openj9"     : 'adoptopenjdk/centos6_build_image',
+                        "bisheng"    : 'adoptopenjdk/centos6_build_image',
                 ],
                 arch                 : 'riscv64',
                 crossCompile         : [
-                        "openj9"     : 'x64'
+                        "openj9"     : 'x64',
+                        "bisheng"    : 'x64',
                 ],
                 buildArgs            : [
-                        "openj9"     : '--cross-compile'
+                        "openj9"     : '--cross-compile',
+                        "bisheng"    : '--cross-compile',
                 ],
                 configureArgs        : [
-                        "openj9"     : '--disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root'
+                        "openj9"     : '--disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root',
+                        "bisheng"    : '--openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-jvm-features=shenandoahgc',
                 ]
         ]
   ]

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -173,20 +173,20 @@ class Config11 {
                 os                   : 'linux',
                 dockerImage          : [
                         "openj9"     : 'adoptopenjdk/centos6_build_image',
-                        "bisheng"    : 'adoptopenjdk/centos6_build_image',
+                        "bisheng"    : 'adoptopenjdk/centos6_build_image'
                 ],
                 arch                 : 'riscv64',
                 crossCompile         : [
                         "openj9"     : 'x64',
-                        "bisheng"    : 'x64',
+                        "bisheng"    : 'x64'
                 ],
                 buildArgs            : [
                         "openj9"     : '--cross-compile',
-                        "bisheng"    : '--cross-compile',
+                        "bisheng"    : '--cross-compile'
                 ],
                 configureArgs        : [
                         "openj9"     : '--disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root',
-                        "bisheng"    : '--openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-jvm-features=shenandoahgc',
+                        "bisheng"    : '--openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-jvm-features=shenandoahgc'
                 ]
         ]
   ]


### PR DESCRIPTION
https://github.com/adoptium/temurin-build/pull/2616/commits has been merged. This pr enables bishengjdk-11 risc-v nightly build.

Question: in temurin-build, I have added `BUILD_CC` and `BUILD_CXX` as configuring args, are they needed in pipeline jobs `configureArgs`?