### PR TITLE
Ensure archive filename OpenJDKU prefix ends with U

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1074,7 +1074,7 @@ class Build {
 
         javaToBuild = javaToBuild.trim().toUpperCase()
  
-        # Add "U" to javaToBuild filename prefix for non-head versions
+        // Add "U" to javaToBuild filename prefix for non-head versions
         if (!javaToBuild.endsWith("U") && !javaToBuild.equals("JDK")) {
           javaToBuild += "U"
         }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1072,7 +1072,12 @@ class Build {
             extension = "zip"
         }
 
-        javaToBuild = javaToBuild.toUpperCase()
+        javaToBuild = javaToBuild.trim().toUpperCase()
+ 
+        # Add "U" to javaToBuild filename prefix for non-head versions
+        if (!javaToBuild.endsWith("U") && !javaToBuild.equals("JDK")) {
+          javaToBuild += "U"
+        }
 
         def fileName = "Open${javaToBuild}-jdk_${architecture}_${os}_${variant}"
         if (variant == "temurin") {


### PR DESCRIPTION
Branched new jdk versions eg.jdk19, do not have a "U" suffix on the java to build archive filename.
For compatibility we need it to end with U: OpenJDK19U

Fixes: https://github.com/adoptium/temurin-build/issues/2980
