### PR TITLE
Remove aarch64Alpine from default jdk11u pipeline config due to test hangs reliability

### DIFF
--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -8,7 +8,6 @@ targetConfigurations = [
         "ppc64leLinux"  : [    "temurin",    "openj9"                    ],
         "s390xLinux"    : [    "temurin",    "openj9"                    ],
         "aarch64Linux"  : [    "temurin",    "openj9",    "dragonwell",                   "bisheng"    ],
-        "aarch64AlpineLinux": [    "temurin"                            ],
         "aarch64Mac"    : [    "temurin",                           ],
         "arm32Linux"    : [    "temurin"                            ]
 ]


### PR DESCRIPTION
Due to nearly always hanging during jdk11u test jobs, the aarch64Alpine platform is being removed from the default nightly jdk11u pipeline config.
See: https://github.com/adoptium/aqa-tests/issues/3799

Signed-off-by: Andrew Leonard <anleonar@redhat.com>