### PR TITLE
Add MacOS/aarch64 builds to JDK11 pipelines

### DIFF
--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -8,6 +8,7 @@ targetConfigurations = [
         "ppc64leLinux"  : [    "temurin",    "openj9"                    ],
         "s390xLinux"    : [    "temurin",    "openj9"                    ],
         "aarch64Linux"  : [    "temurin",    "openj9",    "dragonwell",                   "bisheng"    ],
+        "aarch64Mac"    : [    "temurin",                           ],
         "arm32Linux"    : [    "temurin"                            ],
         "riscv64Linux"  : [                  "openj9",                                    "bisheng"    ]
 ]

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -41,7 +41,6 @@ class Config11 {
                 arch                : 'x64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--enable-headless-only=yes'
         ],
 
         x64Windows: [
@@ -112,6 +111,14 @@ class Config11 {
                         "openj9"      : '--enable-dtrace=auto --enable-jitserver'
                 ]
 
+        ],
+
+        aarch64Mac: [
+                os                  : 'mac',
+                arch                : 'aarch64',
+                additionalNodeLabels: 'macos11',
+                test                : 'default',
+                configureArgs       : '--disable-ccache"
         ],
 
         arm32Linux    : [

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -40,7 +40,7 @@ class Config11 {
                 os                  : 'alpine-linux',
                 arch                : 'x64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
-                test                : 'default',
+                test                : 'default'
         ],
 
         x64Windows: [


### PR DESCRIPTION
As discussed in PMC meeting on March 30, 2022.

Draft at the moment as I've been getting hangs when enabling builds with ccache and need to verify it works ok without that. Approvals welcome for the change though :-)

Signed-off-by: Stewart X Addison <sxa@redhat.com>