### PR TITLE
Revert "feat: enable --create-sbom (in temurin-build) by passing new flag

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -8,9 +8,6 @@ class Config11 {
                 configureArgs       : [
                         "openj9"      : '--enable-dtrace=auto --with-cmake',
                         "temurin"     : '--enable-dtrace=auto'
-                ],
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
                 ]
         ],
 
@@ -35,7 +32,7 @@ class Config11 {
                         "bisheng"     : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server --disable-warnings-as-errors'
                 ],
                 buildArgs            : [
-                        "temurin"     : '--create-source-archive --create-sbom'
+                        "temurin"     : '--create-source-archive'
                 ]
         ],
 
@@ -44,10 +41,7 @@ class Config11 {
                 arch                : 'x64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--enable-headless-only=yes',
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
-                ]
+                configureArgs       : '--enable-headless-only=yes'
         ],
 
         aarch64AlpineLinux  : [
@@ -55,10 +49,7 @@ class Config11 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--enable-headless-only=yes',
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
-                ]
+                configureArgs       : '--enable-headless-only=yes'
         ],
 
         x64Windows: [
@@ -70,7 +61,7 @@ class Config11 {
                         dragonwell: 'win2012'
                 ],
                 buildArgs : [
-                        temurin : '--jvm-variant client,server --create-sbom'
+                        temurin : '--jvm-variant client,server'
                 ],
                 test                : 'default'
         ],
@@ -89,7 +80,7 @@ class Config11 {
                 arch                : 'x86-32',
                 additionalNodeLabels: 'win2012',
                 buildArgs : [
-                        temurin : '--jvm-variant client,server --create-sbom'
+                        temurin : '--jvm-variant client,server'
                 ],
                 test                : 'default'
         ],
@@ -102,30 +93,21 @@ class Config11 {
                         openj9:  'xlc13&&aix715'
                 ],
                 test                : 'default',
-                cleanWorkspaceAfterBuild: true,
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
-                ]
+                cleanWorkspaceAfterBuild: true
         ],
 
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
                 test                : 'default',
-                configureArgs       : '--enable-dtrace=auto',
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
-                ]
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         sparcv9Solaris    : [
                 os                  : 'solaris',
                 arch                : 'sparcv9',
                 test                : false,
-                configureArgs       : '--enable-dtrace=auto',
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
-                ]
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         ppc64leLinux    : [
@@ -136,10 +118,8 @@ class Config11 {
                 configureArgs       : [
                         "temurin"     : '--enable-dtrace=auto',
                         "openj9"      : '--enable-dtrace=auto --enable-jitserver'
-                ],
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
                 ]
+
         ],
 
         aarch64Mac: [
@@ -147,20 +127,14 @@ class Config11 {
                 arch                : 'aarch64',
                 additionalNodeLabels: 'macos11',
                 test                : 'default',
-                configureArgs       : '--disable-ccache',
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
-                ]
+                configureArgs       : '--disable-ccache'
         ],
 
         arm32Linux    : [
                 os                  : 'linux',
                 arch                : 'arm',
                 test                : 'default',
-                configureArgs       : '--enable-dtrace=auto',
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
-                ]
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         aarch64Linux    : [
@@ -181,10 +155,7 @@ class Config11 {
                         "dragonwell": "--enable-dtrace=auto --with-extra-cflags=\"-march=armv8.2-a+crypto\" --with-extra-cxxflags=\"-march=armv8.2-a+crypto\"",
                         "bisheng"   : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server'
                 ],
-                testDynamic        : false,
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
-                ]
+                testDynamic        : false
         ],
 
         riscv64Linux      :  [
@@ -200,8 +171,7 @@ class Config11 {
                 ],
                 buildArgs            : [
                         "openj9"     : '--cross-compile',
-                        "bisheng"    : '--cross-compile --branch risc-v',
-                        "temurin"   : '--create-sbom'
+                        "bisheng"    : '--cross-compile --branch risc-v'
                 ],
                 configureArgs        : [
                         "openj9"     : '--disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root',

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -10,7 +10,7 @@ class Config17 {
                 test                : 'default',
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -33,7 +33,7 @@ class Config17 {
                         "temurin"   : '--enable-dtrace'
                 ],
                 buildArgs           : [
-                        "temurin"   : '--create-source-archive --create-jre-image --create-sbom'
+                        "temurin"   : '--create-source-archive --create-jre-image'
                 ]
         ],
 
@@ -44,7 +44,7 @@ class Config17 {
                 test                : 'default',
                 configureArgs       : '--enable-headless-only=yes',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -55,7 +55,7 @@ class Config17 {
                 test                : 'default',
                 configureArgs       : '--enable-headless-only=yes',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -65,7 +65,7 @@ class Config17 {
                 additionalNodeLabels: 'win2012&&vs2017',
                 test                : 'default',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -81,7 +81,7 @@ class Config17 {
                         weekly : []
                 ],
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -92,7 +92,7 @@ class Config17 {
                 additionalNodeLabels: 'win2012&&vs2017',
                 test                : 'default',
                 buildArgs           : [
-                        "temurin"   : '--jvm-variant client,server --create-jre-image --create-sbom'
+                        "temurin"   : '--jvm-variant client,server --create-jre-image'
                 ]
         ],
 
@@ -106,7 +106,7 @@ class Config17 {
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -117,7 +117,7 @@ class Config17 {
                 test                : 'default',
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -131,7 +131,7 @@ class Config17 {
                         "openj9"      : '--enable-dtrace --enable-jitserver'
                 ],
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -143,7 +143,7 @@ class Config17 {
                 configureArgs : '--enable-dtrace',
                 testDynamic          : false,
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
 
         ],
@@ -154,7 +154,7 @@ class Config17 {
                 additionalNodeLabels: 'macos11',
                 test                : 'default',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
 
         ],
@@ -165,7 +165,7 @@ class Config17 {
                 test                : 'default',
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ]
 

--- a/pipelines/jobs/configurations/jdk18u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk18u_pipeline_config.groovy
@@ -10,7 +10,7 @@ class Config18 {
                 test                : 'default',
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -33,7 +33,7 @@ class Config18 {
                         "temurin"   : '--enable-dtrace'
                 ],
                 buildArgs           : [
-                        "temurin"   : '--create-source-archive --create-jre-image --create-sbom'
+                        "temurin"   : '--create-source-archive --create-jre-image'
                 ]
         ],
 
@@ -44,7 +44,7 @@ class Config18 {
                 test                : 'default',
                 configureArgs       : '--enable-headless-only=yes',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -55,7 +55,7 @@ class Config18 {
                 test                : 'default',
                 configureArgs       : '--enable-headless-only=yes',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
         
@@ -65,7 +65,7 @@ class Config18 {
                 additionalNodeLabels: 'win2012&&vs2017',
                 test                : 'default',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -81,7 +81,7 @@ class Config18 {
                         weekly : []
                 ],
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -92,7 +92,7 @@ class Config18 {
                 additionalNodeLabels: 'win2012&&vs2017',
                 test                : 'default',
                 buildArgs           : [
-                        "temurin"   : '--jvm-variant client,server --create-jre-image --create-sbom'
+                        "temurin"   : '--jvm-variant client,server --create-jre-image'
                 ]
         ],
 
@@ -106,7 +106,7 @@ class Config18 {
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -117,7 +117,7 @@ class Config18 {
                 test                : 'default',
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -131,7 +131,7 @@ class Config18 {
                         "openj9"      : '--enable-dtrace --enable-jitserver'
                 ],
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -143,7 +143,7 @@ class Config18 {
                 configureArgs : '--enable-dtrace',
                 testDynamic          : false,
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
         
@@ -153,7 +153,7 @@ class Config18 {
                 additionalNodeLabels: 'macos11',
                 test                : 'default',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -163,7 +163,7 @@ class Config18 {
                 test                : 'default',
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ]
   ]

--- a/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
@@ -10,7 +10,7 @@ class Config19 {
                 test                : 'default',
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -33,7 +33,7 @@ class Config19 {
                         "temurin"   : '--enable-dtrace'
                 ],
                 buildArgs           : [
-                        "temurin"   : '--create-source-archive --create-jre-image --create-sbom'
+                        "temurin"   : '--create-source-archive --create-jre-image'
                 ]
         ],
 
@@ -44,7 +44,7 @@ class Config19 {
                 test                : 'default',
                 configureArgs       : '--enable-headless-only=yes',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -55,7 +55,7 @@ class Config19 {
                 test                : 'default',
                 configureArgs       : '--enable-headless-only=yes',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
         
@@ -65,7 +65,7 @@ class Config19 {
                 additionalNodeLabels: 'win2012&&vs2017',
                 test                : 'default',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -81,7 +81,7 @@ class Config19 {
                         weekly : []
                 ],
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -90,10 +90,10 @@ class Config19 {
                 os                  : 'windows',
                 arch                : 'x86-32',
                 additionalNodeLabels: 'win2012&&vs2017',
-                buildArgs           : [
-                        temurin : '--jvm-variant client,server --create-jre-image'
-                ],
                 test                : 'default',
+                buildArgs           : [
+                        "temurin"   : '--jvm-variant client,server --create-jre-image'
+                ]
         ],
 
         ppc64Aix    : [
@@ -106,7 +106,7 @@ class Config19 {
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -117,7 +117,7 @@ class Config19 {
                 test                : 'default',
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -131,7 +131,7 @@ class Config19 {
                         "openj9"      : '--enable-dtrace --enable-jitserver'
                 ],
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -143,7 +143,7 @@ class Config19 {
                 configureArgs : '--enable-dtrace',
                 testDynamic          : false,
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
         
@@ -153,7 +153,7 @@ class Config19 {
                 additionalNodeLabels: 'macos11',
                 test                : 'default',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
 
@@ -163,14 +163,14 @@ class Config19 {
                 test                : 'default',
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
-                        "temurin"   : '--create-jre-image --create-sbom'
+                        "temurin"   : '--create-jre-image'
                 ]
         ],
         riscv64Linux      :  [
                 os                   : 'linux',
                 arch                 : 'riscv64',
                 configureArgs        : '--enable-dtrace --with-native-debug-symbols=none',
-                buildArgs            : '-r https://github.com/openjdk/riscv-port -b riscv-port --custom-cacerts false --disable-adopt-branch-safety --create-sbom',
+                buildArgs            : '-r https://github.com/openjdk/riscv-port -b riscv-port --custom-cacerts false --disable-adopt-branch-safety',
                 test                : [
                         nightly: ['sanity.openjdk'],
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -8,10 +8,7 @@ class Config8 {
                         corretto: 'build-macstadium-macos1010-1',
                         openj9  : 'macos10.14'
                 ],
-                test                 : 'default',
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
-                ]
+                test                 : 'default'
         ],
 
         x64Linux      : [
@@ -28,7 +25,7 @@ class Config8 {
                         "dragonwell"  : '--enable-unlimited-crypto --with-jvm-variants=server  --with-zlib=system',
                 ],
                 buildArgs           : [
-                        "temurin"   : '--create-source-archive --create-sbom'
+                        "temurin"   : '--create-source-archive'
                 ]
         ],
 
@@ -37,10 +34,7 @@ class Config8 {
                 arch                : 'x64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--disable-headful',
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
-                ]
+                configureArgs       : '--disable-headful'
         ],
 
         aarch64AlpineLinux  : [
@@ -48,10 +42,7 @@ class Config8 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--disable-headful',
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
-                ]
+                configureArgs       : '--disable-headful'
         ],
 
         x64Windows    : [
@@ -66,7 +57,7 @@ class Config8 {
                 arch                : 'x86-32',
                 additionalNodeLabels: 'win2012',
                 buildArgs : [
-                        temurin : '--jvm-variant client,server --create-sbom'
+                        temurin : '--jvm-variant client,server'
                 ],
                 test                 : 'default'
         ],
@@ -79,10 +70,7 @@ class Config8 {
                         openj9:  'xlc13&&aix715'
                 ],
                 test                 : 'default',
-                cleanWorkspaceAfterBuild: true,
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
-                ]
+                cleanWorkspaceAfterBuild: true
         ],
 
         s390xLinux    : [
@@ -91,28 +79,19 @@ class Config8 {
                 test: [
                         temurin: ['sanity.openjdk'],
                         openj9: 'default'
-                ],
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
                 ]
         ],
 
         sparcv9Solaris: [
                 os  : 'solaris',
                 arch: 'sparcv9',
-                test: 'default',
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
-                ]
+                test: 'default'
         ],
 
         x64Solaris    : [
                 os                  : 'solaris',
                 arch                : 'x64',
-                test                : 'default',
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
-                ]
+                test                : 'default'
         ],
 
         ppc64leLinux  : [
@@ -122,19 +101,13 @@ class Config8 {
                 test                 : 'default',
                 configureArgs       : [
                         "openj9"      : '--enable-jitserver'
-                ],
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
                 ]
         ],
 
         arm32Linux    : [
                 os  : 'linux',
                 arch: 'arm',
-                test: 'default',
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
-                ]
+                test: 'default'
         ],
 
         aarch64Linux  : [
@@ -145,10 +118,7 @@ class Config8 {
                         dragonwell: 'pipelines/build/dockerFiles/dragonwell_aarch64.dockerfile'
                 ],
                 test                 : 'default',
-                testDynamic          : false,
-                buildArgs           : [
-                        "temurin"   : '--create-sbom'
-                ]
+                testDynamic          : false
         ],
   ]
 


### PR DESCRIPTION
	- windows is working with --create-sbom
	- enable --create-sbom flag for all jdk version * platform
	- by default, value set in temurin-build
	
merge this PR after [temurin-build PR](https://github.com/adoptium/temurin-build/pull/2937) is merged

This reverts commit 03de63a180a7b134de1d191aafbd3c46acd821da.


Ref: https://github.com/adoptium/temurin-build/issues/2900