### PR TITLE
Ensure pipeline/library git repo is cleared before load

### DIFF
--- a/pipelines/build/common/import_lib.groovy
+++ b/pipelines/build/common/import_lib.groovy
@@ -18,7 +18,7 @@ limitations under the License.
 
 // Imports our custom groovy library containing classes such as MetaData.groovy, VersionInfo.groovy, etc.
 def path = "pipelines/library"
-sh("cd ${path} && git init && git add --all . && git config user.email 'none' && git config user.name 'none' && git commit -m init &> /dev/null || true")
+sh("rm -rf ${path}/.git && cd ${path} && git init && git add --all . && git config user.email 'none' && git config user.name 'none' && git commit -m init &> /dev/null || true")
 def repoPath = sh(returnStdout: true, script: "pwd").trim() + "/" + path;
 library(identifier: 'local-lib@master', retriever: modernSCM([$class: 'GitSCMSource', remote: repoPath]))
 


### PR DESCRIPTION
Ensure the pipeline/library/.git repo is cleared prior to load in case it is corrupt or out of date

Fixes: https://github.com/adoptium/ci-jenkins-pipelines/issues/345
and also DOCKER_ARGS not defined error...

Signed-off-by: Andrew Leonard <anleonar@redhat.com>