### PR TITLE
Ensure prTester does not block built-in node

### DIFF
--- a/pipelines/build/prTester/kick_off_tester.groovy
+++ b/pipelines/build/prTester/kick_off_tester.groovy
@@ -26,6 +26,7 @@ if (!DEFAULTS_JSON) {
 }
 
 String url = DEFAULTS_JSON['repository']['pipeline_url']
+Closure prTest
 
 // Switch to controller node to load library groovy definitions
 node("built-in || master") {
@@ -39,7 +40,7 @@ node("built-in || master") {
     ])
 
     load DEFAULTS_JSON['importLibraryScript']
-    Closure prTest = load DEFAULTS_JSON['scriptDirectories']['tester']
+    prTest = load DEFAULTS_JSON['scriptDirectories']['tester']
 }
 
 // Run tests outside node context

--- a/pipelines/build/prTester/kick_off_tester.groovy
+++ b/pipelines/build/prTester/kick_off_tester.groovy
@@ -38,12 +38,14 @@ node("built-in || master") {
 
     load DEFAULTS_JSON['importLibraryScript']
     Closure prTest = load DEFAULTS_JSON['scriptDirectories']['tester']
+}
 
-    prTest(
+// Run tests outside node context
+prTest(
         branch,
         currentBuild,
         this,
         url,
         DEFAULTS_JSON
-    ).runTests()
-}
+).runTests()
+

--- a/pipelines/build/prTester/kick_off_tester.groovy
+++ b/pipelines/build/prTester/kick_off_tester.groovy
@@ -14,19 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Don't parameterise url as we currently have no need and the job generates its own params anyway
+String branch = "${ghprbActualCommit}"
+String DEFAULTS_FILE_URL = "https://raw.githubusercontent.com/adoptium/ci-jenkins-pipelines/${branch}/pipelines/defaults.json"
+
+// Retrieve User defaults
+def getUser = new URL(DEFAULTS_FILE_URL).openConnection()
+Map<String, ?> DEFAULTS_JSON = new JsonSlurper().parseText(getUser.getInputStream().getText()) as Map
+if (!DEFAULTS_JSON) {
+    throw new Exception("[ERROR] No DEFAULTS_JSON found at ${DEFAULTS_FILE_URL}. Please ensure this path is correct and it leads to a JSON or Map object file.")
+}
+
+String url = DEFAULTS_JSON['repository']['pipeline_url']
+
+// Switch to controller node to load library groovy definitions
 node("built-in || master") {
-    // Don't parameterise url as we currently have no need and the job generates its own params anyway
-    String branch = "${ghprbActualCommit}"
-    String DEFAULTS_FILE_URL = "https://raw.githubusercontent.com/adoptium/ci-jenkins-pipelines/${branch}/pipelines/defaults.json"
-
-    // Retrieve User defaults
-    def getUser = new URL(DEFAULTS_FILE_URL).openConnection()
-    Map<String, ?> DEFAULTS_JSON = new JsonSlurper().parseText(getUser.getInputStream().getText()) as Map
-    if (!DEFAULTS_JSON) {
-        throw new Exception("[ERROR] No DEFAULTS_JSON found at ${DEFAULTS_FILE_URL}. Please ensure this path is correct and it leads to a JSON or Map object file.")
-    }
-
-    String url = DEFAULTS_JSON['repository']['pipeline_url']
     checkout([
         $class: 'GitSCM',
         branches: [[name: branch]],

--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -78,7 +78,7 @@ class PullRequestTestPipeline implements Serializable {
         Boolean pipelineFailed = false
 
         // Load generation scripts
-        node("built-in || master") {
+        context.node("built-in || master") {
             context.println "loading ${context.WORKSPACE}/${DEFAULTS_JSON['scriptDirectories']['regeneration']}"
             Closure regenerationScript = context.load "${context.WORKSPACE}/${DEFAULTS_JSON['scriptDirectories']['regeneration']}"
 

--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -144,8 +144,8 @@ class PullRequestTestPipeline implements Serializable {
                         }
                     }
                 }
-            } // End: node("built-in || master")
-        })
+            })
+        } // End: node("built-in || master")
 
         context.parallel jobs
 


### PR DESCRIPTION
pipelines/build/prTester/kick_off_tester.groovy was unnecessarily blocking the built-in node for the whole of the pr pipeline builds, which unfortunately now with the GPG signing on the built-in node causes a deadlock. 

I have re-worked the node() context to only where it is needed, just like the standard build pipelines.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>