### PR TITLE
Remove aarch64Windows from pipeline config, to be re-introduced in a prototype pipeline

### DIFF
--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -3,7 +3,6 @@ targetConfigurations = [
         'x64Linux'      : [    'temurin',    'openj9',    'dragonwell',    'corretto',    'bisheng',    'fast_startup'],
         'x64AlpineLinux': [    'temurin'                            ],
         'x64Windows'    : [    'temurin',    'openj9',    'dragonwell'            ],
-        'aarch64Windows': [    'temurin'                            ],
         'x32Windows'    : [    'temurin'                            ],
         'ppc64Aix'      : [    'temurin',    'openj9'                    ],
         'ppc64leLinux'  : [    'temurin',    'openj9'                    ],

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -76,17 +76,6 @@ class Config11 {
                 test                : 'default'
         ],
 
-        aarch64Windows: [
-                os                  : 'windows',
-                arch                : 'aarch64',
-                crossCompile        : 'x64',
-                additionalNodeLabels: 'win2016&&vs2019',
-                test                : false,
-                buildArgs       : [
-                        'temurin'   : '--jvm-variant client,server --create-sbom --cross-compile'
-                ]
-        ],
-
         x32Windows: [
                 os                  : 'windows',
                 arch                : 'x86-32',

--- a/pipelines/jobs/configurations/jdk16u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk16u_pipeline_config.groovy
@@ -52,19 +52,6 @@ class Config16 {
                 test                : 'default'
         ],
 
-        // TODO: Enable testing (https://github.com/adoptium/ci-jenkins-pipelines/issues/77)
-        aarch64Windows: [
-                os                  : 'windows',
-                arch                : 'aarch64',
-                crossCompile        : 'x64',
-                buildArgs           : '--cross-compile',
-                additionalNodeLabels: 'win2016&&vs2019',
-                test                : [
-                        nightly: [],
-                        weekly : []
-                ]
-        ],
-
         x32Windows: [
                 os                  : 'windows',
                 arch                : 'x86-32',

--- a/pipelines/jobs/configurations/jdk17u.groovy
+++ b/pipelines/jobs/configurations/jdk17u.groovy
@@ -15,9 +15,6 @@ targetConfigurations = [
                 'temurin',
                 'openj9'
         ],
-        'aarch64Windows' : [
-                'temurin'
-        ],
         'x32Windows'  : [
                 'temurin'
         ],

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -70,17 +70,6 @@ class Config17 {
                 ]
         ],
 
-        aarch64Windows: [
-                os                  : 'windows',
-                arch                : 'aarch64',
-                crossCompile        : 'x64',
-                additionalNodeLabels: 'win2016&&vs2019',
-                test                : false,
-                buildArgs       : [
-                        'temurin'   : '--create-jre-image --create-sbom --cross-compile'
-                ]
-        ],
-
         x32Windows: [
                 os                  : 'windows',
                 arch                : 'x86-32',

--- a/pipelines/jobs/configurations/jdk18u.groovy
+++ b/pipelines/jobs/configurations/jdk18u.groovy
@@ -11,9 +11,6 @@ targetConfigurations = [
         'x64Windows'  : [
                 'temurin'
         ],
-        'aarch64Windows' : [
-                'temurin'
-        ],
         'x32Windows'  : [
                 'temurin'
         ],

--- a/pipelines/jobs/configurations/jdk18u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk18u_pipeline_config.groovy
@@ -70,17 +70,6 @@ class Config18 {
                 ]
         ],
 
-        aarch64Windows: [
-                os                  : 'windows',
-                arch                : 'aarch64',
-                crossCompile        : 'x64',
-                additionalNodeLabels: 'win2016&&vs2019',
-                test                : false,
-                buildArgs       : [
-                        'temurin'   : '--create-jre-image --create-sbom --cross-compile'
-                ]
-        ],
-
         x32Windows: [
                 os                  : 'windows',
                 arch                : 'x86-32',

--- a/pipelines/jobs/configurations/jdk19.groovy
+++ b/pipelines/jobs/configurations/jdk19.groovy
@@ -11,9 +11,6 @@ targetConfigurations = [
         'x64Windows'  : [
                 'temurin'
         ],
-        'aarch64Windows' : [
-                'temurin'
-        ],
         'x32Windows'  : [
                 'temurin'
         ],

--- a/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
@@ -70,18 +70,6 @@ class Config19 {
                 ]
         ],
 
-        aarch64Windows: [
-                os                  : 'windows',
-                arch                : 'aarch64',
-                crossCompile        : 'x64',
-                additionalNodeLabels: 'win2016&&vs2019',
-                test                : false,
-                buildArgs       : [
-                        'temurin'   : '--create-jre-image --create-sbom --cross-compile'
-                ]
-
-        ],
-
         x32Windows: [
                 os                  : 'windows',
                 arch                : 'x86-32',

--- a/pipelines/jobs/configurations/jdk20.groovy
+++ b/pipelines/jobs/configurations/jdk20.groovy
@@ -11,9 +11,6 @@ targetConfigurations = [
         'x64Windows'  : [
                 'temurin'
         ],
-        'aarch64Windows' : [
-                'temurin'
-        ],
         'x32Windows'  : [
                 'temurin'
         ],

--- a/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
@@ -70,18 +70,6 @@ class Config20 {
                 ]
         ],
 
-        aarch64Windows: [
-                os                  : 'windows',
-                arch                : 'aarch64',
-                crossCompile        : 'x64',
-                additionalNodeLabels: 'win2016&&vs2019',
-                test                : false,
-                buildArgs       : [
-                        'temurin'   : '--create-jre-image --create-sbom --cross-compile'
-                ]
-
-        ],
-
         x32Windows: [
                 os                  : 'windows',
                 arch                : 'x86-32',


### PR DESCRIPTION
aarch64Windows is not currently a candidate for releases, and is not stable.
We should re-introduce in a new "prototype" pipeline so as to not affect mainline release platforms.

ref: https://github.com/adoptium/ci-jenkins-pipelines/issues/473

Signed-off-by: Andrew Leonard <anleonar@redhat.com>