### PR TITLE
Adjust output filename for temurin to still be called hotspot

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1024,7 +1024,12 @@ class Build {
 
         javaToBuild = javaToBuild.toUpperCase()
 
-        def fileName = "Open${javaToBuild}-jdk_${architecture}_${os}_${variant}"
+        if (variant == "temurin") {
+          // For compatibility with existing releases
+          def fileName = "Open${javaToBuild}-jdk_${architecture}_${os}_hotspot"
+        } else {
+          def fileName = "Open${javaToBuild}-jdk_${architecture}_${os}_${variant}"
+        }
 
         if (additionalFileNameTag) {
             fileName = "${fileName}_${additionalFileNameTag}"


### PR DESCRIPTION
I hadn't compensated for the output filename in https://github.com/adoptium/ci-jenkins-pipelines/pull/226 - it would be undesirable to change it to `temurin` at the moment since it would be an externally visible change. This should switch it back to having `hotspot` in the filename

Signed-off-by: Stewart X Addison <sxa@redhat.com>