### PR TITLE
Revert "Disable nightly testing for the October 2021 releases"

### DIFF
--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -33,7 +33,7 @@
         "downstream"         : "pipelines/build/common/openjdk_build_pipeline.groovy"
     },
     "testDetails"            : {
-        "enableTests"        : false,
+        "enableTests"        : true,
         "nightlyDefault"     : [
             "sanity.openjdk",
             "sanity.system",


### PR DESCRIPTION
Reverts adoptium/ci-jenkins-pipelines#209