### PR TITLE
improve: move "node" block to only on the copyartifacts step to reduce resource lock by long running job

### DIFF
--- a/pipelines/build/common/weekly_release_pipeline.groovy
+++ b/pipelines/build/common/weekly_release_pipeline.groovy
@@ -13,42 +13,42 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-node("worker") {
-    stage("Submit Release Pipelines") {
-        // Map of <variant> : <scmRef>
-        def Map<String, String> scmRefs = new JsonSlurper().parseText("${params.scmReferences}") as Map
+stage("Submit Release Pipelines") {
+    // Map of <variant> : <scmRef>
+    def Map<String, String> scmRefs = new JsonSlurper().parseText("${params.scmReferences}") as Map
 
-        // Map of <platform> : [<variant>,<variant>,..]
-        def Map<String, List<String>> targetConfigurations = new JsonSlurper().parseText("${params.targetConfigurations}") as Map
+    // Map of <platform> : [<variant>,<variant>,..]
+    def Map<String, List<String>> targetConfigurations = new JsonSlurper().parseText("${params.targetConfigurations}") as Map
 
-        def Map<String, String> jobs = [:]
+    def Map<String, String> jobs = [:]
 
-        // For each variant create a release pipeline job
-        scmRefs.each{ variant ->
-            def variantName = variant.key
-            def scmRef = variant.value
-            def Map<String, List<String>> targetConfig = [:]
+    // For each variant create a release pipeline job
+    scmRefs.each{ variant ->
+        def variantName = variant.key
+        def scmRef = variant.value
+        def Map<String, List<String>> targetConfig = [:]
 
-            targetConfigurations.each{ target ->
-                if (target.value.contains(variantName)) {
-                    targetConfig.put(target.key,[variantName])
-                }
+        targetConfigurations.each{ target ->
+            if (target.value.contains(variantName)) {
+                targetConfig.put(target.key,[variantName])
             }
+        }
 
-            if (!targetConfig.isEmpty()) {
-                echo("Creating ${params.buildPipeline} - ${variantName}")
-                jobs[variantName] = {
-                    stage("Build - ${params.buildPipeline} - ${variantName}") {
-                        result = build job: "${params.buildPipeline}",
-                                parameters: [
-                                    string(name: 'releaseType',        value: 'Release'),
-                                    string(name: 'scmReference',       value: scmRef),
-                                    text(name: 'targetConfigurations', value: JsonOutput.prettyPrint(JsonOutput.toJson(targetConfig))),
-                                    ['$class': 'BooleanParameterValue', name: 'keepReleaseLogs', value: false]
-                                ]
-                        // For reproducible builds (releaseType==Release) to have comparison on multiple builds' artifacts.
-                        // Copy artifacts from downstream and archive again on weekly-pipeline. For details, see issue: https://github.com/adoptium/ci-jenkins-pipelines/issues/301
-                        if ( result.getCurrentResult() == "SUCCESS" ) {
+        if (!targetConfig.isEmpty()) {
+            echo("Creating ${params.buildPipeline} - ${variantName}")
+            jobs[variantName] = {
+                stage("Build - ${params.buildPipeline} - ${variantName}") {
+                    result = build job: "${params.buildPipeline}",
+                            parameters: [
+                                string(name: 'releaseType',        value: 'Release'),
+                                string(name: 'scmReference',       value: scmRef),
+                                text(name: 'targetConfigurations', value: JsonOutput.prettyPrint(JsonOutput.toJson(targetConfig))),
+                                ['$class': 'BooleanParameterValue', name: 'keepReleaseLogs', value: false]
+                            ]
+                    // For reproducible builds (releaseType==Release) to have comparison on multiple builds' artifacts.
+                    // Copy artifacts from downstream and archive again on weekly-pipeline. For details, see issue: https://github.com/adoptium/ci-jenkins-pipelines/issues/301
+                    if ( result.getCurrentResult() == "SUCCESS" ) {
+                        node("worker") {
                             copyArtifacts(
                                 projectName: result.getProjectName(), // copy-up
                                 selector: specific(result.getNumber().toString()), // buildNumber need to be string not int
@@ -62,9 +62,9 @@ node("worker") {
                 }
             }
         }
-        // Run downstream jobs in parallel
-        parallel jobs
-
-        archiveArtifacts artifacts: "workspace/target/"
     }
+    // Run downstream jobs in parallel
+    parallel jobs
+
+    archiveArtifacts artifacts: "workspace/target/"
 }


### PR DESCRIPTION
From comments: https://github.com/adoptium/ci-jenkins-pipelines/pull/390#issuecomment-1234599140
this change can reduce resource/"worker" node be locked with executor's number during a long weekly pipeline run.

(use Hide Whitespace for better review experience)

Also fix wrong filter
from openjdkXX pipeline copy up to weekly job, does not have workspace/target (this is for downstream build job)

Fix: https://github.com/adoptium/ci-jenkins-pipelines/issues/389