### PR TITLE
feat: enable sanity.external test for jdk8/17/19/head on x64linux

### DIFF
--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -24,7 +24,10 @@ class Config17 {
                 dockerFile: [
                         openj9      : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
-                test                : 'default',
+                test                : [
+                        nightly: ["sanity.openjdk", "sanity.system", "extended.system", "sanity.perf", "sanity.functional", "extended.functional"],
+                        weekly : ["extended.openjdk", "extended.perf", "special.functional", "sanity.external"]
+                ],
                 additionalTestLabels: [
                         openj9      : '!(centos6||rhel6)'
                 ],

--- a/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
@@ -24,7 +24,10 @@ class Config19 {
                 dockerFile: [
                         openj9      : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
-                test                : 'default',
+                test                : [
+                        nightly: ["sanity.openjdk", "sanity.system", "extended.system", "sanity.perf", "sanity.functional", "extended.functional"],
+                        weekly : ["extended.openjdk", "extended.perf", "special.functional", "sanity.external"]
+                ],
                 additionalTestLabels: [
                         openj9      : '!(centos6||rhel6)'
                 ],

--- a/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
@@ -24,7 +24,10 @@ class Config20 {
                 dockerFile: [
                         openj9      : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
-                test                : 'default',
+                test                : [
+                        nightly: ["sanity.openjdk", "sanity.system", "extended.system", "sanity.perf", "sanity.functional", "extended.functional"],
+                        weekly : ["extended.openjdk", "extended.perf", "special.functional", "sanity.external"]
+                ],
                 additionalTestLabels: [
                         openj9      : '!(centos6||rhel6)'
                 ],

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -22,7 +22,10 @@ class Config8 {
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile',
                         dragonwell: 'pipelines/build/dockerFiles/dragonwell.dockerfile'
                 ],
-                test                 : 'default',
+                test                : [
+                        nightly: ["sanity.openjdk", "sanity.system", "extended.system", "sanity.perf", "sanity.functional", "extended.functional"],
+                        weekly : ["extended.openjdk", "extended.perf", "special.functional", "sanity.external"]
+                ],
                 configureArgs       : [
                         "openj9"      : '--enable-jitserver',
                         "dragonwell"  : '--enable-unlimited-crypto --with-jvm-variants=server  --with-zlib=system',


### PR DESCRIPTION
	- jdk11 has been enabled already
	- set full tests to overwrite "default"
	- skip 18 since we wont have more release on it

Fix: https://github.com/adoptium/ci-jenkins-pipelines/issues/273