### PR TITLE
fix: wrong property context, should not be in  workflowscript

### DIFF
--- a/pipelines/build/common/weekly_release_pipeline.groovy
+++ b/pipelines/build/common/weekly_release_pipeline.groovy
@@ -49,9 +49,9 @@ stage("Submit Release Pipelines") {
                     // For reproducible builds (releaseType==Release) to have comparison on multiple builds' artifacts.
                     // Copy artifacts from downstream and archive again on weekly-pipeline. For details, see issue: https://github.com/adoptium/ci-jenkins-pipelines/issues/301
                     if ( result.getCurrentResult() == "SUCCESS" ) {
-                        context.copyArtifacts(
+                        copyArtifacts(
                             projectName: result.getProjectName(), // copy-up
-                            selector: context.specific(result.getNumber()),
+                            selector: specific(result.getNumber()),
                             filter: 'workspace/target/*',
                             fingerprintArtifacts: true,
                             target: "workspace/target/",


### PR DESCRIPTION
to fix : https://ci.adoptopenjdk.net/job/build-scripts/job/weekly-openjdk8-pipeline/81/console
`hudson.remoting.ProxyException: groovy.lang.MissingPropertyException: No such property: context for class: WorkflowScript`