### PR TITLE
Move GPG signing to after installer generation so installers are signed too

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -807,7 +807,7 @@ class Build {
                 flatten: true)
     }
 
-    private void gpgSign()
+    private void gpgSign() {
         context.stage("GPG sign") {
 
            context.println "RUNNING sign_temurin_gpg for ${buildConfig.TARGET_OS}/${buildConfig.ARCHITECTURE} ..."
@@ -1816,7 +1816,6 @@ class Build {
                 }
                 try {
                     gpgSign()
-                    }
                 } catch (Exception e) {
                     context.println(e.message)
                 }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -739,6 +739,39 @@ class Build {
                 }
             }
         }
+        context.stage("GPG sign") {
+
+           context.println "RUNNING sign_temurin_gpg for ${buildConfig.TARGET_OS}/${buildConfig.ARCHITECTURE} ..."
+           
+           def params = [
+                  context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
+                  context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
+                  context.string(name: 'UPSTREAM_DIR', value: "workspace/target"),
+                  ['$class': 'LabelParameterValue', name: 'NODE_LABEL', label: "built-in"]
+           ]
+
+           def signSHAsJob = context.build job: "build-scripts/release/sign_temurin_gpg",
+               propagate: true,
+               parameters: params
+
+           context.node('built-in || master') {
+               context.copyArtifacts(
+                    projectName: "build-scripts/release/sign_temurin_gpg",
+                    selector: context.specific("${signSHAsJob.getNumber()}"),
+                    filter: '**/*.sig',
+                    fingerprintArtifacts: true, 
+                    target: 'workspace/target/',
+                    flatten: true)
+           }
+           // Archive GPG signatures in Jenkins
+           try {
+               context.timeout(time: pipelineTimeouts.ARCHIVE_ARTIFACTS_TIMEOUT, unit: "HOURS") {
+                   context.archiveArtifacts artifacts: "target/${buildConfig.TARGET_OS}/${buildConfig.ARCHITECTURE}/${buildConfig.VARIANT}/*.sha256.txt.sig"
+               }
+           } catch (FlowInterruptedException e) {
+               throw new Exception("[ERROR] Archive artifact timeout (${pipelineTimeouts.ARCHIVE_ARTIFACTS_TIMEOUT} HOURS) for ${downstreamJobName}has been reached. Exiting...")
+           }
+        }
     }
 
     private void signInstallerJob(VersionInfo versionData) {
@@ -774,7 +807,41 @@ class Build {
                 flatten: true)
     }
 
+    private void gpgSign()
+        context.stage("GPG sign") {
 
+           context.println "RUNNING sign_temurin_gpg for ${buildConfig.TARGET_OS}/${buildConfig.ARCHITECTURE} ..."
+           
+           def params = [
+                  context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
+                  context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
+                  context.string(name: 'UPSTREAM_DIR', value: "workspace/target"),
+                  ['$class': 'LabelParameterValue', name: 'NODE_LABEL', label: "gpgsign"]
+           ]
+
+           def signSHAsJob = context.build job: "build-scripts/release/sign_temurin_gpg",
+               propagate: true,
+               parameters: params
+
+           context.node('gpgsign') {
+               context.copyArtifacts(
+                    projectName: "build-scripts/release/sign_temurin_gpg",
+                    selector: context.specific("${signSHAsJob.getNumber()}"),
+                    filter: '**/*.sig',
+                    fingerprintArtifacts: true, 
+                    target: 'workspace/target/',
+                    flatten: true)
+           }
+           // Archive GPG signatures in Jenkins
+           try {
+               context.timeout(time: pipelineTimeouts.ARCHIVE_ARTIFACTS_TIMEOUT, unit: "HOURS") {
+                   context.archiveArtifacts artifacts: "target/${buildConfig.TARGET_OS}/${buildConfig.ARCHITECTURE}/${buildConfig.VARIANT}/*.sha256.txt.sig"
+               }
+           } catch (FlowInterruptedException e) {
+               throw new Exception("[ERROR] Archive artifact timeout (${pipelineTimeouts.ARCHIVE_ARTIFACTS_TIMEOUT} HOURS) for ${downstreamJobName}has been reached. Exiting...")
+           }
+        }
+    }
     /*
     Lists and returns any compressed archived or sbom file contents of the top directory of the build node
     */
@@ -1746,6 +1813,12 @@ class Build {
                     } catch (FlowInterruptedException e) {
                         throw new Exception("[ERROR] Installer job timeout (${buildTimeouts.INSTALLER_JOBS_TIMEOUT} HOURS) has been reached OR the downstream installer job failed. Exiting...")
                     }
+                }
+                try {
+                    gpgSign()
+                    }
+                } catch (Exception e) {
+                    context.println(e.message)
                 }
 
             // Generic catch all. Will usually be the last message in the log.


### PR DESCRIPTION
Self-explanatory. The existing solution does not GPG sign the installers as they haven't been created at the time the GPG signing is executed. This moves it to a more suitable location, and also separtes the operation into its own function.

Signed-off-by: Stewart X Addison <sxa@redhat.com>