### PR TITLE
Ensure listArchives correctly returns archives on Solaris including the -sbom_

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -788,14 +788,18 @@ class Build {
     Lists and returns any compressed archived or sbom file contents of the top directory of the build node
     */
     List<String> listArchives() {
-        return context.sh(
-                script: '''find workspace/target/ | egrep -e '(.tar.gz|.zip|.msi|.pkg|.deb|.rpm)$' -e '-sbom_' ''',
+        def files = context.sh(
+                script: '''find workspace/target/ | egrep -e '(\\.tar\\.gz|\\.zip|\\.msi|\\.pkg|\\.deb|\\.rpm|-sbom_.*\\.json)$' ''',
                 returnStdout: true,
                 returnStatus: false
         )
                 .trim()
                 .split('\n')
                 .toList()
+
+        context.println "listArchives: ${files}"
+
+        return files
     }
 
     /*


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3061

On Solaris egrep is more limited than other platforms. Re-formed the listArchives() function to do a single -e pattener egrep.
Also corrected previous extension greps that was not matching on the literal ".".
