### PR TITLE
Use Jenkins fileExists and not java File.exists in pipeline script

### DIFF
--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -66,8 +66,8 @@ node ("worker") {
     def buildConfigFilePath = (params.buildConfigFilePath) ?: "${DEFAULTS_JSON['configDirectories']['build']}/${javaToBuild}_pipeline_config.groovy"
 
     // Check if pipeline is jdk11 or jdk11u
-    def configPath =  new File("${WORKSPACE}/${buildConfigFilePath}")
-    if (configPath.exists()) {
+    def configPath =  "${WORKSPACE}/${buildConfigFilePath}"
+    if (fileExists(configPath)) {
         println "Found ${buildConfigFilePath}"
     } else {
         javaToBuild = "${javaToBuild}u"
@@ -85,8 +85,8 @@ node ("worker") {
         javaToBuild = javaToBuild.replaceAll("u", "")
 
         // Check if pipeline is jdk11 or jdk11u
-        configPath =  new File("${WORKSPACE}/${ADOPT_DEFAULTS_JSON['configDirectories']['build']}/${javaToBuild}_pipeline_config.groovy")
-        if (configPath.exists()) {
+        configPath =  "${WORKSPACE}/${ADOPT_DEFAULTS_JSON['configDirectories']['build']}/${javaToBuild}_pipeline_config.groovy"
+        if (fileExists(configPath)) {
             buildConfigurations = load "${WORKSPACE}/${ADOPT_DEFAULTS_JSON['configDirectories']['build']}/${javaToBuild}_pipeline_config.groovy"
         } else {
             javaToBuild = "${javaToBuild}u"


### PR DESCRIPTION
Within Jenkins pipeline groovy scripts using java File.exists(path) will search the "built-in|master" node context for the file
and not the current node context. The Jenkins fileExists() script function should be used instead.

jdk19 and jdk20 pipelines were failing because the config did not exist in the cached workspace on the built-in node, and the job was running on C3jenkins.

Fixes: https://github.com/adoptium/ci-jenkins-pipelines/issues/379

Signed-off-by: Andrew Leonard <anleonar@redhat.com>