### PR TITLE
Add AQA_AUTO_GEN option to force generate AQA test jobs

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -47,6 +47,7 @@ class Builder implements Serializable {
     String releaseType
     String scmReference
     String aqaReference
+    boolean aqaAutoGen
     String publishName
     String additionalConfigureArgs
     def scmVars
@@ -146,6 +147,7 @@ class Builder implements Serializable {
             NUM_MACHINES: numMachines,
             SCM_REF: scmReference,
             AQA_REF: aqaReference,
+            AQA_AUTO_GEN: aqaAutoGen,
             BUILD_ARGS: buildArgs,
             NODE_LABEL: "${additionalNodeLabels}&&${platformConfig.os}&&${archLabel}",
             ADDITIONAL_TEST_LABEL: "${additionalTestLabels}",
@@ -745,6 +747,7 @@ class Builder implements Serializable {
             context.echo "Release: ${release}"
             context.echo "Tag/Branch name: ${scmReference}"
             context.echo "AQA tests Release/Branch name: ${aqaReference}"
+            context.echo "Force auto generate AQA test jobs: ${aqaAutoGen}"
             context.echo "Keep test reportdir: ${keepTestReportDir}"
             context.echo "Keep release logs: ${keepReleaseLogs}"
 
@@ -856,6 +859,7 @@ return {
     String releaseType,
     String scmReference,
     String aqaReference,
+    String aqaAutoGen,
     String overridePublishName,
     String useAdoptShellScripts,
     String additionalConfigureArgs,
@@ -914,6 +918,7 @@ return {
             releaseType: releaseType,
             scmReference: scmReference,
             aqaReference: aqaReference,
+            aqaAutoGen: Boolean.parseBoolean(aqaAutoGen),
             publishName: publishName,
             additionalConfigureArgs: additionalConfigureArgs,
             scmVars: scmVars,

--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -418,6 +418,7 @@ class Regeneration implements Serializable {
                 NUM_MACHINES: numMachines,
                 SCM_REF: "",
                 AQA_REF: "",
+                AQA_AUTO_GEN: false,
                 BUILD_ARGS: buildArgs,
                 NODE_LABEL: "${additionalNodeLabels}&&${platformConfig.os}&&${archLabel}",
                 ADDITIONAL_TEST_LABEL: "${additionalTestLabels}",

--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -95,6 +95,7 @@ pipelineJob("$buildFolder/$JOB_NAME") {
                 <dt><strong>NUM_MACHINES</strong></dt><dd>The number of machines for parallel=dynamic</dd>
                 <dt><strong>SCM_REF</strong></dt><dd>Source code ref to build, i.e branch, tag, commit id.</dd>
                 <dt><strong>AQA_REF</strong></dt><dd>Specific aqa-tests release or branch.</dd>
+                <dt><strong>AQA_AUTO_GEN</strong></dt><dd>If true, froce auto generate AQA test jobs.</dd>
                 <dt><strong>BUILD_ARGS</strong></dt><dd>args to pass to makejdk-any-platform.sh</dd>
                 <dt><strong>NODE_LABEL</strong></dt><dd>Labels of node to build on</dd>
                 <dt><strong>ADDITIONAL_TEST_LABEL</strong></dt><dd>Additional label for test jobs</dd>

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -321,6 +321,8 @@ class Build {
             useTestEnvProperties = true
         }
 
+        def aqaAutoGen = buildConfig.AQA_AUTO_GEN ?: false
+
         testList.each { testType ->
 
             // For each requested test, i.e 'sanity.openjdk', 'sanity.system', 'sanity.perf', 'sanity.external', call test job
@@ -353,8 +355,8 @@ class Build {
                         def jobName = jobParams.TEST_JOB_NAME
                         def JobHelper = context.library(identifier: 'openjdk-jenkins-helper@master').JobHelper
 
-                        // Create test job if job doesn't exist or is not runnable
-                        if (!JobHelper.jobIsRunnable(jobName as String)) {
+                        // Create test job if AQA_AUTO_GEN is set to true, the job doesn't exist or is not runnable
+                        if (aqaAutoGen || !JobHelper.jobIsRunnable(jobName as String)) {
                             context.node('master') {
                                 context.sh('curl -Os https://raw.githubusercontent.com/adoptium/aqa-tests/master/buildenv/jenkins/testJobTemplate')
                                 def templatePath = 'testJobTemplate'
@@ -376,6 +378,7 @@ class Build {
                                             context.string(name: 'PARALLEL', value: parallel),
                                             context.string(name: 'NUM_MACHINES', value: "${numMachinesPerTest}"),
                                             context.booleanParam(name: 'USE_TESTENV_PROPERTIES', value: useTestEnvProperties),
+                                            context.booleanParam(name: 'GENERATE_JOBS', value: aqaAutoGen),
                                             context.string(name: 'ADOPTOPENJDK_BRANCH', value: aqaBranch),
                                             context.string(name: 'ACTIVE_NODE_TIMEOUT', value: "${buildConfig.ACTIVE_NODE_TIMEOUT}")]
                         }

--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -123,6 +123,7 @@ if (scmVars != null || configureBuild != null || buildConfigurations != null) {
         releaseType,
         scmReference,
         aqaReference,
+        aqaAutoGen,
         overridePublishName,
         useAdoptBashScripts,
         additionalConfigureArgs,

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -96,6 +96,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
         stringParam('overridePublishName', "", '<strong>REQUIRED for OpenJ9</strong>: Name that determines the publish name (and is used by the meta-data file), defaults to scmReference(minus _adopt if present).<br/>Nightly builds: Leave blank (defaults to a date_time stamp).<br/>OpenJ9 Release build Java 8 example <code>jdk8u192-b12_openj9-0.12.1</code> and for OpenJ9 Java 11 example <code>jdk-11.0.2+9_openj9-0.12.1</code>.')
         stringParam('scmReference', "", 'Tag name or Branch name from which to build. Nightly builds: Defaults to, Hotspot=dev, OpenJ9=openj9, others=master.</br>Release builds: For hotspot JDK8 this would be the OpenJDK tag, for hotspot JDK11+ this would be the Adopt merge tag for the desired OpenJDK tag eg.jdk-11.0.4+10_adopt, and for OpenJ9 this will be the release branch, eg.openj9-0.14.0.')
         stringParam('aqaReference', "", 'Tag name or Branch name of aqa-tests. Defaults to master')
+        booleanParam('aqaAutoGen', false, 'If set to true, force auto generate AQA test jobs. Defaults to false')
         booleanParam('enableTests', runTests, 'If set to true the test pipeline will be executed')
         booleanParam('enableTestDynamicParallel', runParallel, 'If set to true test will be run parallel')
         booleanParam('enableInstallers', runInstaller, 'If set to true the installer pipeline will be executed')

--- a/pipelines/library/src/common/IndividualBuildConfig.groovy
+++ b/pipelines/library/src/common/IndividualBuildConfig.groovy
@@ -13,6 +13,7 @@ class IndividualBuildConfig implements Serializable {
     final List<String> NUM_MACHINES
     final String SCM_REF
     final String AQA_REF
+    final boolean AQA_AUTO_GEN
     final String BUILD_ARGS
     final String NODE_LABEL
     final String ADDITIONAL_TEST_LABEL
@@ -77,6 +78,7 @@ class IndividualBuildConfig implements Serializable {
 
         SCM_REF = map.get("SCM_REF")
         AQA_REF = map.get("AQA_REF")
+        AQA_AUTO_GEN = map.get("AQA_AUTO_GEN")
         BUILD_ARGS = map.get("BUILD_ARGS")
         NODE_LABEL = map.get("NODE_LABEL")
         ADDITIONAL_TEST_LABEL = map.get("ADDITIONAL_TEST_LABEL")
@@ -132,6 +134,7 @@ class IndividualBuildConfig implements Serializable {
                 NUM_MACHINES              : NUM_MACHINES,
                 SCM_REF                   : SCM_REF,
                 AQA_REF                   : AQA_REF,
+                AQA_AUTO_GEN              : AQA_AUTO_GEN,
                 BUILD_ARGS                : BUILD_ARGS,
                 NODE_LABEL                : NODE_LABEL,
                 ADDITIONAL_TEST_LABEL     : ADDITIONAL_TEST_LABEL,

--- a/pipelines/src/test/groovy/IndividualBuildConfigTest.groovy
+++ b/pipelines/src/test/groovy/IndividualBuildConfigTest.groovy
@@ -17,6 +17,7 @@ class IndividualBuildConfigTest {
                 NUM_MACHINES               : "e",
                 SCM_REF                    : "f",
                 AQA_REF                    : "s",
+                AQA_AUTO_GEN               : false,
                 BUILD_ARGS                 : "g",
                 NODE_LABEL                 : "h",
                 ADDITIONAL_TEST_LABEL      : "t",


### PR DESCRIPTION
Force generating AQA test jobs is needed for updating out-of-date test jobs. This PR allows users to set AQA_AUTO_GEN option for the pipeline.


Related: https://github.com/eclipse-openj9/openj9/issues/14318

Signed-off-by: lanxia <lan_xia@ca.ibm.com>