### PR TITLE
Only run linter for pull requests targeting the master branch

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,13 +11,10 @@ name: Linter
 # https://help.github.com/en/articles/workflow-syntax-for-github-actions
 #
 
-#############################
-# Start the job on all push #
-#############################
+####################################################################
+# Start the job on all pull requests that target the master branch #
+####################################################################
 on:
-  push:
-    branches-ignore: [master]
-    # Remove the line above to run when pushing to master
   pull_request:
     branches: [master]
 


### PR DESCRIPTION
It isn't helpful to re-run it in forks, particularly where it will only fail if the master branch does not exist.