### PR TITLE
fix: add pre-job cleanup workspace to avoid folder left from old run

### DIFF
--- a/tools/reproduce_comparison/Jenkinsfile
+++ b/tools/reproduce_comparison/Jenkinsfile
@@ -19,6 +19,7 @@ pipeline {
             steps {
                 script {
                     try {
+                        cleanWs()
                         echo "Fetching artifact1 from ${params.URL1}"
                         def ret1 = sh returnStatus: true, script: "mkdir url1Dir1 && wget -q ${params.URL1} -O - | tar -xz -C url1Dir1"
                         if (ret1 != 0) {


### PR DESCRIPTION
From run https://ci.adoptopenjdk.net/view/ReproducibleBuild/job/reproducible_comparision/6/console got error
`mkdir: cannot create directory ‘url1Dir1’: File exists`
folder is left from https://ci.adoptopenjdk.net/view/ReproducibleBuild/job/reproducible_comparision/4/console on the same agent 
```
[WS-CLEANUP] Deleting project workspace...
[WS-CLEANUP] Deferred wipeout is used...
ERROR: Cannot delete workspace :Remote call on build-osuosl-centos74-ppc64le-1X failed
```

Ref https://github.com/adoptium/ci-jenkins-pipelines/issues/397