### PR TITLE
Enable sanity.external on JDK11 xlinux

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -347,6 +347,11 @@ class Build {
                             keep_test_reportdir = "true"
                         }
 
+                        def DYNAMIC_COMPILE = false
+                        if (("${testType}".contains("functional")) || ("${testType}".contains("external"))) {
+                            DYNAMIC_COMPILE = true
+                        }
+
                         def jobParams = getAQATestJobParams(testType)
                         def parallel = 'None'
                         def numMachinesPerTest = ''
@@ -413,7 +418,8 @@ class Build {
                                             context.booleanParam(name: 'USE_TESTENV_PROPERTIES', value: useTestEnvProperties),
                                             context.booleanParam(name: 'GENERATE_JOBS', value: aqaAutoGen),
                                             context.string(name: 'ADOPTOPENJDK_BRANCH', value: aqaBranch),
-                                            context.string(name: 'ACTIVE_NODE_TIMEOUT', value: "${buildConfig.ACTIVE_NODE_TIMEOUT}")]
+                                            context.string(name: 'ACTIVE_NODE_TIMEOUT', value: "${buildConfig.ACTIVE_NODE_TIMEOUT}"),
+                                            context.booleanParam(name: 'DYNAMIC_COMPILE', value: DYNAMIC_COMPILE)]
                         }
                     }
                 }

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -18,7 +18,10 @@ class Config11 {
                 dockerFile: [
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
-                test                : 'default',
+                test                : [
+                        nightly: ["sanity.openjdk", "sanity.system", "extended.system", "sanity.perf", "sanity.functional", "extended.functional"],
+                        weekly : ["extended.openjdk", "extended.perf", "special.functional", "sanity.external"]
+                ],
                 configureArgs       : [
                         "openj9"      : '--enable-jitserver --enable-dtrace=auto',
                         "temurin"     : '--enable-dtrace=auto',


### PR DESCRIPTION
- Enable sanity.external on JDK11 xlinux (weekly)
- Set DYNAMIC_COMPILE to true for functional and external testing

Signed-off-by: lanxia <lan_xia@ca.ibm.com>