### PR TITLE
AIX: Use xlc16 compiler for JDK11

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -80,8 +80,8 @@ class Config11 {
                 os                  : 'aix',
                 arch                : 'ppc64',
                 additionalNodeLabels: [
-                        temurin: 'xlc13&&aix710',
-                        openj9:  'xlc13&&aix715'
+                        temurin: 'xlc16&&aix710',
+                        openj9:  'xlc16&&aix715'
                 ],
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true


### PR DESCRIPTION
To sync with https://github.com/adoptium/temurin-build/pull/2886

@AdamBrousseau I presume you're OK with using XLC16 for OpenJ9 JDK11? Would be good to get the OpenJ9 team's OK on this since the PR changes hotspot and openj9