### PR TITLE
Update success rating to get build failures from TRSS

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -23,18 +23,10 @@ node ("master") {
   def trssUrl    = "${params.TRSS_URL}"
   def slackChannel = "${params.SLACK_CHANNEL}"
 
-  def buildFailures = 0
   def testStats = []
 
-  // Get the number of "Failing Builds"
-  stage("getBuildFailures") {
-    def builds = sh(returnStdout: true, script: "wget -q -O - ${jenkinsUrl}/view/Failing%20Builds/api/json")
-    def json = new JsonSlurper().parseText(builds)
-    buildFailures = json.jobs.size()
-  }
-
-  // Get the last Nightly test job & case stats
-  stage("getTestStats") {
+  // Get the last Nightly build and test job & case stats
+  stage("getStats") {
     // Get top level builds names
     def trssBuildNames = sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getTopLevelBuildNames?type=Test")
     def buildNamesJson = new JsonSlurper().parseText(trssBuildNames)
@@ -55,6 +47,8 @@ node ("master") {
             if (!foundNightly) {
               def pipeline_id = null
               def pipelineUrl
+              def buildJobSuccess = 0
+              def buildJobFailure = 0
               def testJobSuccess = 0
               def testJobUnstable = 0
               def testJobFailure = 0
@@ -102,10 +96,23 @@ node ("master") {
                   }
                 }
                 // Get all child Build jobs for this pipeline job
-                def pipelineBuildJobs = sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getAllChildBuilds?parentId=${pipeline_id}\\&buildNameRegex=^jdk.*")
+                def pipelineBuildJobs = sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getChildBuilds?parentId=${pipeline_id}")
                 def pipelineBuildJobsJson = new JsonSlurper().parseText(pipelineBuildJobs)
-                buildJobNumber = pipelineBuildJobsJson.size()
-                def testResult = [name: pipelineName, url: pipelineUrl, buildJobNumber: buildJobNumber,
+                buildJobNumber = pipelineBuildJobsJson.size() 
+                if (pipelineBuildJobsJson.size() > 0) {
+                  pipelineBuildJobsJson.each { buildJob ->
+                    if (buildJob.buildResult.equals("SUCCESS")) {
+                      buildJobSuccess += 1
+                    } else {
+                      buildJobFailure += 1
+                    }
+                  }
+                }
+
+                def testResult = [name: pipelineName, url: pipelineUrl,
+                          buildJobNumber:   buildJobNumber,
+                          buildJobSuccess:  buildJobSuccess,
+                          buildJobFailure:  buildJobFailure,
                           testJobSuccess:   testJobSuccess,
                           testJobUnstable:  testJobUnstable,
                           testJobFailure:   testJobFailure,
@@ -124,9 +131,7 @@ node ("master") {
 
   // Print the results
   stage("printResults") {
-    echo "==================================================================================="
-    echo "Build Failures = ${buildFailures}"
-    echo "==================================================================================="
+    def buildFailures = 0
     def nightlyTestSuccessRating = 0
     def numTestPipelines = 0
     def totalBuildJobs = 0
@@ -134,6 +139,8 @@ node ("master") {
     testStats.each { pipeline ->
       echo "Pipeline : ${pipeline.name} : ${pipeline.url}"
       echo "  => Number of Build jobs = ${pipeline.buildJobNumber}"
+      echo "  => Build job SUCCESS   = ${pipeline.buildJobSuccess}"
+      echo "  => Build job FAILURE   = ${pipeline.buildJobFailure}"
       echo "  => Number of Test jobs = ${pipeline.testJobNumber}" 
       echo "  => Test job SUCCESS    = ${pipeline.testJobSuccess}"
       echo "  => Test job UNSTABLE   = ${pipeline.testJobUnstable}"
@@ -143,6 +150,7 @@ node ("master") {
       echo "  => Test case Disabled  = ${pipeline.testCaseDisabled}"
       echo "==================================================================================="
       totalBuildJobs += pipeline.buildJobNumber
+      buildFailures += pipeline.buildJobFailure
       totalTestJobs += pipeline.testJobNumber
       // Did tests run? (build may have failed)
       if (pipeline.testJobNumber > 0) {
@@ -179,7 +187,7 @@ node ("master") {
     echo "======> Overall Nightly Build & Test Success Rating = ${overallNightlySuccessRating} %"
 
     // Slack message:
-    slackSend(channel: slackChannel, color: 'good', message: 'Adoptium Jenkins Nightly Build & Test Pipeline Success Rating: '+overallNightlySuccessRating+' % (derived from '+totalBuildJobs+' at '+nightlyBuildSuccessRating.intValue()+' %, '+totalTestJobs+' at '+nightlyTestSuccessRating.intValue()+' %)')
+    slackSend(channel: slackChannel, color: 'good', message: 'Adoptium Jenkins Nightly Build & Test Pipeline Success Rating: '+overallNightlySuccessRating+' %\n  - Build Jobs: '+totalBuildJobs+' at '+nightlyBuildSuccessRating.intValue()+' %\n  - Test Jobs: '+totalTestJobs+' at '+nightlyTestSuccessRating.intValue()+' %\n<'+jenkinsUrl+'/view/Tooling/job/nightlyBuildAndTestStats/'+BUILD_NUMBER+'/console|Job>')
   }
 }
 


### PR DESCRIPTION
This avoids trying to scrape ci.adoptopenjdk.net for builds results and the auth problems that involves, using TRSS API instead.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>