### PR TITLE
feat: add default timeout to 1hr for smoketest

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -158,6 +158,7 @@ class Build {
         jobParams.put("VENDOR_TEST_REPOS", vendorTestRepos)
         jobParams.put("VENDOR_TEST_BRANCHES", vendorTestBranches)
         jobParams.put("VENDOR_TEST_DIRS", vendorTestDirs)
+        jobParams.put("TIME_LIMIT", 1) // default smoketest to timeout after 1hr
         return jobParams
     }
 


### PR DESCRIPTION
Fix: https://github.com/adoptium/ci-jenkins-pipelines/issues/383 

To have this solution need to have changes in aqa-tests as well
