### PR TITLE
remove downstream create_installer_linux job

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -538,34 +538,6 @@ class Build {
     }
 
     /*
-    Run the Linux installer downstream job.
-    */
-    private void buildLinuxInstaller(VersionInfo versionData) {
-        def filter = "**/OpenJDK*_linux_*.tar.gz"
-        def nodeFilter = "${buildConfig.TARGET_OS}&&fpm"
-
-        String releaseType = "Nightly"
-        if (buildConfig.RELEASE) {
-            releaseType = "Release"
-        }
-
-        // Execute installer job
-        context.build job: "build-scripts/release/create_installer_linux",
-            propagate: true,
-            parameters: [
-                    context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
-                    context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
-                    context.string(name: 'FILTER', value: "${filter}"),
-                    context.string(name: 'RELEASE_TYPE', value: "${releaseType}"),
-                    context.string(name: 'VERSION', value: "${versionData.version}"),
-                    context.string(name: 'MAJOR_VERSION', value: "${versionData.major}"),
-                    context.string(name: 'ARCHITECTURE', value: "${buildConfig.ARCHITECTURE}"),
-                    ['$class': 'LabelParameterValue', name: 'NODE_LABEL', label: "${nodeFilter}"]
-            ]
-
-    }
-
-    /*
     Run the Windows installer downstream jobs.
     We run two jobs if we have a JRE (see https://github.com/adoptium/temurin-build/issues/1751).
     */
@@ -665,13 +637,11 @@ class Build {
             context.stage("installer") {
                 switch (buildConfig.TARGET_OS) {
                     case "mac": context.sh 'rm -f workspace/target/*.pkg workspace/target/*.pkg.json workspace/target/*.pkg.sha256.txt'; buildMacInstaller(versionData); break
-                    case "linux": buildLinuxInstaller(versionData); break
                     case "windows": buildWindowsInstaller(versionData); break
                     default: break
                 }
 
                 // Archive the Mac and Windows pkg/msi
-                // (Linux installer job produces no artifacts, it just uploads rpm/deb to the repositories)
                 if (buildConfig.TARGET_OS == "mac" || buildConfig.TARGET_OS == "windows") {
                     try {
                         context.sh 'for file in $(ls workspace/target/*.tar.gz workspace/target/*.pkg workspace/target/*.msi); do sha256sum "$file" > $file.sha256.txt ; done'


### PR DESCRIPTION
fixes: https://github.com/adoptium/ci-jenkins-pipelines/issues/243

The build pipelines are currently still invoking [create_installer_linux](https://ci.adoptopenjdk.net/job/build-scripts/job/release/job/create_installer_linux) at the end of each Linux build but it's a no-op (The whole inlined shell script in that jenkins job is commented out, so it copies artifacts around but does nothing with thtem)

The functionality has been superceded by the linuxNew functionality in the [adoptium-packages-linux-pipeline](https://ci.adoptopenjdk.net/job/adoptium-packages-linux-pipeline/) job.