### PR TITLE
add support for building Bisheng JDK17 on Linux_x64/aarch64

### DIFF
--- a/pipelines/jobs/configurations/jdk17u.groovy
+++ b/pipelines/jobs/configurations/jdk17u.groovy
@@ -5,7 +5,8 @@ targetConfigurations = [
         ],
         "x64Linux"    : [
                 "temurin",
-                "openj9"
+                "openj9",
+                "bisheng"
         ],
         "x64AlpineLinux" : [
                 "temurin"
@@ -31,7 +32,8 @@ targetConfigurations = [
         ],
         "aarch64Linux": [
                 "temurin",
-                "openj9"
+                "openj9",
+                "bisheng"
         ],
         "aarch64Mac": [
                 "temurin"
@@ -52,7 +54,8 @@ weekly_release_scmReferences=[
         "temurin"        : "",
         "openj9"         : "",
         "corretto"       : "",
-        "dragonwell"     : ""
+        "dragonwell"     : "",
+        "bisheng"        : ""
 ]
 
 return this


### PR DESCRIPTION
Hope bishengjdk-17 could also be added to the pipeline as 8/11 is already supported.