### PR TITLE
fix: convert buildNumber to string for jenkins copyArtifacts do not accept int

### DIFF
--- a/pipelines/build/common/weekly_release_pipeline.groovy
+++ b/pipelines/build/common/weekly_release_pipeline.groovy
@@ -51,7 +51,7 @@ stage("Submit Release Pipelines") {
                     if ( result.getCurrentResult() == "SUCCESS" ) {
                         copyArtifacts(
                             projectName: result.getProjectName(), // copy-up
-                            selector: specific(result.getNumber()),
+                            selector: specific(result.getNumber().toString()), // buildNumber need to be string not int
                             filter: 'workspace/target/*',
                             fingerprintArtifacts: true,
                             target: "workspace/target/",


### PR DESCRIPTION
To fix: https://ci.adoptopenjdk.net/job/build-scripts/job/weekly-openjdk8-pipeline/82/console

Ref: https://github.com/jenkinsci/workflow-support-plugin/blob/master/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java#L135