### PR TITLE
Add missing quotes to build_base_file.groovy excludePlats list strings riscv64_linux

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -904,7 +904,7 @@ class Builder implements Serializable {
             } else if (release && enableTests) {
                 //remote trigger job https://ci.eclipse.org/temurin-compliance/job/AQA_Test_Pipeline/
                 //exclude not supported platforms
-                List<String> excludePlats = [riscv64_linux, aarch64_windows]
+                List<String> excludePlats = ['riscv64_linux', 'aarch64_windows']
                 if ( javaToBuild == 'jdk8u' ) {
                     excludePlats.add('s390x_linux')
                 }


### PR DESCRIPTION
Fixes build break from https://github.com/adoptium/ci-jenkins-pipelines/pull/446
Missing ' quotes

Signed-off-by: Andrew Leonard <anleonar@redhat.com>