### PR TITLE
fix: add recursive for rm so it won't fail because of folder

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -690,7 +690,7 @@ class Build {
         context.node('built-in || master') {
             context.stage("installer") {
                 // Ensure master context workspace is clean of any previous archives
-                context.sh "rm -f workspace/target/* || true"
+                context.sh "rm -rf workspace/target/* || true"
 
                 switch (buildConfig.TARGET_OS) {
                     case "mac":     buildMacInstaller(versionData); break
@@ -722,7 +722,7 @@ class Build {
         context.node('built-in || master') {
             context.stage("sign installer") {
                 // Ensure master context workspace is clean of any previous archives
-                context.sh "rm -f workspace/target/* || true"
+                context.sh "rm -rf workspace/target/* || true"
 
                 if (buildConfig.TARGET_OS == "mac" || buildConfig.TARGET_OS == "windows") {
                     try {


### PR DESCRIPTION
fix error when pipeline cannot rm a folder
` rm: cannot remove 'workspace/target/AQAvitTaps': Is a directory`
e.g https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk19/job/jdk19-windows-x64-temurin/11/consoleFull
