### PR TITLE
Switch visible build pipeline jobs from hotspot to temurin

### DIFF
--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -57,7 +57,7 @@ pipelineJob("$buildFolder/$JOB_NAME") {
     }
     properties {
         // Hide all non Temurin builds from public view
-        if (VARIANT != "hotspot") {
+        if (VARIANT != "temurin") {
             authorizationMatrix {
                 inheritanceStrategy {
                     // Do not inherit permissions from global configuration


### PR DESCRIPTION
With the deployment of https://github.com/adoptium/ci-jenkins-pipelines/pull/226 the publicly visible pipelines should be changed from `hotspot` to `temurin`

Signed-off-by: Stewart X Addison <sxa@redhat.com>