### PR TITLE
Tag sources tarball as such in metadata

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -955,6 +955,8 @@ class Build {
                 type = "debugimage"
             } else if (file.contains("-static-libs")) {
                 type = "staticlibs"
+            } else if (file.contains("-sources")) {
+                type = "sources"
             }
 
             String hash = context.sh(script: """\


### PR DESCRIPTION
This should also avoid the issue of duplicate tarballs matching
"jdk" image type requests via the API.

Related epic: https://github.com/adoptium/temurin-build/issues/2728