### PR TITLE
Remove RELEASE_TAG, which has been removed from downstream jobs

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -288,7 +288,6 @@ class Build {
                                     context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
                                     context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
                                     context.string(name: 'JDK_VERSION', value: "${jobParams.JDK_VERSIONS}"),
-                                    context.string(name: 'RELEASE_TAG', value: "${buildConfig.SCM_REF}"),
                                     context.string(name: 'LABEL_ADDITION', value: additionalTestLabel),
                                     context.string(name: 'KEEP_REPORTDIR', value: "${buildConfig.KEEP_TEST_REPORTDIR}"),
                                     context.string(name: 'ACTIVE_NODE_TIMEOUT', value: "${buildConfig.ACTIVE_NODE_TIMEOUT}")]
@@ -363,7 +362,6 @@ class Build {
                                     parameters: [
                                             context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
                                             context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
-                                            context.string(name: 'RELEASE_TAG', value: "${buildConfig.SCM_REF}"),
                                             context.string(name: 'JDK_REPO', value: jdkRepo),
                                             context.string(name: 'JDK_BRANCH', value: jdkBranch),
                                             context.string(name: 'OPENJ9_BRANCH', value: openj9Branch),


### PR DESCRIPTION
Related with https://github.com/adoptium/temurin-build/pull/2166/ 
https://github.com/adoptium/aqa-tests/pull/2035

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>