### PR TITLE
Correct the excessive failure bias in the Test rating

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -208,6 +208,8 @@ node ("worker") {
         numTestPipelines += 1
         // Pipeline Test % success rating: Failure twice as signficant as a Success, Unstable counts as -1/4
         nightlyTestSuccessRating += (((pipeline.testJobSuccess)-(pipeline.testJobUnstable*0.25)-(pipeline.testJobFailure*2))*100)/(pipeline.testJobNumber)
+        // Pipeline Test % success rating: %(SucceededOrUnstable) - %(FailedTestCases)
+        nightlyTestSuccessRating += ( ((pipeline.testJobNumber-pipeline.testJobFailure)*100/pipeline.testJobNumber) - (pipeline.testCaseFailed*100/(pipeline.testCasePassed+pipeline.testCaseFailed)) )
       }
     }
     // Average test success rating across all pipelines

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -206,8 +206,6 @@ node ("worker") {
       // Did tests run? (build may have failed)
       if (pipeline.testJobNumber > 0) {
         numTestPipelines += 1
-        // Pipeline Test % success rating: Failure twice as signficant as a Success, Unstable counts as -1/4
-        nightlyTestSuccessRating += (((pipeline.testJobSuccess)-(pipeline.testJobUnstable*0.25)-(pipeline.testJobFailure*2))*100)/(pipeline.testJobNumber)
         // Pipeline Test % success rating: %(SucceededOrUnstable) - %(FailedTestCases)
         nightlyTestSuccessRating += ( ((pipeline.testJobNumber-pipeline.testJobFailure)*100/pipeline.testJobNumber) - (pipeline.testCaseFailed*100/(pipeline.testCasePassed+pipeline.testCaseFailed)) )
       }


### PR DESCRIPTION
This PR corrects the overly excessive failure bias in the test rating calculation.
The new algorithm is now based on:
**Pipeline Test % success rating: %(SucceededOrUnstable) - %(FailedTestCases)**