### PR TITLE
fix: pass down jobParams for timeout on any existing smoke_test jobs

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -310,7 +310,10 @@ class Build {
                                     context.string(name: 'LABEL_ADDITION', value: additionalTestLabel),
                                     context.booleanParam(name: 'KEEP_REPORTDIR', value: buildConfig.KEEP_TEST_REPORTDIR),
                                     context.string(name: 'ACTIVE_NODE_TIMEOUT', value: "${buildConfig.ACTIVE_NODE_TIMEOUT}"),
-                                    context.booleanParam(name: 'DYNAMIC_COMPILE', value: true)]
+                                    context.booleanParam(name: 'DYNAMIC_COMPILE', value: true),
+                                    context.string(name: 'TIME_LIMIT', value: "${jobParams.TIME_LIMIT}")
+                            ]
+
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
Fix: #383 

After [change](https://github.com/adoptium/ci-jenkins-pipelines/pull/394) merged into master, smoke test https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk/job/jdk-alpine-linux-x64-temurin_SmokeTests/59/console still seen value set to 10 for TIME_LIMIT

the reason is, the existing jobs we called are from block https://github.com/adoptium/ci-jenkins-pipelines/blob/master/pipelines/build/common/openjdk_build_pipeline.groovy#L303 not https://github.com/adoptium/ci-jenkins-pipelines/blob/master/pipelines/build/common/openjdk_build_pipeline.groovy#L299
so we need explicit add it here to overwrite the 10 which has been set when the jobs were created.

for any new smoke test (e.g jdk21 and so on) it should use 1 to create job this is after [change](https://github.com/adoptium/ci-jenkins-pipelines/pull/394) but for any job already exists it wont be re-created to correct 10 to 1 from https://github.com/adoptium/ci-jenkins-pipelines/blob/master/pipelines/build/common/openjdk_build_pipeline.groovy#L294