### PR TITLE
Hardcode 1hr for TIME_LIMIT for smoketest

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -158,7 +158,6 @@ class Build {
         jobParams.put("VENDOR_TEST_REPOS", vendorTestRepos)
         jobParams.put("VENDOR_TEST_BRANCHES", vendorTestBranches)
         jobParams.put("VENDOR_TEST_DIRS", vendorTestDirs)
-        jobParams.put("TIME_LIMIT", 1) // default smoketest to timeout after 1hr
         return jobParams
     }
 
@@ -311,7 +310,7 @@ class Build {
                                     context.booleanParam(name: 'KEEP_REPORTDIR', value: buildConfig.KEEP_TEST_REPORTDIR),
                                     context.string(name: 'ACTIVE_NODE_TIMEOUT', value: "${buildConfig.ACTIVE_NODE_TIMEOUT}"),
                                     context.booleanParam(name: 'DYNAMIC_COMPILE', value: true),
-                                    context.string(name: 'TIME_LIMIT', value: "${jobParams.TIME_LIMIT}")
+                                    context.string(name: 'TIME_LIMIT', value: "1")
                             ]
 
                 }


### PR DESCRIPTION
See detail : https://github.com/adoptium/ci-jenkins-pipelines/issues/383#issuecomment-1245393408
This reverts commit 4daae0cfefb508810912f91e6de03c8b4afe9e7b.
This is to cleanup the code
also set value directly

Fix https://github.com/adoptium/ci-jenkins-pipelines/issues/383

