### PR TITLE
fix broken mac arm64 generator

### DIFF
--- a/pipelines/jobs/configurations/jdk17.groovy
+++ b/pipelines/jobs/configurations/jdk17.groovy
@@ -33,7 +33,7 @@ targetConfigurations = [
                 "hotspot",
                 "openj9"
         ],
-        "arm64Mac": [
+        "aarch64Mac": [
                 "hotspot"
         ],
         "arm32Linux"  : [

--- a/pipelines/jobs/configurations/jdk18.groovy
+++ b/pipelines/jobs/configurations/jdk18.groovy
@@ -33,7 +33,7 @@ targetConfigurations = [
                 "hotspot",
                 "openj9"
         ],
-        "arm64Mac": [
+        "aarch64Mac": [
                 "hotspot"
         ],
         "arm32Linux"  : [


### PR DESCRIPTION
This was changed from arm64mac to aarch64mac at some point but this was missed