### PR TITLE
Build jdk-19 AIX on aix720

### DIFF
--- a/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
@@ -100,7 +100,7 @@ class Config19 {
                 os                  : 'aix',
                 arch                : 'ppc64',
                 additionalNodeLabels: [
-                        temurin: 'xlc16&&aix710',
+                        temurin: 'xlc16&&aix720',
                         openj9:  'xlc16&&aix715'
                 ],
                 test                : 'default',


### PR DESCRIPTION
Building jdk-19 on AIX requires AIX 7.2 due to the new Virtual Threads using OS Thread Local storage.
See: https://www.ibm.com/docs/en/xl-c-and-cpp-aix/16.1?topic=end-language-standard-features

Signed-off-by: Andrew Leonard <anleonar@redhat.com>