### PR TITLE
fix Visual Studio version labels for Windows

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -56,7 +56,7 @@ class Config11 {
                 os                  : 'windows',
                 arch                : 'x64',
                 additionalNodeLabels: [
-                        temurin:    'win2012&&vs2017',
+                        temurin:    'win2012&&vs2019',
                         openj9:     'win2012&&vs2017',
                         dragonwell: 'win2012'
                 ],
@@ -69,7 +69,7 @@ class Config11 {
         x32Windows: [
                 os                  : 'windows',
                 arch                : 'x86-32',
-                additionalNodeLabels: 'win2012',
+                additionalNodeLabels: 'win2012&&vs2019',
                 buildArgs : [
                         temurin : '--jvm-variant client,server'
                 ],

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -62,7 +62,7 @@ class Config17 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
-                additionalNodeLabels: 'win2012&&vs2017',
+                additionalNodeLabels: 'win2012&&vs2019',
                 test                : 'default',
                 buildArgs           : [
                         "temurin"   : '--create-jre-image'
@@ -89,7 +89,7 @@ class Config17 {
         x32Windows: [
                 os                  : 'windows',
                 arch                : 'x86-32',
-                additionalNodeLabels: 'win2012&&vs2017',
+                additionalNodeLabels: 'win2012&&vs2019',
                 test                : 'default',
                 buildArgs           : [
                         "temurin"   : '--jvm-variant client,server --create-jre-image'

--- a/pipelines/jobs/configurations/jdk18u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk18u_pipeline_config.groovy
@@ -62,7 +62,7 @@ class Config18 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
-                additionalNodeLabels: 'win2012&&vs2017',
+                additionalNodeLabels: 'win2012&&vs2019',
                 test                : 'default',
                 buildArgs           : [
                         "temurin"   : '--create-jre-image'
@@ -89,7 +89,7 @@ class Config18 {
         x32Windows: [
                 os                  : 'windows',
                 arch                : 'x86-32',
-                additionalNodeLabels: 'win2012&&vs2017',
+                additionalNodeLabels: 'win2012&&vs2019',
                 test                : 'default',
                 buildArgs           : [
                         "temurin"   : '--jvm-variant client,server --create-jre-image'

--- a/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
@@ -62,7 +62,7 @@ class Config19 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
-                additionalNodeLabels: 'win2012&&vs2017',
+                additionalNodeLabels: 'win2012&&vs2019',
                 test                : 'default',
                 buildArgs           : [
                         "temurin"   : '--create-jre-image'
@@ -89,7 +89,7 @@ class Config19 {
         x32Windows: [
                 os                  : 'windows',
                 arch                : 'x86-32',
-                additionalNodeLabels: 'win2012&&vs2017',
+                additionalNodeLabels: 'win2012&&vs2019',
                 test                : 'default',
                 buildArgs           : [
                         "temurin"   : '--jvm-variant client,server --create-jre-image'


### PR DESCRIPTION
We are already building JDK17+ on VS 2019 so the label was incorrect.

Also updated JDK11 so this PR can be merged once https://github.com/adoptium/temurin-build/pull/2992 has been merged