### PR TITLE
feat: add support for jenkins-helper git ref when build pipeline

### DIFF
--- a/docs/UsingOurScripts.md
+++ b/docs/UsingOurScripts.md
@@ -19,7 +19,9 @@ This file contains the default constants and paths used in the build scripts for
         // Git Url of the current repository.
         "pipeline_url"       : "https://github.com/adoptium/ci-jenkins-pipelines.git",
         // Git branch you wish to use when running the groovy scripts inside the pipeline_url
-        "pipeline_branch"    : "master"
+        "pipeline_branch"    : "master",
+        // Git branch of which checkout from https://github.com/adoptium/jenkins-helper.git repo. This can only be as branch or tag, not SHA1
+        "helper_ref"      : "master"
     },
     // Jenkins server details
     "jenkinsDetails"         : {

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -86,7 +86,8 @@ class Builder implements Serializable {
     IndividualBuildConfig buildConfiguration(Map<String, ?> platformConfig, String variant) {
 
         // Query the Adopt api to get the "tip_version"
-        def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}").JobHelper
+        String helperRef = DEFAULTS_JSON['repository']['helper_ref']
+        def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${helperRef}").JobHelper
         context.println "Querying Adopt Api for the JDK-Head number (tip_version)..."
         def response = JobHelper.getAvailableReleases(context)
         int headVersion = (int) response.getAt("tip_version")
@@ -632,7 +633,8 @@ class Builder implements Serializable {
         try {
             context.timeout(time: pipelineTimeouts.API_REQUEST_TIMEOUT, unit: "HOURS") {
                 // Query the Adopt api to get the "tip_version"
-                def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}").JobHelper
+                String helperRef = DEFAULTS_JSON['repository']['helper_ref']
+                def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${helperRef}").JobHelper
                 context.println "Querying Adopt Api for the JDK-Head number (tip_version)..."
                 def response = JobHelper.getAvailableReleases(context)
                 return (int) response.getAt("tip_version")

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -86,7 +86,7 @@ class Builder implements Serializable {
     IndividualBuildConfig buildConfiguration(Map<String, ?> platformConfig, String variant) {
 
         // Query the Adopt api to get the "tip_version"
-        def JobHelper = context.library(identifier: 'openjdk-jenkins-helper@master').JobHelper
+        def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}").JobHelper
         context.println "Querying Adopt Api for the JDK-Head number (tip_version)..."
         def response = JobHelper.getAvailableReleases(context)
         int headVersion = (int) response.getAt("tip_version")
@@ -632,7 +632,7 @@ class Builder implements Serializable {
         try {
             context.timeout(time: pipelineTimeouts.API_REQUEST_TIMEOUT, unit: "HOURS") {
                 // Query the Adopt api to get the "tip_version"
-                def JobHelper = context.library(identifier: 'openjdk-jenkins-helper@master').JobHelper
+                def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}").JobHelper
                 context.println "Querying Adopt Api for the JDK-Head number (tip_version)..."
                 def response = JobHelper.getAvailableReleases(context)
                 return (int) response.getAt("tip_version")

--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -661,7 +661,9 @@ class Regeneration implements Serializable {
                 // If we're building jdk head, update the javaToBuild
                 context.println "[INFO] Querying Adoptium api to get the JDK-Head number"
 
-                def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}").JobHelper
+                String helperRef = DEFAULTS_JSON['repository']['helper_ref']
+                def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${helperRef}").JobHelper
+
                 Integer jdkHeadNum = Integer.valueOf(JobHelper.getAvailableReleases(context).tip_version)
 
                 if (Integer.valueOf(versionNumbers[0]) == jdkHeadNum) {

--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -661,7 +661,7 @@ class Regeneration implements Serializable {
                 // If we're building jdk head, update the javaToBuild
                 context.println "[INFO] Querying Adoptium api to get the JDK-Head number"
 
-                def JobHelper = context.library(identifier: 'openjdk-jenkins-helper@master').JobHelper
+                def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}").JobHelper
                 Integer jdkHeadNum = Integer.valueOf(JobHelper.getAvailableReleases(context).tip_version)
 
                 if (Integer.valueOf(versionNumbers[0]) == jdkHeadNum) {

--- a/pipelines/build/common/kick_off_build.groovy
+++ b/pipelines/build/common/kick_off_build.groovy
@@ -52,7 +52,7 @@ node("worker") {
         userRemoteConfigs = new JsonSlurper().parseText(USER_REMOTE_CONFIGS) as Map
     }
 
-    String helperRef = DEFAULTS_JSON['repository']['helper_ref']
+    String helperRef = LOCAL_DEFAULTS_JSON['repository']['helper_ref']
     library(identifier: "openjdk-jenkins-helper@${helperRef}")
 
     try {

--- a/pipelines/build/common/kick_off_build.groovy
+++ b/pipelines/build/common/kick_off_build.groovy
@@ -52,7 +52,7 @@ node("worker") {
         userRemoteConfigs = new JsonSlurper().parseText(USER_REMOTE_CONFIGS) as Map
     }
 
-    library(identifier: 'openjdk-jenkins-helper@master')
+    library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}")
 
     try {
         downstreamBuilder = load "${WORKSPACE}/${baseFilePath}"

--- a/pipelines/build/common/kick_off_build.groovy
+++ b/pipelines/build/common/kick_off_build.groovy
@@ -52,7 +52,8 @@ node("worker") {
         userRemoteConfigs = new JsonSlurper().parseText(USER_REMOTE_CONFIGS) as Map
     }
 
-    library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}")
+    String helperRef = DEFAULTS_JSON['repository']['helper_ref']
+    library(identifier: "openjdk-jenkins-helper@${helperRef}")
 
     try {
         downstreamBuilder = load "${WORKSPACE}/${baseFilePath}"

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -119,7 +119,7 @@ class Build {
             try {
                 context.timeout(time: buildTimeouts.API_REQUEST_TIMEOUT, unit: "HOURS") {
                     // Query the Adopt api to get the "tip_version"
-                    def JobHelper = context.library(identifier: 'openjdk-jenkins-helper@master').JobHelper
+                    def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}").JobHelper
                     context.println "Querying Adopt Api for the JDK-Head number (tip_version)..."
 
                     def response = JobHelper.getAvailableReleases(context)
@@ -289,7 +289,7 @@ class Build {
             context.stage("smoke test") {
                 def jobParams = getSmokeTestJobParams()
                 def jobName = jobParams.TEST_JOB_NAME
-                def JobHelper = context.library(identifier: 'openjdk-jenkins-helper@master').JobHelper
+                def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}").JobHelper
                 if (!JobHelper.jobIsRunnable(jobName as String)) {
                     context.node('worker') {
                         context.sh('curl -Os https://raw.githubusercontent.com/adoptium/aqa-tests/master/buildenv/jenkins/testJobTemplate')
@@ -380,7 +380,7 @@ class Build {
                         }
 
                         def jobName = jobParams.TEST_JOB_NAME
-                        def JobHelper = context.library(identifier: 'openjdk-jenkins-helper@master').JobHelper
+                        def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}").JobHelper
 
                         // Create test job if AQA_AUTO_GEN is set to true, the job doesn't exist or is not runnable
                         if (aqaAutoGen || !JobHelper.jobIsRunnable(jobName as String)) {
@@ -1484,7 +1484,7 @@ class Build {
     If it doesn't find one or the timeout is set to 0 (default), it'll crash out. Otherwise, it'll return and jump onto the node.
     */
     def waitForANodeToBecomeActive(def label) {
-        def NodeHelper = context.library(identifier: 'openjdk-jenkins-helper@master').NodeHelper
+        def NodeHelper = context.library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}").NodeHelper
 
         // A node with the requested label is ready to go
         if (NodeHelper.nodeIsOnline(label)) {
@@ -1574,7 +1574,7 @@ class Build {
                 context.stage("queue") {
                     /* This loads the library containing two Helper classes, and causes them to be
                     imported/updated from their repo. Without the library being imported here, runTests method will fail to execute the post-build test jobs for reasons unknown.*/
-                    context.library(identifier: 'openjdk-jenkins-helper@master')
+                    context.library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}")
 
                     // Set Github Commit Status
                     if (env.JOB_NAME.contains("pr-tester")) {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -119,7 +119,8 @@ class Build {
             try {
                 context.timeout(time: buildTimeouts.API_REQUEST_TIMEOUT, unit: "HOURS") {
                     // Query the Adopt api to get the "tip_version"
-                    def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}").JobHelper
+                    String helperRef = DEFAULTS_JSON['repository']['helper_ref']
+                    def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${helperRef}").JobHelper
                     context.println "Querying Adopt Api for the JDK-Head number (tip_version)..."
 
                     def response = JobHelper.getAvailableReleases(context)
@@ -289,7 +290,8 @@ class Build {
             context.stage("smoke test") {
                 def jobParams = getSmokeTestJobParams()
                 def jobName = jobParams.TEST_JOB_NAME
-                def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}").JobHelper
+                String helperRef = DEFAULTS_JSON['repository']['helper_ref']
+                def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${helperRef}").JobHelper
                 if (!JobHelper.jobIsRunnable(jobName as String)) {
                     context.node('worker') {
                         context.sh('curl -Os https://raw.githubusercontent.com/adoptium/aqa-tests/master/buildenv/jenkins/testJobTemplate')
@@ -380,7 +382,8 @@ class Build {
                         }
 
                         def jobName = jobParams.TEST_JOB_NAME
-                        def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}").JobHelper
+                        String helperRef = DEFAULTS_JSON['repository']['helper_ref']
+                        def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${helperRef}").JobHelper
 
                         // Create test job if AQA_AUTO_GEN is set to true, the job doesn't exist or is not runnable
                         if (aqaAutoGen || !JobHelper.jobIsRunnable(jobName as String)) {
@@ -1484,7 +1487,8 @@ class Build {
     If it doesn't find one or the timeout is set to 0 (default), it'll crash out. Otherwise, it'll return and jump onto the node.
     */
     def waitForANodeToBecomeActive(def label) {
-        def NodeHelper = context.library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}").NodeHelper
+        String helperRef = DEFAULTS_JSON['repository']['helper_ref']
+        def NodeHelper = context.library(identifier: "openjdk-jenkins-helper@${helperRef}").NodeHelper
 
         // A node with the requested label is ready to go
         if (NodeHelper.nodeIsOnline(label)) {
@@ -1574,7 +1578,8 @@ class Build {
                 context.stage("queue") {
                     /* This loads the library containing two Helper classes, and causes them to be
                     imported/updated from their repo. Without the library being imported here, runTests method will fail to execute the post-build test jobs for reasons unknown.*/
-                    context.library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}")
+                    String helperRef = DEFAULTS_JSON['repository']['helper_ref']
+                    context.library(identifier: "openjdk-jenkins-helper@${helperRef}")
 
                     // Set Github Commit Status
                     if (env.JOB_NAME.contains("pr-tester")) {

--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -48,7 +48,7 @@ node ("worker") {
 
     scmVars = checkout scm
 
-    library(identifier: 'openjdk-jenkins-helper@master')
+    library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}")
 
     // Load baseFilePath. This is where build_base_file.groovy is located. It runs the downstream job setup and configuration retrieval services.
     def baseFilePath = (params.baseFilePath) ?: DEFAULTS_JSON['baseFileDirectories']['upstream']

--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -48,7 +48,8 @@ node ("worker") {
 
     scmVars = checkout scm
 
-    library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}")
+    String helperRef = DEFAULTS_JSON['repository']['helper_ref']
+    library(identifier: "openjdk-jenkins-helper@${helperRef}")
 
     // Load baseFilePath. This is where build_base_file.groovy is located. It runs the downstream job setup and configuration retrieval services.
     def baseFilePath = (params.baseFilePath) ?: DEFAULTS_JSON['baseFileDirectories']['upstream']

--- a/pipelines/build/prTester/kick_off_tester.groovy
+++ b/pipelines/build/prTester/kick_off_tester.groovy
@@ -39,7 +39,7 @@ node("worker") {
         ]]
     ])
 
-    library(identifier: 'openjdk-jenkins-helper@master')
+    library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}")
     prTest = load DEFAULTS_JSON['scriptDirectories']['tester']
 }
 

--- a/pipelines/build/prTester/kick_off_tester.groovy
+++ b/pipelines/build/prTester/kick_off_tester.groovy
@@ -26,6 +26,7 @@ if (!DEFAULTS_JSON) {
 }
 
 String url = DEFAULTS_JSON['repository']['pipeline_url']
+String helperRef = DEFAULTS_JSON['repository']['helper_ref']
 Closure prTest
 
 // Switch to controller node to load library groovy definitions
@@ -39,7 +40,8 @@ node("worker") {
         ]]
     ])
 
-    library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}")
+
+    library(identifier: "openjdk-jenkins-helper@${helperRef}")
     prTest = load DEFAULTS_JSON['scriptDirectories']['tester']
 }
 

--- a/pipelines/build/regeneration/build_job_generator.groovy
+++ b/pipelines/build/regeneration/build_job_generator.groovy
@@ -77,7 +77,8 @@ node ("worker") {
 
     checkoutUserPipelines()
 
-    library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}")
+    String helperRef = DEFAULTS_JSON['repository']['helper_ref']
+    library(identifier: "openjdk-jenkins-helper@${helperRef}")
 
     // Load buildConfigurations from config file. This is what the nightlies & releases use to setup their downstream jobs
     def buildConfigurations = null

--- a/pipelines/build/regeneration/build_job_generator.groovy
+++ b/pipelines/build/regeneration/build_job_generator.groovy
@@ -77,7 +77,7 @@ node ("worker") {
 
     checkoutUserPipelines()
 
-    library(identifier: 'openjdk-jenkins-helper@master')
+    library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}")
 
     // Load buildConfigurations from config file. This is what the nightlies & releases use to setup their downstream jobs
     def buildConfigurations = null

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -63,8 +63,10 @@ node('worker') {
 
       // Checkout into user repository
       checkoutUserPipelines()
+      
+      String helperRef = DEFAULTS_JSON['repository']['helper_ref']
+      library(identifier: "openjdk-jenkins-helper@${helperRef}")
 
-      library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}")
 
       // Load jobRoot. This is where the openjdkxx-pipeline jobs will be created.
       def jobRoot = (params.JOB_ROOT) ?: DEFAULTS_JSON["jenkinsDetails"]["rootDirectory"]
@@ -134,7 +136,8 @@ node('worker') {
       println "USE_ADOPT_SHELL_SCRIPTS = $useAdoptShellScripts"
 
       // Collect available JDK versions to check for generation (tip_version + 1 just in case it is out of date on a release day)
-      def JobHelper = library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}").JobHelper
+      String helperRef = DEFAULTS_JSON['repository']['helper_ref']
+      def JobHelper = library(identifier: "openjdk-jenkins-helper@${helperRef}").JobHelper
       println "Querying Adopt Api for the JDK-Head number (tip_version)..."
 
       def response = JobHelper.getAvailableReleases(this)

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -136,7 +136,7 @@ node('worker') {
       println "USE_ADOPT_SHELL_SCRIPTS = $useAdoptShellScripts"
 
       // Collect available JDK versions to check for generation (tip_version + 1 just in case it is out of date on a release day)
-      String helperRef = DEFAULTS_JSON['repository']['helper_ref']
+
       def JobHelper = library(identifier: "openjdk-jenkins-helper@${helperRef}").JobHelper
       println "Querying Adopt Api for the JDK-Head number (tip_version)..."
 

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -64,7 +64,7 @@ node('worker') {
       // Checkout into user repository
       checkoutUserPipelines()
 
-      library(identifier: 'openjdk-jenkins-helper@master')
+      library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}")
 
       // Load jobRoot. This is where the openjdkxx-pipeline jobs will be created.
       def jobRoot = (params.JOB_ROOT) ?: DEFAULTS_JSON["jenkinsDetails"]["rootDirectory"]
@@ -134,7 +134,7 @@ node('worker') {
       println "USE_ADOPT_SHELL_SCRIPTS = $useAdoptShellScripts"
 
       // Collect available JDK versions to check for generation (tip_version + 1 just in case it is out of date on a release day)
-      def JobHelper = library(identifier: 'openjdk-jenkins-helper@master').JobHelper
+      def JobHelper = library(identifier: "openjdk-jenkins-helper@${DEFAULTS_JSON['repository']['helper_ref']}").JobHelper
       println "Querying Adopt Api for the JDK-Head number (tip_version)..."
 
       def response = JobHelper.getAvailableReleases(this)

--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -4,7 +4,8 @@
         "build_branch"       : "master",
         "test_dirs"          : "/test/functional",
         "pipeline_url"       : "https://github.com/adoptium/ci-jenkins-pipelines.git",
-        "pipeline_branch"    : "master"
+        "pipeline_branch"    : "master",
+        "helper_ref"         : "master"
     },
     "jenkinsDetails"         : {
         "rootUrl"            : "https://ci.adoptopenjdk.net",

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -85,13 +85,13 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
     parameters {
         textParam('targetConfigurations', JsonOutput.prettyPrint(JsonOutput.toJson(targetConfigurations)))
         stringParam('activeNodeTimeout', "0", 'Number of minutes we will wait for a label-matching node to become active.')
-        stringParam('jdkVersion', jdkVersion, 'The JDK version of the pipeline e.g (11, 8, 17).')
+        stringParam('jdkVersion', jdkVersion, 'The JDK version of the pipeline e.g (8, 11, 17, 19, 20).')
         stringParam('dockerExcludes', "", 'Map of targetConfigurations to exclude from docker building. If a targetConfiguration (i.e. { "x64LinuxXL": [ "openj9" ], "aarch64Linux": [ "hotspot", "openj9" ] }) has been entered into this field, jenkins will build the jdk without using docker. This param overrides the dockerImage and dockerFile downstream job parameters.')
         stringParam('baseFilePath', "", "Relative path to where the build_base_file.groovy file is located. This runs the downstream job setup and configuration retrieval services.<br>Default: <code>${defaultsJson['baseFileDirectories']['upstream']}</code>")
         stringParam('buildConfigFilePath', "", "Relative path to where the jdkxx_pipeline_config.groovy file is located. It contains the build configurations for each platform, architecture and variant.<br>Default: <code>${defaultsJson['configDirectories']['build']}/jdkxx_pipeline_config.groovy</code>")
         choiceParam('releaseType', ['Nightly', 'Nightly Without Publish', 'Weekly', 'Release'], 'Nightly - release a standard nightly build.<br/>Nightly Without Publish - run a nightly but do not publish.<br/>Weekly - release a standard weekly build, run with extended tests.<br/>Release - this is a release, this will need to be manually promoted.')
         stringParam('overridePublishName', "", '<strong>REQUIRED for OpenJ9</strong>: Name that determines the publish name (and is used by the meta-data file), defaults to scmReference(minus _adopt if present).<br/>Nightly builds: Leave blank (defaults to a date_time stamp).<br/>OpenJ9 Release build Java 8 example <code>jdk8u192-b12_openj9-0.12.1</code> and for OpenJ9 Java 11 example <code>jdk-11.0.2+9_openj9-0.12.1</code>.')
-        stringParam('scmReference', "", 'Tag name or Branch name from which to build. Nightly builds: Defaults to, Hotspot=dev, OpenJ9=openj9, others=master.</br>Release builds: For hotspot JDK8 this would be the OpenJDK tag, for hotspot JDK11+ this would be the Adopt merge tag for the desired OpenJDK tag eg.jdk-11.0.4+10_adopt, and for OpenJ9 this will be the release branch, eg.openj9-0.14.0.')
+        stringParam('scmReference', "", 'Tag name or Branch name from which openjdk source code repo to build. Nightly builds: Defaults to, Hotspot=dev, OpenJ9=openj9, others=master.</br>Release builds: For hotspot JDK8 this would be the OpenJDK tag, for hotspot JDK11+ this would be the Adopt merge tag for the desired OpenJDK tag eg.jdk-11.0.4+10_adopt, and for OpenJ9 this will be the release branch, eg.openj9-0.14.0.')
         stringParam('buildReference', "", 'Tag name or Branch name of temurin-build repo. Defaults to master')
         stringParam('ciReference', "", 'Tag name or Branch name of ci-jenkins-pipeline repo. Defaults to master')
         stringParam('helperReference', "", 'Tag name or Branch name of jenkins-helper repo. Defaults to master')
@@ -113,6 +113,6 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
         booleanParam('keepReleaseLogs', true, 'If true, "Release" type pipeline Jenkins logs will be marked as "Keep this build forever".')
         stringParam('adoptBuildNumber', "", "Empty by default. If you ever need to re-release then bump this number. Currently this is only added to the build metadata file.")
         textParam('defaultsJson', JsonOutput.prettyPrint(JsonOutput.toJson(defaultsJson)), '<strong>DO NOT ALTER THIS PARAM UNLESS YOU KNOW WHAT YOU ARE DOING!</strong> This passes down the user\'s default constants to the downstream jobs.')
-        textParam('adoptDefaultsJson', JsonOutput.prettyPrint(JsonOutput.toJson(adoptDefaultsJson)), '<strong>DO NOT ALTER THIS PARAM UNDER ANY CIRCUMSTANCES!</strong> This passes down adopt\'s default constants to the downstream jobs. NOTE: <code>defaultsJson</code> has priority, the constants contained within this param will only be used as a failsafe.')
+        textParam('adoptDefaultsJson', JsonOutput.prettyPrint(JsonOutput.toJson(adoptDefaultsJson)), '<strong>DO NOT ALTER THIS PARAM UNDER ANY CIRCUMSTANCES!</strong> This passes down adoptium\'s default constants to the downstream jobs. NOTE: <code>defaultsJson</code> has priority, the constants contained within this param will only be used as a failsafe.')
     }
 }

--- a/pipelines/src/test/groovy/RepoHandlerTest.groovy
+++ b/pipelines/src/test/groovy/RepoHandlerTest.groovy
@@ -24,6 +24,7 @@ class RepoHandlerTest {
         Assertions.assertEquals(adoptJson.repository.build_branch, "master")
         Assertions.assertEquals(adoptJson.repository.pipeline_url, "https://github.com/adoptium/ci-jenkins-pipelines.git")
         Assertions.assertEquals(adoptJson.repository.pipeline_branch, "master")
+        Assertions.assertEquals(adoptJson.repository.helper_ref, "master")
 
         // Jenkins Details
         Assertions.assertTrue(adoptJson.jenkinsDetails instanceof Map)
@@ -78,6 +79,7 @@ class RepoHandlerTest {
         Assertions.assertEquals(userJson.repository.build_branch, "20")
         Assertions.assertEquals(userJson.repository.pipeline_url, "19")
         Assertions.assertEquals(userJson.repository.pipeline_branch, "21")
+        Assertions.assertEquals(userJson.repository.helper_ref, "24")
 
         // Jenkins Details
         Assertions.assertTrue(userJson.jenkinsDetails instanceof Map)

--- a/pipelines/src/test/groovy/fakeDefaults.json
+++ b/pipelines/src/test/groovy/fakeDefaults.json
@@ -3,7 +3,8 @@
         "build_url"          : "1",
         "build_branch"       : "20",
         "pipeline_url"       : "19",
-        "pipeline_branch"    : "21"
+        "pipeline_branch"    : "21",
+        "helper_ref"         : "24"
     },
     "jenkinsDetails"         : {
         "rootUrl"            : "3",


### PR DESCRIPTION
Fix: https://github.com/adoptium/ci-jenkins-pipelines/issues/419 

As stated in the doc: `
You may find that the `RepoHandlerTest.groovy:adoptDefaultsGetterReturns()` will fail when you add new values. This is expected as the test is pulling in Adopt's master branch `defaults.json` which does not yet contain the new values. Please inform any reviewers of this in the pull request.`
thats why GH action groovy test failed on adoptDefaultsGetterReturns because on master helper_ref does not exist as null

```
RepoHandlerTest > adoptDefaultsGetterReturns() FAILED
    org.opentest4j.AssertionFailedError: expected: <null> but was: <master>
        at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
        at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
        at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1124)
        at org.junit.jupiter.api.Assertions$assertEquals$1.call(Unknown Source)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:148)
        at RepoHandlerTest.adoptDefaultsGetterReturns(RepoHandlerTest.groovy:27)
```