### PR TITLE
Re-enable Solaris x64 now that there is a working build machine again

### DIFF
--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -39,6 +39,9 @@ targetConfigurations = [
         ],
         "arm32Linux"  : [
                 "hotspot"
+        ],
+        "x64Solaris": [
+                "hotspot"
         ]
 ]
 


### PR DESCRIPTION
Tested at https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk8u/job/jdk8u-solaris-x64-hotspot/622/
Fixes https://github.com/adoptium/infrastructure/issues/1865
Fixes https://github.com/adoptium/infrastructure/issues/1871
Had been disabled at https://github.com/adoptium/temurin-build/pull/2435