### PR TITLE
Revert "Inhibit nightly tests during 2021.07.20 release cycle (#179)"

### DIFF
--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -33,7 +33,7 @@
         "downstream"         : "pipelines/build/common/openjdk_build_pipeline.groovy"
     },
     "testDetails"            : {
-        "enableTests"        : false,
+        "enableTests"        : true,
         "nightlyDefault"     : [
             "sanity.openjdk",
             "sanity.system",


### PR DESCRIPTION
We are over a month past the time we disabled this and there are no large runs of testing enabled that the nightlies will block, therefore re-enabling nightly testing.

This reverts commit 4f2d16e5adbed11423dd1ff2fa67dbc0eb842fe8.