### PR TITLE
sign jpackageapplauncher for jdk16+

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1125,7 +1125,9 @@ class Build {
                                     context.stash name: 'jmods',
                                         includes: "${macos_base_path}/hotspot/variant-server/**/*," +
                                             "${macos_base_path}/support/modules_cmds/**/*," +
-                                            "${macos_base_path}/support/modules_libs/**/*"
+                                            "${macos_base_path}/support/modules_libs/**/*," +
+                                            // JDK 16 + jpackage needs to be signed as well
+                                            "${macos_base_path}/jdk/modules/jdk.jpackage/jdk/jpackage/internal/resources/jpackageapplauncher" 
 
                                     context.node('eclipse-codesign') {
                                         context.sh "rm -rf ${macos_base_path}/* || true"
@@ -1161,6 +1163,10 @@ class Build {
                                     context.sh "rm -rf ${macos_base_path}/hotspot/variant-server || true"
                                     context.sh "rm -rf ${macos_base_path}/support/modules_cmds || true"
                                     context.sh "rm -rf ${macos_base_path}/support/modules_libs || true"
+                                    // JDK 16 + jpackage needs to be signed as well
+                                    if (buildConfig.JAVA_TO_BUILD != "jdk11u") {
+                                        context.sh "rm -rf ${macos_base_path}/jdk/modules/jdk.jpackage/jdk/jpackage/internal/resources/jpackageapplauncher || true"
+                                    }
 
                                     // Restore signed JMODs
                                     context.unstash 'signed_jmods'


### PR DESCRIPTION
Fixes the following notarization issue:

temurin-16.jdk/Contents/Home/jmods/jdk.jpackage.jmod/classes/jdk/jpackage/internal/resources/jpackageapplauncher\",\n      \"message\": \"The binary is not signed.\",\n 