### PR TITLE
Disable nightly sanity testing on RISC-V for JDK11 as it slows pipeline completion

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -158,7 +158,7 @@ class Config11 {
                         "bisheng"    : '--openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-jvm-features=shenandoahgc'
                 ],
                 test                : [
-                        nightly: ['sanity.openjdk'],
+                        nightly: false,
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
                 ]
         ]


### PR DESCRIPTION
Caused JDK11u pipeline to still be running this morning. Until we are able to automate dynamic parallel testing on sanity, this should be removed.

Signed-off-by: Stewart X Addison <sxa@redhat.com>