### PR TITLE
chore: prep for 2022 Oct CPU release to disable nightly test

### DIFF
--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -33,7 +33,7 @@
         "downstream"         : "pipelines/build/common/openjdk_build_pipeline.groovy"
     },
     "testDetails"            : {
-        "enableTests"        : true,
+        "enableTests"        : false,
         "nightlyDefault"     : [
             "sanity.openjdk",
             "sanity.system",


### PR DESCRIPTION
Disable Nightly test for 2022 Oct CPU release
