### PR TITLE
Update tip RISC-V builds to official repository (Replace JDK17 with JDK19)

### DIFF
--- a/pipelines/jobs/configurations/jdk17u.groovy
+++ b/pipelines/jobs/configurations/jdk17u.groovy
@@ -38,9 +38,6 @@ targetConfigurations = [
         ],
         "arm32Linux"  : [
                 "hotspot"
-        ],
-        "riscv64Linux"  : [
-                "hotspot"
         ]
 ]
 

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -156,18 +156,6 @@ class Config17 {
                 buildArgs           : [
                         "hotspot"   : '--create-jre-image'
                 ]
-
-        ],
-
-        riscv64Linux      :  [
-                os                   : 'linux',
-                arch                 : 'riscv64',
-                configureArgs        : '--enable-dtrace --with-native-debug-symbols=none',
-                buildArgs            : '-r https://github.com/openjdk/jdk-sandbox -b riscv-port-branch --custom-cacerts false --disable-adopt-branch-safety',
-                test                : [
-                        nightly: ['sanity.openjdk'],
-                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
-                ]
         ]
 
   ]

--- a/pipelines/jobs/configurations/jdk19.groovy
+++ b/pipelines/jobs/configurations/jdk19.groovy
@@ -31,7 +31,11 @@ targetConfigurations = [
         ],
         "arm32Linux"  : [
                 "hotspot"
+        ],
+        "riscv64Linux"  : [
+                "hotspot"
         ]
+
 ]
 
 // 23:30 Tue, Thur

--- a/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
@@ -119,7 +119,18 @@ class Config19 {
                 arch                : 'arm',
                 test                : 'default',
                 configureArgs       : '--enable-dtrace'
+        ],
+        riscv64Linux      :  [
+                os                   : 'linux',
+                arch                 : 'riscv64',
+                configureArgs        : '--enable-dtrace --with-native-debug-symbols=none',
+                buildArgs            : '-r https://github.com/openjdk/riscv-port -b riscv-port --custom-cacerts false --disable-adopt-branch-safety',
+                test                : [
+                        nightly: ['sanity.openjdk'],
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                ]
         ]
+
   ]
 
 }


### PR DESCRIPTION
As per https://openjdk.java.net/jeps/422

Signed-off-by: Stewart X Addison <sxa@redhat.com>