### PR TITLE
re-enable Solaris Sparc builds for JDK8

### DIFF
--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -42,6 +42,9 @@ targetConfigurations = [
         ],
         "x64Solaris": [
                 "hotspot"
+        ],
+        "sparcv9Solaris": [
+                "hotspot"
         ]
 ]
 


### PR DESCRIPTION
Sparc was disabled because all the machines went down. We now have 2 build/test machines and the builds are passing so bringing this back into the nightly builds.

CC @smlambert let's work on getting the testing running on these boxes when you get some time

Seen to be passing again at https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk8u/job/jdk8u-solaris-sparcv9-hotspot/