### PR TITLE
Pull riscv64 sources from default repository

### DIFF
--- a/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
@@ -171,7 +171,9 @@ class Config19 {
                 os                   : 'linux',
                 arch                 : 'riscv64',
                 configureArgs        : '--enable-dtrace --with-native-debug-symbols=none',
-                buildArgs            : '-r https://github.com/openjdk/riscv-port -b riscv-port --custom-cacerts false --disable-adopt-branch-safety --create-sbom',
+                buildArgs           : [
+                        "temurin"   : '--create-jre-image --create-sbom'
+                ],
                 test                : [
                         nightly: ['sanity.openjdk'],
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']

--- a/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
@@ -170,7 +170,7 @@ class Config19 {
         riscv64Linux      :  [
                 os                   : 'linux',
                 arch                 : 'riscv64',
-                configureArgs        : '--enable-dtrace --with-native-debug-symbols=none',
+                configureArgs        : '--enable-dtrace',
                 buildArgs           : [
                         "temurin"   : '--create-jre-image --create-sbom'
                 ],

--- a/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
@@ -172,7 +172,9 @@ class Config20 {
                 os                   : 'linux',
                 arch                 : 'riscv64',
                 configureArgs        : '--enable-dtrace --with-native-debug-symbols=none',
-                buildArgs            : '-r https://github.com/openjdk/riscv-port -b riscv-port --custom-cacerts false --disable-adopt-branch-safety --create-sbom',
+                buildArgs           : [
+                        "temurin"   : '--create-jre-image --create-sbom'
+                ],
                 test                : [
                         nightly: ['sanity.openjdk'],
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']

--- a/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
@@ -171,7 +171,7 @@ class Config20 {
         riscv64Linux      :  [
                 os                   : 'linux',
                 arch                 : 'riscv64',
-                configureArgs        : '--enable-dtrace --with-native-debug-symbols=none',
+                configureArgs        : '--enable-dtrace',
                 buildArgs           : [
                         "temurin"   : '--create-jre-image --create-sbom'
                 ],


### PR DESCRIPTION
Since https://openjdk.org/jeps/422 has been merged in JDK 19, we don't need to pull from the riscv-port repo anymore and we can pull from the default repo instead.