### PR TITLE
Only run sanity.openjdk on RISC-V nightly builds

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -146,7 +146,10 @@ class Config11 {
                         "openj9"     : '--disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root',
                         "bisheng"    : '--openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-jvm-features=shenandoahgc'
                 ],
-                test                 : 'default'
+                test                : [
+                        nightly: ['sanity.openjdk'],
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                ]
         ]
   ]
 

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -126,7 +126,10 @@ class Config17 {
                 arch                 : 'riscv64',
                 configureArgs        : '--enable-dtrace --with-native-debug-symbols=none',
                 buildArgs            : '-r https://github.com/openjdk/jdk-sandbox -b riscv-port-branch --custom-cacerts false --disable-adopt-branch-safety',
-                test                 : 'default'
+                test                : [
+                        nightly: ['sanity.openjdk'],
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                ]
         ]
 
   ]


### PR DESCRIPTION
At the moment the RISC-V testing is the limiting factor in the overnight builds and even sanity.openjdk is taking about nine hours. Until we can perform some of these actions, I am disabling the full testing regime but leaving extras on the weekend runs so that we have some up to date logs to diagnose.

Actions required to be able to re-enable:
- Ideally acquire more systems ...
- My Beagle-V board is temporarily offline due to a network problem but I'll aim to get that resolved in the next week
- Re-activate on the two that are currently off
- Start diagnosis of why we're getting lots of failures on the RISC-V test runs.

Signed-off-by: Stewart X Addison <sxa@redhat.com>