### PR TITLE
Enable testing on JDK11/RISC-V builds

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -145,7 +145,8 @@ class Config11 {
                 configureArgs        : [
                         "openj9"     : '--disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root',
                         "bisheng"    : '--openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-jvm-features=shenandoahgc'
-                ]
+                ],
+                test                 : 'default'
         ]
   ]
 


### PR DESCRIPTION
Subject line says it all. We are currently only running testing on JDK17 builds. This will enable JDK11 too.

Signed-off-by: Stewart X Addison <sxa@redhat.com>