### PR TITLE
fix: only copy up tar.gz and zip file as needed for comparison

### DIFF
--- a/pipelines/build/common/weekly_release_pipeline.groovy
+++ b/pipelines/build/common/weekly_release_pipeline.groovy
@@ -54,6 +54,7 @@ stage("Submit Release Pipelines") {
                                 selector: specific(result.getNumber().toString()), // buildNumber need to be string not int
                                 filter: '**/*.tar.gz, **/*.zip',
                                 fingerprintArtifacts: true,
+                                target: "workspace",
                                 flatten: true
                             )
                         }
@@ -64,6 +65,7 @@ stage("Submit Release Pipelines") {
     }
     // Run downstream jobs in parallel
     parallel jobs
-
-    archiveArtifacts artifacts: "workspace/target/"
+    node("worker") {
+        archiveArtifacts artifacts: "workspace"
+    }
 }

--- a/pipelines/build/common/weekly_release_pipeline.groovy
+++ b/pipelines/build/common/weekly_release_pipeline.groovy
@@ -52,9 +52,8 @@ stage("Submit Release Pipelines") {
                             copyArtifacts(
                                 projectName: result.getProjectName(), // copy-up
                                 selector: specific(result.getNumber().toString()), // buildNumber need to be string not int
-                                filter: 'target/**',
+                                filter: '**/target/**/temurin/*.tar.gz, **/target/**/temurin/*.zip',
                                 fingerprintArtifacts: true,
-                                target: "workspace/target/",
                                 flatten: true
                             )
                         }

--- a/pipelines/build/common/weekly_release_pipeline.groovy
+++ b/pipelines/build/common/weekly_release_pipeline.groovy
@@ -52,7 +52,7 @@ stage("Submit Release Pipelines") {
                             copyArtifacts(
                                 projectName: result.getProjectName(), // copy-up
                                 selector: specific(result.getNumber().toString()), // buildNumber need to be string not int
-                                filter: '**/target/**/temurin/*.tar.gz, **/target/**/temurin/*.zip',
+                                filter: '**/*.tar.gz, **/*.zip',
                                 fingerprintArtifacts: true,
                                 flatten: true
                             )


### PR DESCRIPTION
	 - to only copy tar.gz and zip file, to exclude others msi pkg json etc
	 - have jdk jre testimage static all copied up
	 - flat target to put everything in the same folder since each name is unique 

This one will be test out first in weekly openjdk19/20 to see if it does work
waiting https://ci.adoptopenjdk.net/job/build-scripts/job/weekly-openjdk20-pipeline/ to be run on 11th morning