### PR TITLE
Enable creating source archive tarball (x64 Linux)

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -26,6 +26,9 @@ class Config11 {
                         "SapMachine"  : '--enable-dtrace=auto',
                         "dragonwell"  : '--enable-dtrace=auto --enable-unlimited-crypto --with-jvm-variants=server --with-zlib=system --with-jvm-features=zgc',
                         "bisheng"     : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server --disable-warnings-as-errors'
+                ],
+                buildArgs            : [
+                        "hotspot"     : '--create-source-archive'
                 ]
         ],
 

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -25,6 +25,9 @@ class Config17 {
                 configureArgs       : [
                         "openj9"    : '--enable-dtrace --enable-jitserver',
                         "hotspot"   : '--enable-dtrace'
+                ],
+                buildArgs           : [
+                        "hotspot"   : '--create-source-archive'
                 ]
         ],
 

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -23,6 +23,9 @@ class Config8 {
                 configureArgs       : [
                         "openj9"      : '--enable-jitserver',
                         "dragonwell"  : '--enable-unlimited-crypto --with-jvm-variants=server  --with-zlib=system',
+                ],
+                buildArgs           : [
+                        "hotspot"   : '--create-source-archive'
                 ]
         ],
         x64Windows    : [


### PR DESCRIPTION
This will enable source tarball creation on Linux x86_64. It's
on that platform only since sources are the same on all arches
and it would overwhelm the CI server's disk space otherwise.

Related epic: https://github.com/adoptium/temurin-build/issues/2728