### PR TITLE
feat: remove jdk18 from pr-Test and retire jdk18

### DIFF
--- a/.github/workflows/comment-bot.yml
+++ b/.github/workflows/comment-bot.yml
@@ -26,4 +26,4 @@ jobs:
 
             In order to run the advanced [pipeline tests](https://github.com/adoptium/ci-jenkins-pipelines/tree/master/pipelines/build/prTester#openjdk-build-pr-tester) (executing a set of mock pipelines), it requires an admin to post `run tests` on this PR.
             If you are not an admin, please ask for one's attention in [#infrastructure on Slack](https://adoptium.slack.com/archives/C53GHCXL4) or ping one here.
-            To run full set of tests, use "run tests"; a subset of tests on specific jdk version, use "run tests quick 11,18" 
+            To run full set of tests, use "run tests"; a subset of tests on specific jdk version, use "run tests quick 11,19" 

--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -199,7 +199,7 @@ Map<String, ?> defaultTestConfigurations = [
     ]
 ]
 
-List<Integer> defaultJavaVersions = [8, 11, 17, 18, 19]
+List<Integer> defaultJavaVersions = [8, 11, 17, 19]
 
 return {
     String branch,

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -44,7 +44,7 @@ node('worker') {
     }
 
     timestamps {
-      def retiredVersions = [9, 10, 12, 13, 14, 15, 16]
+      def retiredVersions = [9, 10, 12, 13, 14, 15, 16, 18]
       def generatedPipelines = []
 
       // Load git url and branch and gitBranch. These determine where we will be pulling user configs from.


### PR DESCRIPTION
release jdk19 , no need jdk18 in pr-test job and should set to retired