### PR TITLE
Add job level security to hide non Temurin builds

### DIFF
--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -472,6 +472,7 @@ class Regeneration implements Serializable {
         Map<String, ?> params = config.toMap().clone() as Map
         params.put("JOB_NAME", jobName)
         params.put("JOB_FOLDER", jobFolder)
+        params.put("VARIANT", config.VARIANT)
         params.put("SCRIPT_PATH", scriptPath)
 
         params.put("GIT_URL", gitRemoteConfigs['url'])

--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -56,7 +56,22 @@ pipelineJob("$buildFolder/$JOB_NAME") {
         }
     }
     properties {
-    disableConcurrentBuilds()
+        // Hide all non Temurin builds from public view
+        if (VARIANT != "hotspot") {
+            authorizationMatrix {
+                inheritanceStrategy {
+                    // Do not inherit permissions from global configuration
+                    nonInheriting()
+                } 
+                permissions(['hudson.model.Item.Build:AdoptOpenJDK*build', 'hudson.model.Item.Build:AdoptOpenJDK*build-triage', 
+                'hudson.model.Item.Cancel:AdoptOpenJDK*build', 'hudson.model.Item.Cancel:AdoptOpenJDK*build-triage',
+                'hudson.model.Item.Configure:AdoptOpenJDK*build', 'hudson.model.Item.Configure:AdoptOpenJDK*build-triage',
+                'hudson.model.Item.Read:AdoptOpenJDK*build', 'hudson.model.Item.Read:AdoptOpenJDK*build-triage',
+                'hudson.model.Item.Workspace:AdoptOpenJDK*build', 'hudson.model.Item.Workspace:AdoptOpenJDK*build-triage',
+                'hudson.model.Run.Update:AdoptOpenJDK*build', 'hudson.model.Run.Update:AdoptOpenJDK*build-triage'])
+            }
+        }
+        disableConcurrentBuilds()
         copyArtifactPermission {
             projectNames('*')
         }

--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -158,12 +158,10 @@ class PullRequestTestPipeline implements Serializable {
 
 Map<String, ?> defaultTestConfigurations = [
     "x64Linux": [
-        "hotspot",
-        "openj9"
+        "hotspot"
     ],
     "aarch64Linux": [
-        "hotspot",
-        "openj9"
+        "hotspot"
     ],
     "x64Windows": [
         "hotspot"


### PR DESCRIPTION
Closes: https://github.com/adoptium/adoptium/issues/6

This change will apply a security matrix to all jobs that are not Temurin builds.