### PR TITLE
Disable nightly testing for the October 2021 releases

### DIFF
--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -33,7 +33,7 @@
         "downstream"         : "pipelines/build/common/openjdk_build_pipeline.groovy"
     },
     "testDetails"            : {
-        "enableTests"        : true,
+        "enableTests"        : false,
         "nightlyDefault"     : [
             "sanity.openjdk",
             "sanity.system",


### PR DESCRIPTION
I want to hold off on this til tomorrow evening to avoid disabling it sooner than necessary (hence draft), but obviously review welcome before that :-)

Signed-off-by: Stewart X Addison <sxa@redhat.com>