### PR TITLE
feat: rename metadata file

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Alongside the built assets a metadata file will be created with info about the b
 
 ```json
 {
-    "vendor": "Eclipse Foundation",
+    "vendor": "Eclipse Adoptium",
     "os": "mac",
     "arch": "x64",
     "variant": "openj9",

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1051,10 +1051,12 @@ class Build {
             }
 
             // Special handling for sbom metadat file (to be backwards compatible for api service)
+            // from "*sbom<XXX>.json" to "*sbom<XXX>-metadata.json"
             if (file.contains("sbom")) {
-                file.replace(".json", "-metadata") // from "*sbom<XXX>.json" to "*sbom<XXX>-metadata"
+                context.writeFile file: file.replace(".json", "-metadata.json"), text: JsonOutput.prettyPrint(JsonOutput.toJson(data.asMap()))
+            } else {
+                context.writeFile file: "${file}.json", text: JsonOutput.prettyPrint(JsonOutput.toJson(data.asMap()))
             }
-            context.writeFile file: "${file}.json", text: JsonOutput.prettyPrint(JsonOutput.toJson(data.asMap()))
         })
     }
 

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1050,7 +1050,7 @@ class Build {
                 metaWrittenOut = true
             }
 
-            // Special handling for sbom metadat file (to be backwards compatible for api service)
+            // Special handling for sbom metadata file (to be backwards compatible for api service)
             // from "*sbom<XXX>.json" to "*sbom<XXX>-metadata.json"
             if (file.contains("sbom")) {
                 context.writeFile file: file.replace(".json", "-metadata.json"), text: JsonOutput.prettyPrint(JsonOutput.toJson(data.asMap()))

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -749,11 +749,11 @@ class Build {
 
 
     /*
-    Lists and returns any compressed archived contents of the top directory of the build node
+    Lists and returns any compressed archived or sbom file contents of the top directory of the build node
     */
     List<String> listArchives() {
         return context.sh(
-                script: '''find workspace/target/ | egrep '(.tar.gz|.zip|.msi|.pkg|.deb|.rpm)$' ''',
+                script: '''find workspace/target/ | egrep -e '(.tar.gz|.zip|.msi|.pkg|.deb|.rpm)$' -e '-sbom_' ''',
                 returnStdout: true,
                 returnStatus: false
         )
@@ -976,7 +976,7 @@ class Build {
         /*
         example data:
             {
-                "vendor": "Eclipse Foundation",
+                "vendor": "Eclipse Adoptium",
                 "os": "mac",
                 "arch": "x64",
                 "variant": "openj9",
@@ -1050,6 +1050,10 @@ class Build {
                 metaWrittenOut = true
             }
 
+            // Special handling for sbom metadat file (to be backwards compatible for api service)
+            if (file.contains("sbom")) {
+                file.replace(".json", "-metadata") // from "*sbom<XXX>.json" to "*sbom<XXX>-metadata"
+            }
             context.writeFile file: "${file}.json", text: JsonOutput.prettyPrint(JsonOutput.toJson(data.asMap()))
         })
     }


### PR DESCRIPTION
	- previous named as *sbom<XXX>.json
	- now change to *sbom<XXX>-metadata.json
	- update filter on binary files to include json (sbom<XXX>.json
	- this could solve problem with *sbom*.json file which does not generate metadata any more
	- this could help "api" to filter sbom's  metadata
Ref: https://github.com/adoptium/ci-jenkins-pipelines/issues/328