### PR TITLE
Remove scmReference for unused hotspot variant from weekly config

### DIFF
--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -19,7 +19,6 @@ triggerSchedule_weekly="TZ=UTC\n05 17 * * 6"
 
 // scmReferences to use for weekly release build
 weekly_release_scmReferences=[
-        "hotspot"        : "",
         "temurin"        : "",
         "openj9"         : "",
         "corretto"       : "",

--- a/pipelines/jobs/configurations/jdk17u.groovy
+++ b/pipelines/jobs/configurations/jdk17u.groovy
@@ -48,7 +48,6 @@ triggerSchedule_weekly="TZ=UTC\n05 12 * * 7"
 
 // scmReferences to use for weekly release build
 weekly_release_scmReferences=[
-        "hotspot"        : "",
         "temurin"        : "",
         "openj9"         : "",
         "corretto"       : "",

--- a/pipelines/jobs/configurations/jdk18.groovy
+++ b/pipelines/jobs/configurations/jdk18.groovy
@@ -41,7 +41,6 @@ triggerSchedule_weekly="TZ=UTC\n30 23 * * 6"
 
 // scmReferences to use for weekly release build
 weekly_release_scmReferences=[
-        "hotspot"        : "",
         "temurin"        : "",
         "openj9"         : "",
         "corretto"       : "",

--- a/pipelines/jobs/configurations/jdk19.groovy
+++ b/pipelines/jobs/configurations/jdk19.groovy
@@ -45,7 +45,6 @@ triggerSchedule_weekly="TZ=UTC\n05 17 * * 7"
 
 // scmReferences to use for weekly release build
 weekly_release_scmReferences=[
-        "hotspot"        : "",
         "temurin"        : "",
         "openj9"         : "",
         "corretto"       : "",


### PR DESCRIPTION
Removed in our pipelines in preference for `temurin` so these options are no longer required as @sophia-guo pointed out in https://github.com/adoptium/temurin-build/issues/2671#issuecomment-1043157258

Signed-off-by: Stewart X Addison <sxa@redhat.com>