### PR TITLE
Enabling Solaris testing in JDK8 build pipeline

### DIFF
--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -65,13 +65,13 @@ class Config8 {
         sparcv9Solaris: [
                 os  : 'solaris',
                 arch: 'sparcv9',
-                test: false
+                test: 'default'
         ],
 
         x64Solaris    : [
                 os                  : 'solaris',
                 arch                : 'x64',
-                test                : false
+                test                : 'default'
         ],
 
         ppc64leLinux  : [


### PR DESCRIPTION
We should be able to run these tests now. Adding them into the
automated pipeline.

Signed-off-by: Adam Farley <adfarley@redhat.com>