### PR TITLE
Add support for Jenkins built-in node

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -771,8 +771,8 @@ class Builder implements Serializable {
 
                             if (downstreamJob.getResult() == 'SUCCESS') {
                                 // copy artifacts from build
-                                context.println "[NODE SHIFT] MOVING INTO MASTER NODE..."
-                                context.node("master") {
+                                context.println "[NODE SHIFT] MOVING INTO CONTROLLER NODE..."
+                                context.node("built-in || master") {
                                     context.catchError {
 
                                         //Remove the previous artifacts
@@ -813,7 +813,7 @@ class Builder implements Serializable {
 
                                     }
                                 }
-                                context.println "[NODE SHIFT] OUT OF MASTER NODE!"
+                                context.println "[NODE SHIFT] OUT OF CONTROLLER NODE!"
                             } else if (propagateFailures) {
                                 context.error("Build failed due to downstream failure of ${downstreamJobName}")
                                 currentBuild.result = "FAILURE"

--- a/pipelines/build/common/kick_off_build.groovy
+++ b/pipelines/build/common/kick_off_build.groovy
@@ -36,7 +36,7 @@ def baseFilePath = (params.CUSTOM_BASEFILE_LOCATION) ?: LOCAL_DEFAULTS_JSON["bas
 
 def userRemoteConfigs = [:]
 def downstreamBuilder = null
-node("master") {
+node("built-in || master") {
     /*
     Changes dir to Adopt's pipeline repo. Use closures as functions aren't accepted inside node blocks
     */

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -76,7 +76,7 @@ class Build {
         NODE_CHECKOUT_TIMEOUT : 1,
         BUILD_JDK_TIMEOUT : 8,
         BUILD_ARCHIVE_TIMEOUT : 3,
-        MASTER_CLEAN_TIMEOUT : 1,
+        CONTROLLER_CLEAN_TIMEOUT : 1,
         DOCKER_CHECKOUT_TIMEOUT : 1,
         DOCKER_PULL_TIMEOUT : 2
     ]
@@ -285,7 +285,7 @@ class Build {
                 def jobName = jobParams.TEST_JOB_NAME
                 def JobHelper = context.library(identifier: 'openjdk-jenkins-helper@master').JobHelper
                 if (!JobHelper.jobIsRunnable(jobName as String)) {
-                    context.node('master') {
+                    context.node('built-in || master') {
                         context.sh('curl -Os https://raw.githubusercontent.com/adoptium/aqa-tests/master/buildenv/jenkins/testJobTemplate')
                         def templatePath = 'testJobTemplate'
                         context.println "Smoke test job doesn't exist, create test job: ${jobName}"
@@ -392,7 +392,7 @@ class Build {
                                     context.build job: "Test_Job_Auto_Gen", propagate: false, parameters: updatedParams
                                 }
                             } else {
-                                context.node('master') {
+                                context.node('built-in || master') {
                                     context.sh('curl -Os https://raw.githubusercontent.com/adoptium/aqa-tests/master/buildenv/jenkins/testJobTemplate')
                                     def templatePath = 'testJobTemplate'
                                     if (!JobHelper.jobIsRunnable(jobName as String)) {
@@ -487,7 +487,7 @@ class Build {
                     propagate: true,
                     parameters: params
 
-                context.node('master') {
+                context.node('built-in || master') {
                     //Copy signed artifact back and archive again
                     context.sh "rm workspace/target/* || true"
 
@@ -634,7 +634,7 @@ class Build {
             return
         }
 
-        context.node('master') {
+        context.node('built-in || master') {
             context.stage("installer") {
                 switch (buildConfig.TARGET_OS) {
                     case "mac": context.sh 'rm -f workspace/target/*.pkg workspace/target/*.pkg.json workspace/target/*.pkg.sha256.txt'; buildMacInstaller(versionData); break
@@ -663,7 +663,7 @@ class Build {
             return
         }
 
-        context.node('master') {
+        context.node('built-in || master') {
             context.stage("sign installer") {
                 if (buildConfig.TARGET_OS == "mac" || buildConfig.TARGET_OS == "windows") {
                     try {
@@ -1500,7 +1500,7 @@ class Build {
 
                     // Set Github Commit Status
                     if (env.JOB_NAME.contains("pr-tester")) {
-                        context.node('master') {
+                        context.node('built-in || master') {
                             updateGithubCommitStatus("PENDING", "Pending")
                         }
                     }
@@ -1523,7 +1523,7 @@ class Build {
                             if (cleanWorkspace) {
 
                                 try {
-                                    context.timeout(time: buildTimeouts.MASTER_CLEAN_TIMEOUT, unit: "HOURS") {
+                                    context.timeout(time: buildTimeouts.CONTROLLER_CLEAN_TIMEOUT, unit: "HOURS") {
                                         // Cannot clean workspace from inside docker container
                                         if (cleanWorkspace) {
                                             try {
@@ -1535,7 +1535,7 @@ class Build {
                                         }
                                     }
                                 } catch (FlowInterruptedException e) {
-                                    throw new Exception("[ERROR] Master clean workspace timeout (${buildTimeouts.MASTER_CLEAN_TIMEOUT} HOURS) has been reached. Exiting...")
+                                    throw new Exception("[ERROR] Controller clean workspace timeout (${buildTimeouts.CONTROLLER_CLEAN_TIMEOUT} HOURS) has been reached. Exiting...")
                                 }
 
                             }
@@ -1554,7 +1554,7 @@ class Build {
                                     dockerImageDigest = context.sh(script: "docker inspect --format='{{.RepoDigests}}' ${buildConfig.DOCKER_IMAGE}", returnStdout:true)
                                 }
                             } catch (FlowInterruptedException e) {
-                                throw new Exception("[ERROR] Master docker image pull timeout (${buildTimeouts.DOCKER_PULL_TIMEOUT} HOURS) has been reached. Exiting...")
+                                throw new Exception("[ERROR] Controller docker image pull timeout (${buildTimeouts.DOCKER_PULL_TIMEOUT} HOURS) has been reached. Exiting...")
                             }
 
                             // Use our docker file if DOCKER_FILE is defined
@@ -1574,7 +1574,7 @@ class Build {
                                         context.sh(script: "git clean -fdx")
                                     }
                                 } catch (FlowInterruptedException e) {
-                                    throw new Exception("[ERROR] Master docker file scm checkout timeout (${buildTimeouts.DOCKER_CHECKOUT_TIMEOUT} HOURS) has been reached. Exiting...")
+                                    throw new Exception("[ERROR] Controller docker file scm checkout timeout (${buildTimeouts.DOCKER_CHECKOUT_TIMEOUT} HOURS) has been reached. Exiting...")
                                 }
 
                                 context.docker.build("build-image", "--build-arg image=${buildConfig.DOCKER_IMAGE} -f ${buildConfig.DOCKER_FILE} .").inside {

--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -21,7 +21,7 @@ Closure configureBuild = null
 def buildConfigurations = null
 Map<String, ?> DEFAULTS_JSON = null
 
-node ("master") {
+node ("built-in || master") {
     // Load defaultsJson. These are passed down from the build_pipeline_generator and is a JSON object containing user's default constants.
     if (!params.defaultsJson || defaultsJson == "") {
         throw new Exception("[ERROR] No User Defaults JSON found! Please ensure the defaultsJson parameter is populated and not altered during parameter declaration.")

--- a/pipelines/build/prTester/kick_off_tester.groovy
+++ b/pipelines/build/prTester/kick_off_tester.groovy
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-node("master") {
+node("built-in || master") {
     // Don't parameterise url as we currently have no need and the job generates its own params anyway
     String branch = "${ghprbActualCommit}"
     String DEFAULTS_FILE_URL = "https://raw.githubusercontent.com/adoptium/ci-jenkins-pipelines/${branch}/pipelines/defaults.json"

--- a/pipelines/build/regeneration/build_job_generator.groovy
+++ b/pipelines/build/regeneration/build_job_generator.groovy
@@ -21,7 +21,7 @@ String javaVersion = params.JAVA_VERSION
 String ADOPT_DEFAULTS_FILE_URL = "https://raw.githubusercontent.com/adoptium/ci-jenkins-pipelines/master/pipelines/defaults.json"
 String DEFAULTS_FILE_URL = (params.DEFAULTS_URL) ?: ADOPT_DEFAULTS_FILE_URL
 
-node ("master") {
+node ("built-in || master") {
   // Retrieve Adopt Defaults
   def getAdopt = new URL(ADOPT_DEFAULTS_FILE_URL).openConnection()
   Map<String, ?> ADOPT_DEFAULTS_JSON = new JsonSlurper().parseText(getAdopt.getInputStream().getText()) as Map

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -2,7 +2,7 @@ import java.nio.file.NoSuchFileException
 import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
 
-node('master') {
+node('built-in || master') {
   try {
     // Pull in Adopt defaults
     String ADOPT_DEFAULTS_FILE_URL = "https://raw.githubusercontent.com/adoptium/ci-jenkins-pipelines/master/pipelines/defaults.json"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -19,7 +19,7 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 
-node ("master") {
+node ("built-in || master") {
   def variant = "${params.VARIANT}"
   def jenkinsUrl = "${params.JENKINS_URL}"
   def trssUrl    = "${params.TRSS_URL}"

--- a/tools/stage_time_analysis.groovy
+++ b/tools/stage_time_analysis.groovy
@@ -60,7 +60,7 @@ limitations under the License.
     }
   }
 
-node ("master") {
+node ("built-in || master") {
   def jenkinsUrl = "${params.JENKINS_URL}"
   def findStage = "${params.STAGE}"
   def periodDays = params.PERIOD_DAYS as Long


### PR DESCRIPTION
Add built-in label to the pipelines due to the renaming of "master node"
to "built-in node" in newer Jenkins versions (master label to be removed
after Jenkins upgrade).

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>