### PR TITLE
Change (built-in or master) node context to worker

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -791,7 +791,7 @@ class Builder implements Serializable {
                             if (downstreamJob.getResult() == 'SUCCESS') {
                                 // copy artifacts from build
                                 context.println "[NODE SHIFT] MOVING INTO CONTROLLER NODE..."
-                                context.node("built-in || master") {
+                                context.node("worker") {
                                     context.catchError {
 
                                         //Remove the previous artifacts

--- a/pipelines/build/common/import_lib.groovy
+++ b/pipelines/build/common/import_lib.groovy
@@ -18,7 +18,7 @@ limitations under the License.
 
 // Imports our custom groovy library containing classes such as MetaData.groovy, VersionInfo.groovy, etc.
 def path = "pipelines/library"
-sh("cd ${path} && git init && git add --all . && git config user.email 'none' && git config user.name 'none' && git commit -m init &> /dev/null || true")
+sh("rm -rf ${path}/.git && cd ${path} && git init && git add --all . && git config user.email 'none' && git config user.name 'none' && git commit -m init &> /dev/null || true")
 def repoPath = sh(returnStdout: true, script: "pwd").trim() + "/" + path;
 library(identifier: 'local-lib@master', retriever: modernSCM([$class: 'GitSCMSource', remote: repoPath]))
 

--- a/pipelines/build/common/kick_off_build.groovy
+++ b/pipelines/build/common/kick_off_build.groovy
@@ -36,7 +36,7 @@ def baseFilePath = (params.CUSTOM_BASEFILE_LOCATION) ?: LOCAL_DEFAULTS_JSON["bas
 
 def userRemoteConfigs = [:]
 def downstreamBuilder = null
-node("built-in || master") {
+node("worker") {
     /*
     Changes dir to Adopt's pipeline repo. Use closures as functions aren't accepted inside node blocks
     */

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -286,7 +286,7 @@ class Build {
                 def jobName = jobParams.TEST_JOB_NAME
                 def JobHelper = context.library(identifier: 'openjdk-jenkins-helper@master').JobHelper
                 if (!JobHelper.jobIsRunnable(jobName as String)) {
-                    context.node('built-in || master') {
+                    context.node('worker') {
                         context.sh('curl -Os https://raw.githubusercontent.com/adoptium/aqa-tests/master/buildenv/jenkins/testJobTemplate')
                         def templatePath = 'testJobTemplate'
                         context.println "Smoke test job doesn't exist, create test job: ${jobName}"
@@ -393,7 +393,7 @@ class Build {
                                     context.build job: "Test_Job_Auto_Gen", propagate: false, parameters: updatedParams
                                 }
                             } else {
-                                context.node('built-in || master') {
+                                context.node('worker') {
                                     context.sh('curl -Os https://raw.githubusercontent.com/adoptium/aqa-tests/master/buildenv/jenkins/testJobTemplate')
                                     def templatePath = 'testJobTemplate'
                                     if (!JobHelper.jobIsRunnable(jobName as String)) {
@@ -424,7 +424,7 @@ class Build {
                                                 context.string(name: 'ACTIVE_NODE_TIMEOUT', value: "${buildConfig.ACTIVE_NODE_TIMEOUT}"),
                                                 context.booleanParam(name: 'DYNAMIC_COMPILE', value: DYNAMIC_COMPILE)],
                                             wait: true
-                            context.node('built-in || master') {
+                            context.node('worker') {
                                 def result = testJob.getResult()
                                 context.echo " ${jobName} result is ${result}"
                                 if (testJob.getResult() == 'SUCCESS' || testJob.getResult() == 'UNSTABLE') {
@@ -513,7 +513,7 @@ class Build {
                     propagate: true,
                     parameters: params
 
-                context.node('built-in || master') {
+                context.node('worker') {
                     //Copy signed artifact back and archive again
                     context.sh "rm workspace/target/* || true"
 
@@ -548,7 +548,7 @@ class Build {
                 propagate: true,
                 parameters: params
 
-            context.node('built-in || master') {
+            context.node('worker') {
                 context.sh "rm -f workspace/target/*.sig"
                 context.copyArtifacts(
                     projectName: "build-scripts/release/sign_temurin_gpg",
@@ -688,7 +688,7 @@ class Build {
             return
         }
 
-        context.node('built-in || master') {
+        context.node('worker') {
             context.stage("installer") {
                 // Ensure master context workspace is clean of any previous archives
                 context.sh "rm -rf workspace/target/* || true"
@@ -720,7 +720,7 @@ class Build {
             return
         }
 
-        context.node('built-in || master') {
+        context.node('worker') {
             context.stage("sign installer") {
                 // Ensure master context workspace is clean of any previous archives
                 context.sh "rm -rf workspace/target/* || true"
@@ -1611,7 +1611,7 @@ class Build {
 
                     // Set Github Commit Status
                     if (env.JOB_NAME.contains("pr-tester")) {
-                        context.node('built-in || master') {
+                        context.node('worker') {
                             updateGithubCommitStatus("PENDING", "Pending")
                         }
                     }

--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -21,7 +21,7 @@ Closure configureBuild = null
 def buildConfigurations = null
 Map<String, ?> DEFAULTS_JSON = null
 
-node ("built-in || master") {
+node ("worker") {
     // Load defaultsJson. These are passed down from the build_pipeline_generator and is a JSON object containing user's default constants.
     if (!params.defaultsJson || defaultsJson == "") {
         throw new Exception("[ERROR] No User Defaults JSON found! Please ensure the defaultsJson parameter is populated and not altered during parameter declaration.")

--- a/pipelines/build/prTester/kick_off_tester.groovy
+++ b/pipelines/build/prTester/kick_off_tester.groovy
@@ -29,7 +29,7 @@ String url = DEFAULTS_JSON['repository']['pipeline_url']
 Closure prTest
 
 // Switch to controller node to load library groovy definitions
-node("built-in || master") {
+node("worker") {
     checkout([
         $class: 'GitSCM',
         branches: [[name: branch]],

--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -78,7 +78,7 @@ class PullRequestTestPipeline implements Serializable {
         Boolean pipelineFailed = false
 
         // Load generation scripts
-        context.node("built-in || master") {
+        context.node("worker") {
             context.println "loading ${context.WORKSPACE}/${DEFAULTS_JSON['scriptDirectories']['regeneration']}"
             Closure regenerationScript = context.load "${context.WORKSPACE}/${DEFAULTS_JSON['scriptDirectories']['regeneration']}"
 
@@ -145,7 +145,7 @@ class PullRequestTestPipeline implements Serializable {
                     }
                 }
             })
-        } // End: node("built-in || master")
+        } // End: node("worker")
 
         context.parallel jobs
 

--- a/pipelines/build/regeneration/build_job_generator.groovy
+++ b/pipelines/build/regeneration/build_job_generator.groovy
@@ -21,7 +21,7 @@ String javaVersion = params.JAVA_VERSION
 String ADOPT_DEFAULTS_FILE_URL = "https://raw.githubusercontent.com/adoptium/ci-jenkins-pipelines/master/pipelines/defaults.json"
 String DEFAULTS_FILE_URL = (params.DEFAULTS_URL) ?: ADOPT_DEFAULTS_FILE_URL
 
-node ("built-in || master") {
+node ("worker") {
   // Retrieve Adopt Defaults
   def getAdopt = new URL(ADOPT_DEFAULTS_FILE_URL).openConnection()
   Map<String, ?> ADOPT_DEFAULTS_JSON = new JsonSlurper().parseText(getAdopt.getInputStream().getText()) as Map

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -2,7 +2,7 @@ import java.nio.file.NoSuchFileException
 import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
 
-node('built-in || master') {
+node('worker') {
   try {
     // Pull in Adopt defaults
     String ADOPT_DEFAULTS_FILE_URL = "https://raw.githubusercontent.com/adoptium/ci-jenkins-pipelines/master/pipelines/defaults.json"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -19,7 +19,7 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 
-node ("built-in || master") {
+node ("worker") {
   def variant = "${params.VARIANT}"
   def jenkinsUrl = "${params.JENKINS_URL}"
   def trssUrl    = "${params.TRSS_URL}"

--- a/tools/stage_time_analysis.groovy
+++ b/tools/stage_time_analysis.groovy
@@ -60,7 +60,7 @@ limitations under the License.
     }
   }
 
-node ("built-in || master") {
+node ("worker") {
   def jenkinsUrl = "${params.JENKINS_URL}"
   def findStage = "${params.STAGE}"
   def periodDays = params.PERIOD_DAYS as Long


### PR DESCRIPTION
Due to the ci-jenkins-pipelines pipeline builds switch back and forth from the "master" node by design, rather than blocking it for the whole job run, the change to use "built-in || master" meant it might switch back to the one not running the job when it started, thus causing unpredictable behaviour.

This PR changes the pipeline code to use the label "worker", which can then be labelled on the appropriate node to use for pipeline job context.

Fixes: https://github.com/adoptium/ci-jenkins-pipelines/issues/345


Signed-off-by: Andrew Leonard <anleonar@redhat.com>