### PR TITLE
Clean workspace prior to installer jobs

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -636,8 +636,11 @@ class Build {
 
         context.node('built-in || master') {
             context.stage("installer") {
+                // Ensure master context workspace is clean
+                context.sh "rm workspace/target/* || true"
+
                 switch (buildConfig.TARGET_OS) {
-                    case "mac": context.sh 'rm -f workspace/target/*.pkg workspace/target/*.pkg.json workspace/target/*.pkg.sha256.txt'; buildMacInstaller(versionData); break
+                    case "mac":     buildMacInstaller(versionData); break
                     case "windows": buildWindowsInstaller(versionData); break
                     default: break
                 }
@@ -665,6 +668,9 @@ class Build {
 
         context.node('built-in || master') {
             context.stage("sign installer") {
+                // Ensure master context workspace is clean
+                context.sh "rm workspace/target/* || true"
+
                 if (buildConfig.TARGET_OS == "mac" || buildConfig.TARGET_OS == "windows") {
                     try {
                         signInstallerJob(versionData);

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -636,8 +636,8 @@ class Build {
 
         context.node('built-in || master') {
             context.stage("installer") {
-                // Ensure master context workspace is clean
-                context.sh "rm workspace/target/* || true"
+                // Ensure master context workspace is clean of any previous archives
+                context.sh "rm -f workspace/target/* || true"
 
                 switch (buildConfig.TARGET_OS) {
                     case "mac":     buildMacInstaller(versionData); break
@@ -668,8 +668,8 @@ class Build {
 
         context.node('built-in || master') {
             context.stage("sign installer") {
-                // Ensure master context workspace is clean
-                context.sh "rm workspace/target/* || true"
+                // Ensure master context workspace is clean of any previous archives
+                context.sh "rm -f workspace/target/* || true"
 
                 if (buildConfig.TARGET_OS == "mac" || buildConfig.TARGET_OS == "windows") {
                     try {


### PR DESCRIPTION
The current buildInstallerMac/Windows() stages relied on the workspace being clean by the prior sign_build stage running on the same Jenkins master node. Now with 2 instances, it may not run on the same node. Thus this PR ensures each stage performs the workspace clean.

Fixes: https://github.com/adoptium/temurin-build/issues/2959

Signed-off-by: Andrew Leonard <anleonar@redhat.com>