### PR TITLE
Ensure MacOS signing jenkins context does not overwrite existing BUILD_ARGS

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1192,7 +1192,7 @@ class Build {
                                 context.println "[CHECKOUT] Checking out to adoptium/temurin-build..."
                                 repoHandler.checkoutAdoptBuild(context)
                                 if (buildConfig.TARGET_OS == "mac" && buildConfig.JAVA_TO_BUILD != "jdk8u") {
-                                    context.withEnv(["BUILD_ARGS=--make-exploded-image"]) {
+                                    context.withEnv(["BUILD_ARGS="+env.BUILD_ARGS+" --make-exploded-image"]) {
                                         context.println "Building an exploded image for signing"
                                         context.sh(script: "./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
                                     }
@@ -1253,7 +1253,7 @@ class Build {
                                     // Restore signed JMODs
                                     context.unstash 'signed_jmods'
 
-                                    context.withEnv(["BUILD_ARGS=--assemble-exploded-image"]) {
+                                    context.withEnv(["BUILD_ARGS="+env.BUILD_ARGS+" --assemble-exploded-image"]) {
                                         context.println "Assembling the exploded image"
                                         context.sh(script: "./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
                                     }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1192,7 +1192,13 @@ class Build {
                                 context.println "[CHECKOUT] Checking out to adoptium/temurin-build..."
                                 repoHandler.checkoutAdoptBuild(context)
                                 if (buildConfig.TARGET_OS == "mac" && buildConfig.JAVA_TO_BUILD != "jdk8u") {
-                                    context.withEnv(["BUILD_ARGS="+env.BUILD_ARGS+" --make-exploded-image"]) {
+                                    def macSignBuildArgs
+                                    if (env.BUILD_ARGS != null && !env.BUILD_ARGS.isEmpty()) {
+                                        macSignBuildArgs = env.BUILD_ARGS+" --make-exploded-image"
+                                    } else {
+                                        macSignBuildArgs = "--make-exploded-image"
+                                    }
+                                    context.withEnv(["BUILD_ARGS="+macSignBuildArgs]) {
                                         context.println "Building an exploded image for signing"
                                         context.sh(script: "./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
                                     }
@@ -1253,7 +1259,13 @@ class Build {
                                     // Restore signed JMODs
                                     context.unstash 'signed_jmods'
 
-                                    context.withEnv(["BUILD_ARGS="+env.BUILD_ARGS+" --assemble-exploded-image"]) {
+                                    def macAssembleBuildArgs
+                                    if (env.BUILD_ARGS != null && !env.BUILD_ARGS.isEmpty()) {
+                                        macAssembleBuildArgs = env.BUILD_ARGS+" --assemble-exploded-image"
+                                    } else {
+                                        macAssembleBuildArgs = "--assemble-exploded-image"
+                                    }
+                                    context.withEnv(["BUILD_ARGS="+macAssembleBuildArgs]) {
                                         context.println "Assembling the exploded image"
                                         context.sh(script: "./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
                                     }

--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -53,7 +53,8 @@ class PullRequestTestPipeline implements Serializable {
                 adoptDefaultsJson   : ADOPT_DEFAULTS_JSON,
                 CHECKOUT_CREDENTIALS: "",
                 adoptScripts        : true,
-                enableTests         : false
+                enableTests         : false,
+                enableTestDynamicParallel : false
         ]
     }
 


### PR DESCRIPTION
The MacOS signing jenkins context pipeline environment was overwriting the BUILD_ARGS when setting --make-exploded-image.
This PR appends --make-exploded-image to the existing variable.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>