### PR TITLE
Implement GPG signing of the binary build artifacts

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -496,7 +496,7 @@ class Build {
                             selector: context.specific("${signJob.getNumber()}"),
                             filter: 'workspace/target/*',
                             fingerprintArtifacts: true,
-                            target: "workspace/target/",
+                            target: 'workspace/target/',
                             flatten: true)
 
 
@@ -505,6 +505,34 @@ class Build {
                     writeMetadata(versionInfo, false)
                     context.archiveArtifacts artifacts: "workspace/target/*"
                 }
+            }
+        }
+        context.stage("GPG sign") {
+
+            context.println "RUNNING sign_temurin_gpg for ${buildConfig.TARGET_OS}/${buildConfig.ARCHITECTURE} ..."
+           
+            def params = [
+                context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
+                context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
+                context.string(name: 'UPSTREAM_DIR', value: "workspace/target"),
+                ['$class': 'LabelParameterValue', name: 'NODE_LABEL', label: "built-in"]
+            ]
+
+            def signSHAsJob = context.build job: "build-scripts/release/sign_temurin_gpg",
+                propagate: true,
+                parameters: params
+
+            context.node('built-in || master') {
+                context.sh "rm -f workspace/target/*.sig"
+                context.copyArtifacts(
+                    projectName: "build-scripts/release/sign_temurin_gpg",
+                    selector: context.specific("${signSHAsJob.getNumber()}"),
+                    filter: '**/*.sig',
+                    fingerprintArtifacts: true, 
+                    target: 'workspace/target/',
+                    flatten: true)
+                // Archive GPG signatures in Jenkins
+                context.archiveArtifacts artifacts: "workspace/target/*.sig"
             }
         }
     }


### PR DESCRIPTION
First stage in solving https://github.com/adoptium/temurin-build/issues/1275

Will require:
- a change in [refactor_openjdk_release_tool](https://ci.adoptopenjdk.net/job/build-scripts/job/release/job/refactor_openjdk_release_tool/) for them to be published ([Done](https://github.com/adoptium/github-release-scripts/pull/88))
- Changes in the API/website to make them downloadable ([Done](https://github.com/adoptium/api.adoptium.net/pull/464))
- Likely subsequent changes in the underlying signing job which should be moved into an external script
- Potential changes to where the job is run to avoid deadlocks occurring with the `master` nodes in jenkins (Hasn't been a problem ... so far!)
- Documentation on how users can use these signatures once they are made available.
- Potentially look at changing this to run from the individual platform build pipelines instead of the top level one - currently the sha256sums are only generated in the top level pipeline so are not available before that point (Except on mac/windows - [slack thread)](https://adoptium.slack.com/archives/C09NW3L2J/p1654609744697389) (Done in this PR)
- Look at aligning more with how the OpenJ9 team have done this as they cannot currently reuse the contents of this PR and will be skipping it

But this is the first step and is a prerequisite for the others. Note that this functionality will always be executed and is not currently gated by the `enableSigner` checkbox on the pipeline jobs. That can be added in a subsequent PR if desired.

This has been successfully trialled on the pipeline jobs.