### PR TITLE
re-enable windows aarch64 pipelines

### DIFF
--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -3,6 +3,7 @@ targetConfigurations = [
         "x64Linux"      : [    "temurin",    "openj9",    "dragonwell",    "corretto",    "bisheng",    "fast_startup"],
         "x64AlpineLinux": [    "temurin"                            ],
         "x64Windows"    : [    "temurin",    "openj9",    "dragonwell"            ],
+        "aarch64Windows": [    "temurin"                            ],   
         "x32Windows"    : [    "temurin"                            ],
         "ppc64Aix"      : [    "temurin",    "openj9"                    ],
         "ppc64leLinux"  : [    "temurin",    "openj9"                    ],

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -75,6 +75,17 @@ class Config11 {
                 test                : 'default'
         ],
 
+        aarch64Windows: [
+                os                  : 'windows',
+                arch                : 'aarch64',
+                crossCompile        : 'x64',
+                additionalNodeLabels: 'win2016&&vs2019',
+                test                : 'default',
+                buildArgs       : [
+                        "temurin"   : '--jvm-variant client,server --create-sbom --cross-compile'
+                ]
+        ],
+
         x32Windows: [
                 os                  : 'windows',
                 arch                : 'x86-32',

--- a/pipelines/jobs/configurations/jdk17u.groovy
+++ b/pipelines/jobs/configurations/jdk17u.groovy
@@ -15,6 +15,9 @@ targetConfigurations = [
                 "temurin",
                 "openj9"
         ],
+        "aarch64Windows" : [
+                "temurin"
+        ],
         "x32Windows"  : [
                 "temurin"
         ],

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -69,21 +69,16 @@ class Config17 {
                 ]
         ],
 
-        // TODO: Enable testing (https://github.com/adoptium/ci-jenkins-pipelines/issues/77)
         aarch64Windows: [
                 os                  : 'windows',
                 arch                : 'aarch64',
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2016&&vs2019',
-                test                : [
-                        nightly: [],
-                        weekly : []
-                ],
+                test                : 'default',
                 buildArgs       : [
                         "temurin"   : '--create-jre-image --create-sbom --cross-compile'
                 ]
         ],
-
 
         x32Windows: [
                 os                  : 'windows',

--- a/pipelines/jobs/configurations/jdk18u.groovy
+++ b/pipelines/jobs/configurations/jdk18u.groovy
@@ -11,6 +11,9 @@ targetConfigurations = [
         "x64Windows"  : [
                 "temurin"
         ],
+        "aarch64Windows" : [
+                "temurin"
+        ],
         "x32Windows"  : [
                 "temurin"
         ],

--- a/pipelines/jobs/configurations/jdk18u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk18u_pipeline_config.groovy
@@ -69,16 +69,12 @@ class Config18 {
                 ]
         ],
 
-        // TODO: Enable testing (https://github.com/adoptium/ci-jenkins-pipelines/issues/77)
         aarch64Windows: [
                 os                  : 'windows',
                 arch                : 'aarch64',
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2016&&vs2019',
-                test                : [
-                        nightly: [],
-                        weekly : []
-                ],
+                test                : 'default',
                 buildArgs       : [
                         "temurin"   : '--create-jre-image --create-sbom --cross-compile'
                 ]

--- a/pipelines/jobs/configurations/jdk19.groovy
+++ b/pipelines/jobs/configurations/jdk19.groovy
@@ -11,6 +11,9 @@ targetConfigurations = [
         "x64Windows"  : [
                 "temurin"
         ],
+        "aarch64Windows" : [
+                "temurin"
+        ],
         "x32Windows"  : [
                 "temurin"
         ],

--- a/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
@@ -69,22 +69,17 @@ class Config19 {
                 ]
         ],
 
-        // TODO: Enable testing (https://github.com/adoptium/ci-jenkins-pipelines/issues/77)
         aarch64Windows: [
                 os                  : 'windows',
                 arch                : 'aarch64',
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2016&&vs2019',
-                test                : [
-                        nightly: [],
-                        weekly : []
-                ],
+                test                : 'default',
                 buildArgs       : [
                         "temurin"   : '--create-jre-image --create-sbom --cross-compile'
                 ]
 
         ],
-
 
         x32Windows: [
                 os                  : 'windows',

--- a/pipelines/jobs/configurations/jdk20.groovy
+++ b/pipelines/jobs/configurations/jdk20.groovy
@@ -11,6 +11,9 @@ targetConfigurations = [
         "x64Windows"  : [
                 "temurin"
         ],
+        "aarch64Windows" : [
+                "temurin"
+        ],
         "x32Windows"  : [
                 "temurin"
         ],

--- a/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
@@ -69,22 +69,17 @@ class Config20 {
                 ]
         ],
 
-        // TODO: Enable testing (https://github.com/adoptium/ci-jenkins-pipelines/issues/77)
         aarch64Windows: [
                 os                  : 'windows',
                 arch                : 'aarch64',
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2016&&vs2019',
-                test                : [
-                        nightly: [],
-                        weekly : []
-                ],
+                test                : 'default',
                 buildArgs       : [
                         "temurin"   : '--create-jre-image --create-sbom --cross-compile'
                 ]
 
         ],
-
 
         x32Windows: [
                 os                  : 'windows',


### PR DESCRIPTION
A stable Azure machine has been added for testing now so this should be good to re-enable (https://github.com/adoptium/infrastructure/issues/2708)

Once I've confirmed that everything is working well I'll provision a second machine for redundancy