### PR TITLE
Add in one 'hotspot' variane build for JDK head

### DIFF
--- a/pipelines/jobs/configurations/jdk19.groovy
+++ b/pipelines/jobs/configurations/jdk19.groovy
@@ -24,6 +24,7 @@ targetConfigurations = [
                 "temurin"
         ],
         "aarch64Linux": [
+                "hotspot",
                 "temurin"
         ],
         "aarch64Mac": [
@@ -45,6 +46,7 @@ triggerSchedule_weekly="TZ=UTC\n05 17 * * 7"
 
 // scmReferences to use for weekly release build
 weekly_release_scmReferences=[
+        "hotspot"        : "",
         "temurin"        : "",
         "openj9"         : "",
         "corretto"       : "",


### PR DESCRIPTION
OK, I know, I removed all these when I switched the VARIANT from HotSpot to Temurin in #226 ...

But given that we still have `hotspot` in the scripts and it's the expected one that end-users who try our scripts will use, I'd like to keep building it somewhere to verify that the code path for building hotspot doesn't break, so I'm reinstating one build on Linux/aarch64, which should be one of our quickest platforms to compelte the build and test. We could also stop it running the tests, but I'll leave that enabled ... for now.

Signed-off-by: Stewart X Addison <sxa@redhat.com>