### PR TITLE
Ensure node context workspace is clean prior to gpg signing

### DIFF
--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -147,13 +147,16 @@ class PullRequestTestPipeline implements Serializable {
 
         context.parallel jobs
 
-        // Only clean up the space if the tester passed
-        if (!pipelineFailed) {
-            context.println "[INFO] Cleaning up..."
-            context.cleanWs notFailBuild: true
-        } else {
-            context.println "[ERROR] Pipelines failed. Setting build result to FAILURE..."
-            currentBuild.result = 'FAILURE'
+        // Move to "worker" workspace context to perform clean up...
+        context.node("worker") {
+            // Only clean up the space if the tester passed
+            if (!pipelineFailed) {
+                context.println "[INFO] Cleaning up..."
+                context.cleanWs notFailBuild: true
+            } else {
+                context.println "[ERROR] Pipelines failed. Setting build result to FAILURE..."
+                currentBuild.result = 'FAILURE'
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/adoptium/temurin-build/issues/3029

The problem of the previous build .sig artifact is because the gpgSign() logic in the build job switches to the gpgsign node context, and then copys the new sign_temurin_gpg output but without clearing any of the previous build output from the workspace/target context for the build job, so any previous .sig from the same type of build could be there.

Changed node context to be consistent with the other pipeline stage contexts, and cleared workspace prior to copying the GPG job artifacts.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>