### PR TITLE
fix headless flag for alpine linux and add to pipeline configs

### DIFF
--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -8,6 +8,7 @@ targetConfigurations = [
         "ppc64leLinux"  : [    "temurin",    "openj9"                    ],
         "s390xLinux"    : [    "temurin",    "openj9"                    ],
         "aarch64Linux"  : [    "temurin",    "openj9",    "dragonwell",                   "bisheng"    ],
+        "aarch64AlpineLinux": [    "temurin"                            ],
         "aarch64Mac"    : [    "temurin",                           ],
         "arm32Linux"    : [    "temurin"                            ],
         "riscv64Linux"  : [                  "openj9",                                    "bisheng"    ]

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -44,6 +44,7 @@ class Config11 {
                 arch                : 'x64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
+                configureArgs       : '--enable-headless-only=yes'
                 buildArgs           : [
                         "temurin"   : '--create-sbom'
                 ]
@@ -54,7 +55,10 @@ class Config11 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--disable-headful'
+                configureArgs       : '--enable-headless-only=yes'
+                buildArgs           : [
+                        "temurin"   : '--create-sbom'
+                ]
         ],
 
         x64Windows: [

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -44,7 +44,7 @@ class Config11 {
                 arch                : 'x64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--enable-headless-only=yes'
+                configureArgs       : '--enable-headless-only=yes',
                 buildArgs           : [
                         "temurin"   : '--create-sbom'
                 ]
@@ -55,7 +55,7 @@ class Config11 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--enable-headless-only=yes'
+                configureArgs       : '--enable-headless-only=yes',
                 buildArgs           : [
                         "temurin"   : '--create-sbom'
                 ]

--- a/pipelines/jobs/configurations/jdk16u.groovy
+++ b/pipelines/jobs/configurations/jdk16u.groovy
@@ -33,6 +33,9 @@ targetConfigurations = [
                 "hotspot",
                 "openj9"
         ],
+        "aarch64AlpineLinux" : [
+                "temurin"
+        ],
         "arm32Linux"  : [
                 "hotspot"
         ]

--- a/pipelines/jobs/configurations/jdk16u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk16u_pipeline_config.groovy
@@ -41,7 +41,7 @@ class Config16 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--disable-headful'
+                configureArgs       : '--enable-headless-only=yes'
         ],
 
         x64Windows: [

--- a/pipelines/jobs/configurations/jdk17u.groovy
+++ b/pipelines/jobs/configurations/jdk17u.groovy
@@ -35,6 +35,9 @@ targetConfigurations = [
                 "openj9",
                 "bisheng"
         ],
+        "aarch64AlpineLinux" : [
+                "temurin"
+        ],
         "aarch64Mac": [
                 "temurin"
         ],

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -53,7 +53,7 @@ class Config17 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--enable-headless-only=yes'
+                configureArgs       : '--enable-headless-only=yes',
                 buildArgs           : [
                         "temurin"   : '--create-jre-image --create-sbom'
                 ]

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -53,7 +53,10 @@ class Config17 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--disable-headful'
+                configureArgs       : '--enable-headless-only=yes'
+                buildArgs           : [
+                        "temurin"   : '--create-jre-image --create-sbom'
+                ]
         ],
 
         x64Windows: [

--- a/pipelines/jobs/configurations/jdk18u.groovy
+++ b/pipelines/jobs/configurations/jdk18u.groovy
@@ -26,6 +26,9 @@ targetConfigurations = [
         "aarch64Linux": [
                 "temurin"
         ],
+        "aarch64AlpineLinux" : [
+                "temurin"
+        ],
         "aarch64Mac": [
                 "temurin"
         ],

--- a/pipelines/jobs/configurations/jdk18u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk18u_pipeline_config.groovy
@@ -53,7 +53,10 @@ class Config18 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--disable-headful'
+                configureArgs       : '--enable-headless-only=yes'
+                buildArgs           : [
+                        "temurin"   : '--create-jre-image --create-sbom'
+                ]
         ],
         
         x64Windows: [

--- a/pipelines/jobs/configurations/jdk18u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk18u_pipeline_config.groovy
@@ -53,7 +53,7 @@ class Config18 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--enable-headless-only=yes'
+                configureArgs       : '--enable-headless-only=yes',
                 buildArgs           : [
                         "temurin"   : '--create-jre-image --create-sbom'
                 ]

--- a/pipelines/jobs/configurations/jdk19.groovy
+++ b/pipelines/jobs/configurations/jdk19.groovy
@@ -27,6 +27,9 @@ targetConfigurations = [
                 "hotspot",
                 "temurin"
         ],
+        "aarch64AlpineLinux" : [
+                "temurin"
+        ],
         "aarch64Mac": [
                 "temurin"
         ],

--- a/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
@@ -53,7 +53,7 @@ class Config19 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--enable-headless-only=yes'
+                configureArgs       : '--enable-headless-only=yes',
                 buildArgs           : [
                         "temurin"   : '--create-jre-image --create-sbom'
                 ]

--- a/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
@@ -53,7 +53,10 @@ class Config19 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--disable-headful'
+                configureArgs       : '--enable-headless-only=yes'
+                buildArgs           : [
+                        "temurin"   : '--create-jre-image --create-sbom'
+                ]
         ],
         
         x64Windows: [

--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -40,6 +40,9 @@ targetConfigurations = [
                 "dragonwell",
                 "bisheng"
         ],
+        "aarch64AlpineLinux" : [
+                "temurin"
+        ],
         "arm32Linux"  : [
                 "temurin"
         ],

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -48,7 +48,7 @@ class Config8 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--disable-headful'
+                configureArgs       : '--disable-headful',
                 buildArgs           : [
                         "temurin"   : '--create-sbom'
                 ]

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -49,6 +49,9 @@ class Config8 {
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
                 configureArgs       : '--disable-headful'
+                buildArgs           : [
+                        "temurin"   : '--create-sbom'
+                ]
         ],
 
         x64Windows    : [


### PR DESCRIPTION
We were passing the wrong headless flag for JDK11+ and didn't add some of the SBOM args etc