### PR TITLE
Prevent rating division by zero error if test job run but no testcases run

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -203,11 +203,15 @@ node ("worker") {
       totalBuildJobs += pipeline.buildJobNumber
       buildFailures += pipeline.buildJobFailure
       totalTestJobs += pipeline.testJobNumber
-      // Did tests run? (build may have failed)
+      // Did test jobs run? (build may have failed)
       if (pipeline.testJobNumber > 0) {
         numTestPipelines += 1
         // Pipeline Test % success rating: %(SucceededOrUnstable) - %(FailedTestCases)
-        nightlyTestSuccessRating += ( ((pipeline.testJobNumber-pipeline.testJobFailure)*100/pipeline.testJobNumber) - (pipeline.testCaseFailed*100/(pipeline.testCasePassed+pipeline.testCaseFailed)) )
+        nightlyTestSuccessRating += ( ((pipeline.testJobNumber-pipeline.testJobFailure)*100/pipeline.testJobNumber) )
+        // Did test cases run?
+        if ((pipeline.testCasePassed+pipeline.testCaseFailed) > 0) {
+            nightlyTestSuccessRating -= (pipeline.testCaseFailed*100/(pipeline.testCasePassed+pipeline.testCaseFailed))
+        }
       }
     }
     // Average test success rating across all pipelines

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -209,7 +209,7 @@ node ("worker") {
         // Pipeline Test % success rating: %(SucceededOrUnstable) - %(FailedTestCases)
         nightlyTestSuccessRating += ( ((pipeline.testJobNumber-pipeline.testJobFailure)*100/pipeline.testJobNumber) )
         // Did test cases run?
-        if ((pipeline.testCasePassed+pipeline.testCaseFailed) > 0) {
+        if ((pipeline.testCasePassed + pipeline.testCaseFailed) > 0) {
             nightlyTestSuccessRating -= (pipeline.testCaseFailed*100/(pipeline.testCasePassed+pipeline.testCaseFailed))
         }
       }


### PR DESCRIPTION
If test jobs run but some failure causes to testcases to run, then a division by zero occurs calculating the rating!
https://ci.adoptopenjdk.net/view/Tooling/job/nightlyBuildAndTestStats_bisheng/398/

This checks some testcases were run in the rating calc.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>