### PR TITLE
Remove riscv64 from default pipeline configurations

### DIFF
--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -10,8 +10,7 @@ targetConfigurations = [
         "aarch64Linux"  : [    "temurin",    "openj9",    "dragonwell",                   "bisheng"    ],
         "aarch64AlpineLinux": [    "temurin"                            ],
         "aarch64Mac"    : [    "temurin",                           ],
-        "arm32Linux"    : [    "temurin"                            ],
-        "riscv64Linux"  : [                  "openj9",                                    "bisheng"    ]
+        "arm32Linux"    : [    "temurin"                            ]
 ]
 
 // 18:05 Tue, Thur

--- a/pipelines/jobs/configurations/jdk19.groovy
+++ b/pipelines/jobs/configurations/jdk19.groovy
@@ -34,9 +34,6 @@ targetConfigurations = [
         ],
         "arm32Linux"  : [
                 "temurin"
-        ],
-        "riscv64Linux"  : [
-                "temurin"
         ]
 
 ]

--- a/pipelines/jobs/configurations/jdk20.groovy
+++ b/pipelines/jobs/configurations/jdk20.groovy
@@ -35,9 +35,6 @@ targetConfigurations = [
         ],
         "arm32Linux"  : [
                 "temurin"
-        ],
-        "riscv64Linux"  : [
-                "temurin"
         ]
 
 ]


### PR DESCRIPTION
Until reliable hardware can be setup, riscv64 is removed from the default pipeline configuration.
If a secondary/experimental platform pipeline configuration is created, it can be re-added to that, thus not affecting the nightly/weekly primary platform builds.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>