### PR TITLE
Disable openj9 build for jdk18 until it is supported

### DIFF
--- a/pipelines/jobs/configurations/jdk18.groovy
+++ b/pipelines/jobs/configurations/jdk18.groovy
@@ -1,37 +1,30 @@
 targetConfigurations = [
         "x64Mac"      : [
-                "hotspot",
-                "openj9"
+                "hotspot"
         ],
         "x64Linux"    : [
-                "hotspot",
-                "openj9"
+                "hotspot"
         ],
         "x64AlpineLinux" : [
                 "hotspot"
         ],
         "x64Windows"  : [
-                "hotspot",
-                "openj9"
+                "hotspot"
         ],
         "x32Windows"  : [
                 "hotspot"
         ],
         "ppc64Aix"    : [
-                "hotspot",
-                "openj9"
+                "hotspot"
         ],
         "ppc64leLinux": [
-                "hotspot",
-                "openj9"
+                "hotspot"
         ],
         "s390xLinux"  : [
-                "hotspot",
-                "openj9"
+                "hotspot"
         ],
         "aarch64Linux": [
-                "hotspot",
-                "openj9"
+                "hotspot"
         ],
         "aarch64Mac": [
                 "hotspot"


### PR DESCRIPTION
openj9 extensions doesn't yet support jdk-18, disable until ready.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>