### PR TITLE
Add support for numMachine per test for dynamic parallel testing

### DIFF
--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -338,7 +338,7 @@ class Regeneration implements Serializable {
     */
     Map<String, ?> getDynamicParams() {
         List<String> testLists = DEFAULTS_JSON["testDetails"]["defaultDynamicParas"]["testLists"]
-        String numMachines = DEFAULTS_JSON["testDetails"]["defaultDynamicParas"]["numMachines"]
+        List<String> numMachines = DEFAULTS_JSON["testDetails"]["defaultDynamicParas"]["numMachines"]
         return ["testLists": testLists, "numMachines": numMachines]
     }
     /*

--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -112,6 +112,7 @@ pipelineJob("$buildFolder/$JOB_NAME") {
                 <dt><strong>PUBLISH_NAME</strong></dt><dd>Set name of publish</dd>
                 <dt><strong>ADOPT_BUILD_NUMBER</strong></dt><dd>Adopt build number</dd>
                 <dt><strong>ENABLE_TESTS</strong></dt><dd>Run tests</dd>
+                <dt><strong>ENABLE_TESTDYNAMICPARALLEL</strong></dt><dd>Run parallel</dd>
                 <dt><strong>ENABLE_INSTALLERS</strong></dt><dd>Run installers</dd>
                 <dt><strong>ENABLE_SIGNER</strong></dt><dd>Run signer</dd>
                 <dt><strong>CLEAN_WORKSPACE</strong></dt><dd>Wipe out workspace before build</dd>

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -206,6 +206,7 @@ node('master') {
         }
 
         config.put("enableTests", DEFAULTS_JSON['testDetails']['enableTests'] as Boolean)
+        config.put("enableTestDynamicParallel", DEFAULTS_JSON['testDetails']['enableTestDynamicParallel'] as Boolean)
 
         println "[INFO] JDK${javaVersion}: nightly pipelineSchedule = ${config.pipelineSchedule}"
 

--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -50,8 +50,8 @@
         "enableTestDynamicParallel"      : true,
         "defaultDynamicParas": {
             "testLists"      : ["extended.openjdk"],
-            "numMachines"    : "3"
-         }
+            "numMachines"    : ["3"]
+        }
     },
     "importLibraryScript"    : "pipelines/build/common/import_lib.groovy",
     "defaultsUrl"            : "https://raw.githubusercontent.com/adoptium/ci-jenkins-pipelines/master/pipelines/defaults.json"

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -3,7 +3,7 @@ import groovy.json.JsonOutput
 gitRefSpec = ""
 propagateFailures = false
 runTests = enableTests
-runParallel = true
+runParallel = enableTestDynamicParallel
 runInstaller = true
 runSigner = true
 cleanWsBuildOutput = true

--- a/pipelines/library/src/common/IndividualBuildConfig.groovy
+++ b/pipelines/library/src/common/IndividualBuildConfig.groovy
@@ -10,7 +10,7 @@ class IndividualBuildConfig implements Serializable {
     final String JAVA_TO_BUILD
     final List<String> TEST_LIST
     final List<String> DYNAMIC_LIST
-    final String NUM_MACHINES
+    final List<String> NUM_MACHINES
     final String SCM_REF
     final String BUILD_ARGS
     final String NODE_LABEL
@@ -33,6 +33,7 @@ class IndividualBuildConfig implements Serializable {
     final String PUBLISH_NAME
     final String ADOPT_BUILD_NUMBER
     final boolean ENABLE_TESTS
+    final boolean ENABLE_TESTDYNAMICPARALLEL
     final boolean ENABLE_INSTALLERS
     final boolean ENABLE_SIGNER
     final boolean CLEAN_WORKSPACE
@@ -63,8 +64,16 @@ class IndividualBuildConfig implements Serializable {
             DYNAMIC_LIST = map.get("DYNAMIC_LIST")
         } else {
             DYNAMIC_LIST = []
-        }        
-        NUM_MACHINES = map.get("NUM_MACHINES")
+        }
+
+        if (String.class.isInstance(map.get("NUM_MACHINES"))) {
+            NUM_MACHINES = map.get("NUM_MACHINES").split(",")
+        } else if (List.class.isInstance(map.get("NUM_MACHINES"))) {
+            NUM_MACHINES = map.get("NUM_MACHINES")
+        } else {
+            NUM_MACHINES = []
+        }
+
         SCM_REF = map.get("SCM_REF")
         BUILD_ARGS = map.get("BUILD_ARGS")
         NODE_LABEL = map.get("NODE_LABEL")
@@ -87,6 +96,7 @@ class IndividualBuildConfig implements Serializable {
         PUBLISH_NAME = map.get("PUBLISH_NAME")
         ADOPT_BUILD_NUMBER = map.get("ADOPT_BUILD_NUMBER")
         ENABLE_TESTS = map.get("ENABLE_TESTS")
+        ENABLE_TESTDYNAMICPARALLEL = map.get("ENABLE_TESTDYNAMICPARALLEL")
         ENABLE_INSTALLERS = map.get("ENABLE_INSTALLERS")
         ENABLE_SIGNER = map.get("ENABLE_SIGNER")
         CLEAN_WORKSPACE = map.get("CLEAN_WORKSPACE")
@@ -140,6 +150,7 @@ class IndividualBuildConfig implements Serializable {
                 PUBLISH_NAME              : PUBLISH_NAME,
                 ADOPT_BUILD_NUMBER        : ADOPT_BUILD_NUMBER,
                 ENABLE_TESTS              : ENABLE_TESTS,
+                ENABLE_TESTDYNAMICPARALLEL: ENABLE_TESTDYNAMICPARALLEL,
                 ENABLE_INSTALLERS         : ENABLE_INSTALLERS,
                 ENABLE_SIGNER             : ENABLE_SIGNER,
                 CLEAN_WORKSPACE           : CLEAN_WORKSPACE,


### PR DESCRIPTION
Update upstream and downtream jobs to suport numMachines per test
targets.
Update the job generator to infer the parallel tests flag from job
configuration.
Propagate enableTestDynamicParallel flag downstream.

Issue: https://github.com/adoptium/ci-jenkins-pipelines/issues/184

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>