### PR TITLE
fix: missing windows msi build for jre

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -569,8 +569,8 @@ class Build {
     Run the Windows installer downstream jobs.
     We run two jobs if we have a JRE (see https://github.com/adoptium/temurin-build/issues/1751).
     */
-    private void buildWindowsInstaller(VersionInfo versionData) {
-        def filter = "**/OpenJDK*jdk_*_windows*.zip"
+    private void buildWindowsInstaller(VersionInfo versionData, String filter, String category) {
+        def nodeFilter = "${buildConfig.TARGET_OS}&&wix"
 
         def buildNumber = versionData.build
 
@@ -600,10 +600,10 @@ class Build {
                         context.string(name: 'PRODUCT_PATCH_VERSION', value: "${patch_version}"),
                         context.string(name: 'PRODUCT_BUILD_NUMBER', value: "${buildNumber}"),
                         context.string(name: 'MSI_PRODUCT_VERSION', value: "${versionData.msi_product_version}"),
-                        context.string(name: 'PRODUCT_CATEGORY', value: "jdk"),
+                        context.string(name: 'PRODUCT_CATEGORY', value: "${category}"),
                         context.string(name: 'JVM', value: "${buildConfig.VARIANT}"),
                         context.string(name: 'ARCH', value: "${INSTALLER_ARCH}"),
-                        ['$class': 'LabelParameterValue', name: 'NODE_LABEL', label: "${buildConfig.TARGET_OS}&&wix"]
+                        ['$class': 'LabelParameterValue', name: 'NODE_LABEL', label: "${nodeFilter}"]
                 ]
         context.copyArtifacts(
                 projectName: "build-scripts/release/create_installer_windows",
@@ -612,42 +612,6 @@ class Build {
                 fingerprintArtifacts: true,
                 target: "workspace/target/",
                 flatten: true)
-
-        // Check if JRE exists, if so, build another installer for it
-        listArchives().each({ file ->
-
-            if (file.contains("-jre")) {
-
-                context.println("We have a JRE. Running another installer for it...")
-                def jreinstallerJob = context.build job: "build-scripts/release/create_installer_windows",
-                        propagate: true,
-                        parameters: [
-                            context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
-                            context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
-                            context.string(name: 'FILTER', value: "**/OpenJDK*jre_*_windows*.zip"),
-                            context.string(name: 'PRODUCT_MAJOR_VERSION', value: "${versionData.major}"),
-                            context.string(name: 'PRODUCT_MINOR_VERSION', value: "${versionData.minor}"),
-                            context.string(name: 'PRODUCT_MAINTENANCE_VERSION', value: "${versionData.security}"),
-                            context.string(name: 'PRODUCT_PATCH_VERSION', value: "${patch_version}"),
-                            context.string(name: 'PRODUCT_BUILD_NUMBER', value: "${buildNumber}"),
-                            context.string(name: 'MSI_PRODUCT_VERSION', value: "${versionData.msi_product_version}"),
-                            context.string(name: 'PRODUCT_CATEGORY', value: "jre"),
-                            context.string(name: 'JVM', value: "${buildConfig.VARIANT}"),
-                            context.string(name: 'ARCH', value: "${INSTALLER_ARCH}"),
-                            ['$class': 'LabelParameterValue', name: 'NODE_LABEL', label: "${buildConfig.TARGET_OS}&&wix"]
-                        ]
-
-                context.copyArtifacts(
-                    projectName: "build-scripts/release/create_installer_windows",
-                    selector: context.specific("${jreinstallerJob.getNumber()}"),
-                    filter: 'wix/ReleaseDir/*',
-                    fingerprintArtifacts: true,
-                    target: "workspace/target/",
-                    flatten: true
-                )
-            }
-
-        })
     }
 
     /*
@@ -665,9 +629,17 @@ class Build {
             context.stage("installer") {
 
                 switch (buildConfig.TARGET_OS) {
-                    case "mac": context.sh 'rm -f workspace/target/*.pkg workspace/target/*.pkg.json workspace/target/*.pkg.sha256.txt'; buildMacInstaller(versionData); break
-                    case "windows": buildWindowsInstaller(versionData); break
-                    default: break
+                    case "mac":
+                        context.sh 'rm -f workspace/target/*.pkg workspace/target/*.pkg.json workspace/target/*.pkg.sha256.txt';
+                        buildMacInstaller(versionData);
+                        break
+                    case "windows":
+                        buildWindowsInstaller(versionData,"**/OpenJDK*jdk_*_windows*.zip", "jdk");
+                        // Check if JRE exists, if so, build another installer for it
+                         if (listArchives().any { it =~ /-jre/} ) {buildWindowsInstaller(versionData,"**/OpenJDK*jre_*_windows*.zip", "jre");} 
+                        break
+                    default:
+                        break
                 }
 
                 // Archive the Mac and Windows pkg/msi

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -636,7 +636,7 @@ class Build {
                     case "windows":
                         context.sh "rm -rf workspace/target/* || true"
                         buildWindowsInstaller(versionData,"**/OpenJDK*jdk_*_windows*.zip", "jdk");
-                        // Check if JRE exists, if so, build another installer for it
+                        // Copy jre artifact from current pipeline job 
                         context.copyArtifacts(
                             projectName: "${env.JOB_NAME}",
                             selector: context.specific("${env.BUILD_NUMBER}"),      
@@ -644,6 +644,7 @@ class Build {
                             fingerprintArtifacts: true,
                             target: "workspace/target/",
                             flatten: true)
+                        // Check if JRE exists, if so, build another installer for it
                         if (listArchives().any { it =~ /-jre/} ) {buildWindowsInstaller(versionData,"**/OpenJDK*jre_*_windows*.zip", "jre");} 
                         break
                     default:

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -630,13 +630,21 @@ class Build {
 
                 switch (buildConfig.TARGET_OS) {
                     case "mac":
-                        context.sh 'rm -f workspace/target/*.pkg workspace/target/*.pkg.json workspace/target/*.pkg.sha256.txt';
+                        context.sh "rm -rf workspace/target/* || true"
                         buildMacInstaller(versionData);
                         break
                     case "windows":
+                        context.sh "rm -rf workspace/target/* || true"
                         buildWindowsInstaller(versionData,"**/OpenJDK*jdk_*_windows*.zip", "jdk");
                         // Check if JRE exists, if so, build another installer for it
-                         if (listArchives().any { it =~ /-jre/} ) {buildWindowsInstaller(versionData,"**/OpenJDK*jre_*_windows*.zip", "jre");} 
+                        context.copyArtifacts(
+                            projectName: context.specific(${env.JOB_NAME}),
+                            selector: context.specific("${env.BUILD_NUMBER}"),      
+                            filter: '**/OpenJDK*jre_*_windows*.zip',
+                            fingerprintArtifacts: true,
+                            target: "workspace/target/",
+                            flatten: true)
+                        if (listArchives().any { it =~ /-jre/} ) {buildWindowsInstaller(versionData,"**/OpenJDK*jre_*_windows*.zip", "jre");} 
                         break
                     default:
                         break

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -673,7 +673,9 @@ class Build {
 
         context.node('worker') {
             context.stage("sign installer") {
-
+                // Ensure master context workspace is clean of any previous archives
+                context.sh "rm -rf workspace/target/* || true"
+                
                 if (buildConfig.TARGET_OS == "mac" || buildConfig.TARGET_OS == "windows") {
                     try {
                         signInstallerJob(versionData);

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -663,11 +663,9 @@ class Build {
 
         context.node('worker') {
             context.stage("installer") {
-                // Ensure master context workspace is clean of any previous archives
-                context.sh "rm -rf workspace/target/* || true"
 
                 switch (buildConfig.TARGET_OS) {
-                    case "mac":     buildMacInstaller(versionData); break
+                    case "mac": context.sh 'rm -f workspace/target/*.pkg workspace/target/*.pkg.json workspace/target/*.pkg.sha256.txt'; buildMacInstaller(versionData); break
                     case "windows": buildWindowsInstaller(versionData); break
                     default: break
                 }
@@ -695,8 +693,6 @@ class Build {
 
         context.node('worker') {
             context.stage("sign installer") {
-                // Ensure master context workspace is clean of any previous archives
-                context.sh "rm -rf workspace/target/* || true"
 
                 if (buildConfig.TARGET_OS == "mac" || buildConfig.TARGET_OS == "windows") {
                     try {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -638,7 +638,7 @@ class Build {
                         buildWindowsInstaller(versionData,"**/OpenJDK*jdk_*_windows*.zip", "jdk");
                         // Check if JRE exists, if so, build another installer for it
                         context.copyArtifacts(
-                            projectName: context.specific("${env.JOB_NAME}"),
+                            projectName: "${env.JOB_NAME}",
                             selector: context.specific("${env.BUILD_NUMBER}"),      
                             filter: '**/OpenJDK*jre_*_windows*.zip',
                             fingerprintArtifacts: true,

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -638,7 +638,7 @@ class Build {
                         buildWindowsInstaller(versionData,"**/OpenJDK*jdk_*_windows*.zip", "jdk");
                         // Check if JRE exists, if so, build another installer for it
                         context.copyArtifacts(
-                            projectName: context.specific(${env.JOB_NAME}),
+                            projectName: context.specific("${env.JOB_NAME}"),
                             selector: context.specific("${env.BUILD_NUMBER}"),      
                             filter: '**/OpenJDK*jre_*_windows*.zip',
                             fingerprintArtifacts: true,


### PR DESCRIPTION
	- we should not have a cleanup workspace before we do listArchives in buildWindowsInstaller this cause the windows installer job dont find a "jre" to match
	- we have moved to use worker node, not master or build-in so the cleanup is not needed as well 

Ref: https://github.com/adoptium/ci-jenkins-pipelines/issues/374