### PR TITLE
Force make to use SHELL=/bin/bash on Solaris

### DIFF
--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -77,13 +77,15 @@ class Config8 {
         sparcv9Solaris: [
                 os  : 'solaris',
                 arch: 'sparcv9',
-                test: 'default'
+                test: 'default',
+                buildArgs: '--make-args SHELL=/bin/bash'
         ],
 
         x64Solaris    : [
                 os                  : 'solaris',
                 arch                : 'x64',
-                test                : 'default'
+                test                : 'default',
+                buildArgs           : '--make-args SHELL=/bin/bash'
         ],
 
         ppc64leLinux  : [


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/2894

I believe this will set `BUILD_ARGS` to the right thing in the pipelines - https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk8u/job/jdk8u-solaris-x64-hotspot/795/ seems to be running happily with this in place:

```
"BUILD_ARGS": "--make-args SHELL=/bin/bash",
```
Signed-off-by: Stewart X Addison <sxa@redhat.com>