### PR TITLE
build exploded image first on macOS to enable EF signing

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -402,7 +402,7 @@ class Build {
     def sign(VersionInfo versionInfo) {
         // Sign and archive jobs if needed
         if (
-            buildConfig.TARGET_OS == "windows" || (buildConfig.TARGET_OS == "mac" && versionInfo.major == 8)
+            buildConfig.TARGET_OS == "windows" || (buildConfig.TARGET_OS == "mac")
         ) {
             context.stage("sign") {
                 def filter = ""
@@ -1113,7 +1113,14 @@ class Build {
                             if (useAdoptShellScripts) {
                                 context.println "[CHECKOUT] Checking out to AdoptOpenJDK/openjdk-build..."
                                 repoHandler.checkoutAdoptBuild(context)
-                                context.sh(script: "./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
+                                if (buildConfig.TARGET_OS == "mac" && buildConfig.JAVA_TO_BUILD != "jdk8u") {
+                                    context.println "Building an exploded image for signing"
+                                    context.sh(script: "./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']} --make-exploded-image")
+                                    context.println "Assembling the exploded image"
+                                    context.sh(script: "./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']} --assemble-exploded-image")
+                                } else {
+                                    context.sh(script: "./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
+                                }
                                 context.println "[CHECKOUT] Reverting pre-build AdoptOpenJDK/openjdk-build checkout..."
 
                                 // Special case for the pr tester as checking out to the user's pipelines doesn't play nicely

--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -1,7 +1,7 @@
 {
     "repository"             : {
-        "build_url"          : "https://github.com/AdoptOpenJDK/openjdk-build.git",
-        "build_branch"       : "master",
+        "build_url"          : "https://github.com/gdams/openjdk-build.git",
+        "build_branch"       : "jmods",
         "test_dirs"          : "/test/functional",
         "pipeline_url"       : "https://github.com/adoptium/ci-jenkins-pipelines.git",
         "pipeline_branch"    : "master"

--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -1,7 +1,7 @@
 {
     "repository"             : {
-        "build_url"          : "https://github.com/gdams/openjdk-build.git",
-        "build_branch"       : "jmods",
+        "build_url"          : "https://github.com/AdoptOpenJDK/openjdk-build.git",
+        "build_branch"       : "master",
         "test_dirs"          : "/test/functional",
         "pipeline_url"       : "https://github.com/adoptium/ci-jenkins-pipelines.git",
         "pipeline_branch"    : "master"


### PR DESCRIPTION
This PR splits the macOS (JDK11 +) build process into 3 steps.

1. Compile an exploded image
2. Grab the JMODs and send them to the EF signing process
3. Retrieve the signed JMODs and assemble the exploded image

This code will only be run if someone is using the Adopt build scripts rather than their own so should not affect other people depending on our pipelines.

closes: https://github.com/adoptium/adoptium/issues/1 (finally) 🎉 