### PR TITLE
Enable nightly test again after 2022 Oct release

### DIFF
--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -33,7 +33,7 @@
         "downstream"         : "pipelines/build/common/openjdk_build_pipeline.groovy"
     },
     "testDetails"            : {
-        "enableTests"        : false,
+        "enableTests"        : true,
         "nightlyDefault"     : [
             "sanity.openjdk",
             "sanity.system",


### PR DESCRIPTION
This reverts commit 7c6051c5d5ce0141c6e7f343bce9f0ee8b0b21ae.