### PR TITLE
add support for adoptium/jdk11u-fast-startup-incubator project

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -169,6 +169,7 @@ class Build {
             case "openj9": variant = "j9"; break
             case "corretto": variant = "corretto"; break
             case "dragonwell": variant = "dragonwell"; break;
+            case "fast_startup": variant = "fast_startup"; break;
             case "bisheng": variant = "bisheng"; break;
             default: variant = "hs"
         }
@@ -221,6 +222,8 @@ class Build {
                 jdkBranch = 'dev'
             } else if (buildConfig.VARIANT == "dragonwell") {
                 jdkBranch = 'master'
+            } else if (buildConfig.VARIANT == "fast_startup") {
+                jdkBranch = 'master'
             } else if (buildConfig.VARIANT == "bisheng") {
                 jdkBranch = 'master'
             } else {
@@ -253,6 +256,8 @@ class Build {
             suffix = "adoptium/${buildConfig.JAVA_TO_BUILD}"
         } else if (buildConfig.VARIANT == "dragonwell") {
             suffix = "alibaba/dragonwell${javaNumber}"
+        } else if (buildConfig.VARIANT == "fast_startup") {
+            suffix = "adoptium/jdk11u-fast-startup-incubator"
         } else if (buildConfig.VARIANT == "bisheng") {
             suffix = "openeuler-mirror/bishengjdk-${javaNumber}"
         } else {

--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -1,6 +1,6 @@
 targetConfigurations = [
         "x64Mac"        : [    "temurin",    "openj9"                    ],
-        "x64Linux"      : [    "temurin",    "openj9",    "dragonwell",    "corretto",    "bisheng"    ],
+        "x64Linux"      : [    "temurin",    "openj9",    "dragonwell",    "corretto",    "bisheng",    "fast_startup"],
         "x64AlpineLinux": [    "temurin"                            ],
         "x64Windows"    : [    "temurin",    "openj9",    "dragonwell"            ],
         "x32Windows"    : [    "temurin"                            ],
@@ -23,6 +23,7 @@ weekly_release_scmReferences=[
         "openj9"         : "",
         "corretto"       : "",
         "dragonwell"     : "",
+        "fast_startup"   : "",
         "bisheng"        : ""
 ]
 

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -25,6 +25,7 @@ class Config11 {
                         "corretto"    : '--enable-dtrace=auto',
                         "SapMachine"  : '--enable-dtrace=auto',
                         "dragonwell"  : '--enable-dtrace=auto --enable-unlimited-crypto --with-jvm-variants=server --with-zlib=system --with-jvm-features=zgc',
+                        "fast_startup": '--enable-dtrace=auto',
                         "bisheng"     : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server --disable-warnings-as-errors'
                 ],
                 buildArgs            : [


### PR DESCRIPTION
Hi there! We have created a fast startup project(https://github.com/adoptium/jdk11u-fast-startup-incubator) under adoptium group to explore some novel JVM startup technilogies. I also create a simple build pipeline(x64_linux) for it. This build pipeline is currently hosted on http://ci.dragonwell-jdk.io/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-linux-x64-fast_startup/, which is a fork of the official adoptium pipeline(https://github.com/adoptium/ci-jenkins-pipelines / https://ci.adoptopenjdk.net/). I want to try to move it to official adoptium CI platform(https://ci.adoptopenjdk.net/) and host on that. Please let me know your advice and thoughts, thanks in advance!

RELATE: https://github.com/adoptium/temurin-build/pull/2866