### PR TITLE
Add nightly pipeline publish health reporting

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -16,15 +16,41 @@ import groovy.json.JsonSlurper
 import java.time.LocalDateTime
 import java.time.Instant
 import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 
 node ("master") {
   def variant = "${params.VARIANT}"
   def jenkinsUrl = "${params.JENKINS_URL}"
   def trssUrl    = "${params.TRSS_URL}"
+  def apiUrl    = "${params.API_URL}"
   def slackChannel = "${params.SLACK_CHANNEL}"
+  def featureReleases = [ 8, 11, 17 ] // Consider making those parameters
+  def nightlyStaleDays = "${params.MAX_NIGHTLY_STALE_DAYS}"
 
+  def healthStatus = [ "jdk8": null, "jdk11": null, "jdk17": null]
   def testStats = []
+
+  stage("getPipelineStatus") {
+    if (variant == "hotspot") { // hotspot only for now
+      // Determine nightly pipeline health by looking at published assets.
+      // In particular, look at one data set for published binaries (Linux x64).
+      // If no published assets happened the last 4 days, the nightly pipeline
+      // is considered unhealthy.
+      // TODO: account for disabled nightly pipelines
+      featureReleases.each { featureRelease ->
+        def assets = sh(returnStdout: true, script: "wget -q -O - '${apiUrl}/v3/assets/feature_releases/${featureRelease}/ea?image_type=jdk&os=linux&architecture=x64&jvm_impl=${variant}'")
+        def assetsJson = new JsonSlurper().parseText(assets)
+        def ts = assetsJson[0].timestamp // newest timestamp of a jdk asset
+        def assetTs = Instant.parse(ts).atZone(ZoneId.of("UTC"))
+        def now = ZonedDateTime.now(ZoneId.of("UTC"))
+        def days = ChronoUnit.DAYS.between(assetTs, now)
+        def status = [maxStaleDays: nightlyStaleDays, actualDays: days]
+        def key = "jdk${featureRelease}"
+        healthStatus[key] = status
+      }
+    }
+  }
 
   // Get the last Nightly build and test job & case stats
   stage("getStats") {
@@ -144,8 +170,8 @@ node ("master") {
     }
   }
 
-  // Print the results
-  stage("printResults") {
+  // Print the results of the nightly build/test stats
+  stage("printBuildTestStats") {
     def buildFailures = 0
     def nightlyTestSuccessRating = 0
     def numTestPipelines = 0
@@ -205,6 +231,32 @@ node ("master") {
 
     // Slack message:
     slackSend(channel: slackChannel, color: 'good', message: 'Adoptium Nightly Build Success : *'+variant+'* => *'+overallNightlySuccessRating+'* %\n  Build Job Rating: '+totalBuildJobs+' jobs ('+nightlyBuildSuccessRating.intValue()+'%)  Test Job Rating: '+totalTestJobs+' jobs ('+nightlyTestSuccessRating.intValue()+'%) <'+jenkinsUrl+'/view/Tooling/job/nightlyBuildAndTestStats_'+variant+'/'+BUILD_NUMBER+'/console|Detail>')
+  }
+
+  stage("printPublishStats") {
+    if (variant == "hotspot") { // hotspot only for now
+      echo "-------------- Nightly pipeline health report ------------------"
+      featureReleases.each { featureRelease ->
+        def key = "jdk${featureRelease}"
+        def status = healthStatus[key]
+        def days = status['actualDays']
+        def msg = "${days} day(s) ago" // might actually be days + N hours, where N < 24
+        if (status['actualDays'] == 0) {
+            msg = "less than 24 hours ago"
+        }
+        def maxDays = status['maxStaleDays']
+        def fullMessage = "JDK ${featureRelease} nigthly pipeline publish status: healthy. Last published: ${msg}"
+        def slackColor = "good"
+        if (maxDays <= days) {
+            slackColor = "warning"
+            fullMessage = "JDK ${featureRelease} nigthly pipeline publish status: unhealthy. Last published: ${msg}. Stale threshold: ${maxDays} days."
+        }
+        echo "===> ${fullMessage}"
+        // One slack message per JDK version:
+        slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
+      }
+      echo "----------------------------------------------------------------"
+    }
   }
 }
 


### PR DESCRIPTION
It uses the /v3/assets/feature_version endpoint by looking on the
timestamp of published binaries (takes the most recent one).

This is hotspot only for now.

Tested here:
https://ci.adoptopenjdk.net/view/Tooling/job/nightlyBuildAndTestStats_hotspot/436/