### PR TITLE
Adjust definition of filename to fix scoping issue

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1030,11 +1030,10 @@ class Build {
 
         javaToBuild = javaToBuild.toUpperCase()
 
+        def fileName = "Open${javaToBuild}-jdk_${architecture}_${os}_${variant}"
         if (variant == "temurin") {
           // For compatibility with existing releases
-          def fileName = "Open${javaToBuild}-jdk_${architecture}_${os}_hotspot"
-        } else {
-          def fileName = "Open${javaToBuild}-jdk_${architecture}_${os}_${variant}"
+          fileName = "Open${javaToBuild}-jdk_${architecture}_${os}_hotspot"
         }
 
         if (additionalFileNameTag) {


### PR DESCRIPTION
I made a hash of the [last commit](https://github.com/adoptium/ci-jenkins-pipelines/pull/241/files) and the variable wasn't defined with adequate scoping.

Combined effect of this and the previous PR is as follows:

```
[sxa@sainz pipelines]$ git diff 7175098
diff --git a/pipelines/build/common/openjdk_build_pipeline.groovy b/pipelines/build/common/openjdk_build_pipeline.groovy
index f60ffc9..6589b8c 100644
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1031,6 +1031,10 @@ class Build {
         javaToBuild = javaToBuild.toUpperCase()
 
         def fileName = "Open${javaToBuild}-jdk_${architecture}_${os}_${variant}"
+        if (variant == "temurin") {
+          // For compatibility with existing releases
+          fileName = "Open${javaToBuild}-jdk_${architecture}_${os}_hotspot"
+        }
 
         if (additionalFileNameTag) {
             fileName = "${fileName}_${additionalFileNameTag}"
[sxa@sainz pipelines]$ 
```

Signed-off-by: Stewart X Addison <sxa@redhat.com>