### PR TITLE
fix: do not fail job if not matching file and correct archive path

### DIFF
--- a/pipelines/build/common/weekly_release_pipeline.groovy
+++ b/pipelines/build/common/weekly_release_pipeline.groovy
@@ -55,7 +55,8 @@ stage("Submit Release Pipelines") {
                                 filter: '**/*.tar.gz, **/*.zip',
                                 fingerprintArtifacts: true,
                                 target: "workspace",
-                                flatten: true
+                                flatten: true,
+                                optional: true  // do not fail pipeline if not find matching filter
                             )
                         }
                     }
@@ -66,6 +67,6 @@ stage("Submit Release Pipelines") {
     // Run downstream jobs in parallel
     parallel jobs
     node("worker") {
-        archiveArtifacts artifacts: "workspace"
+        archiveArtifacts artifacts: "workspace/*"
     }
 }


### PR DESCRIPTION
PR for two parts:
in https://ci.adoptopenjdk.net/job/build-scripts/job/weekly-openjdk8-pipeline/89/console with error `ERROR: Failed to copy artifacts from openjdk8-pipeline with filter: **/*.tar.gz, **/*.zip` because corretto failed https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk8u/job/jdk8u-linux-x64-corretto/726/ so it does not generate artifacts. pipeline should fail in this case, but should not fail if something wrong when copy up artifact

in https://ci.adoptopenjdk.net/job/build-scripts/job/weekly-openjdk18-pipeline/64/console with error `RROR: No artifacts found that match the file pattern "workspace". Configuration error?` because archiveArtifacts require files pattern not only dir.

Ref: https://github.com/adoptium/ci-jenkins-pipelines/issues/397 

