### PR TITLE
Revert "disable nightlies for Java 17 release (#187)"

### DIFF
--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -33,7 +33,7 @@
         "downstream"         : "pipelines/build/common/openjdk_build_pipeline.groovy"
     },
     "testDetails"            : {
-        "enableTests"        : false,
+        "enableTests"        : true,
         "nightlyDefault"     : [
             "sanity.openjdk",
             "sanity.system",


### PR DESCRIPTION
This reverts commit 33dcc880e69bfdfa1540ab38f745ca049c9b5d3f.

We don't need to have tests inhibited any more as we have released all the JDK17 deliverables that we can at the moment.