### PR TITLE
Allow dragonwell JDK11u builds to occur on any armv8.2-capable system

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -112,10 +112,10 @@ class Config11 {
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
                 additionalNodeLabels: [
-                        dragonwell: 'dragonwell'
+                        dragonwell: 'armv8.2'
                 ],
                 additionalTestLabels: [
-                        dragonwell: 'dragonwell'
+                        dragonwell: 'armv8.2'
                 ],
                 configureArgs       : [
                         "hotspot" : '--enable-dtrace=auto',


### PR DESCRIPTION
Reviews welcome but please leave for me to merge ~as I need to verify that https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-linux-aarch64-dragonwell/88 has gone through without problems~ It worked perfectly :-)

Signed-off-by: Stewart X Addison <sxa@redhat.com>