### PR TITLE
Ensure numMachinesPerTest is reset each loop

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -315,7 +315,6 @@ class Build {
         List dynamicList = buildConfig.DYNAMIC_LIST
         List numMachines = buildConfig.NUM_MACHINES
         def enableTestDynamicParallel = Boolean.valueOf(buildConfig.ENABLE_TESTDYNAMICPARALLEL)
-        def numMachinesPerTest = ''
 
         testList.each { testType ->
 
@@ -332,6 +331,7 @@ class Build {
 
                         def jobParams = getAQATestJobParams(testType)
                         def parallel = 'None'
+                        def numMachinesPerTest = ''
 
                         if (enableTestDynamicParallel && dynamicList.contains(testType)) {
                             numMachinesPerTest = numMachines.getAt(dynamicList.indexOf(testType))


### PR DESCRIPTION
The way it is currently defined, the last iteration
of the loop will apply to all the tests once they
are executed. Redifining it each loop will ensure
each test gets the correct value.

Related #213

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>