### PR TITLE
Fix: comparision job does not take in exclude list and bind to only run x64 machine for now

### DIFF
--- a/tools/reproduce_comparison/Jenkinsfile
+++ b/tools/reproduce_comparison/Jenkinsfile
@@ -43,7 +43,8 @@ pipeline {
                         for(String excludeFile in excludeFileList) {
                             excludeFlags="${excludeFlags} --exclude=${excludeFile}"
                         }
-                        def retVal = sh returnStatus: true, script: 'diff -q -r url1Dir1 url1Dir2 ${excludeFlags}'
+			echo "excludeFlags is ${excludeFlags}"
+                        def retVal = sh returnStatus: true, script: "diff -q -r url1Dir1 url1Dir2 ${excludeFlags}"
                         if (retVal != 0) {
                             currentBuild.result = 'FAILURE'
                             error 'Error: two builds are not the same!'

--- a/tools/reproduce_comparison/Jenkinsfile
+++ b/tools/reproduce_comparison/Jenkinsfile
@@ -22,13 +22,13 @@ pipeline {
                     try {
                         cleanWs()
                         echo "Fetching artifact1 from ${params.URL1}"
-                        def ret1 = sh returnStatus: true, script: "mkdir url1Dir1 && wget  ${params.URL1} -O - | tar -xz -C url1Dir1"
+                        def ret1 = sh returnStatus: true, script: "mkdir url1Dir1 && wget -q ${params.URL1} -O - | tar -xz -C url1Dir1"
                         if (ret1 != 0) {
                             currentBuild.result = 'UNSTABLE'
                             error 'Stopping after download and uncompress tar file'
                         }
                         echo "Fetching artifact2 from ${params.URL2}"
-                        def ret2 = sh returnStatus: true, script: "mkdir url1Dir2 && wget  ${params.URL2} -O - | tar -xz -C url1Dir2"
+                        def ret2 = sh returnStatus: true, script: "mkdir url1Dir2 && wget -q ${params.URL2} -O - | tar -xz -C url1Dir2"
                         if (ret2 != 0) {
                             currentBuild.result = 'UNSTABLE'
                             error 'Stopping after download and uncompress tar file'

--- a/tools/reproduce_comparison/Jenkinsfile
+++ b/tools/reproduce_comparison/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
     stages {
         stage('Lets Compare') {
             agent {
-                label "build&&${params.platform}&&build" // build label enables comparisons to be done
+                label "${params.platform}&&build&&x64" // build label enables comparisons to be done
             }
             steps {
                 script {

--- a/tools/reproduce_comparison/Jenkinsfile
+++ b/tools/reproduce_comparison/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
     stages {
         stage('Lets Compare') {
             agent {
-                label "${params.platform}&&build&&x64" // build label enables comparisons to be done
+                label "${params.platform}&&build&&x64" // build label enables comparisons to be done, set to x64 for linux, might need adjust for windows/mac
             }
             steps {
                 script {
@@ -43,7 +43,6 @@ pipeline {
                         for(String excludeFile in excludeFileList) {
                             excludeFlags="${excludeFlags} --exclude=${excludeFile}"
                         }
-			echo "excludeFlags is ${excludeFlags}"
                         def retVal = sh returnStatus: true, script: "diff -q -r url1Dir1 url1Dir2 ${excludeFlags}"
                         if (retVal != 0) {
                             currentBuild.result = 'FAILURE'

--- a/tools/reproduce_comparison/Jenkinsfile
+++ b/tools/reproduce_comparison/Jenkinsfile
@@ -22,13 +22,13 @@ pipeline {
                     try {
                         cleanWs()
                         echo "Fetching artifact1 from ${params.URL1}"
-                        def ret1 = sh returnStatus: true, script: "mkdir url1Dir1 && wget -q ${params.URL1} -O - | tar -xz -C url1Dir1"
+                        def ret1 = sh returnStatus: true, script: "mkdir url1Dir1 && wget  ${params.URL1} -O - | tar -xz -C url1Dir1"
                         if (ret1 != 0) {
                             currentBuild.result = 'UNSTABLE'
                             error 'Stopping after download and uncompress tar file'
                         }
                         echo "Fetching artifact2 from ${params.URL2}"
-                        def ret2 = sh returnStatus: true, script: "mkdir url1Dir2 && wget -q ${params.URL2} -O - | tar -xz -C url1Dir2"
+                        def ret2 = sh returnStatus: true, script: "mkdir url1Dir2 && wget  ${params.URL2} -O - | tar -xz -C url1Dir2"
                         if (ret2 != 0) {
                             currentBuild.result = 'UNSTABLE'
                             error 'Stopping after download and uncompress tar file'

--- a/tools/reproduce_comparison/Jenkinsfile
+++ b/tools/reproduce_comparison/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
     stages {
         stage('Lets Compare') {
             agent {
-                label "${params.platform}&&build" // build label enables comparisons to be done
+                label "build&&${params.platform}&&build" // build label enables comparisons to be done
             }
             steps {
                 script {


### PR DESCRIPTION
- by using '' jenkins does not take in variable excludeFlags so the job still compare classes_nocoops.jsa
- if not set to use x64, currently we might ended on a risvc machine or others(aix?) so we need to test more if wget and tar with currents flags work or not. since this is a small/quick job, it wont hold x64 linux for more than 2mins, should not be a problem. 

Ref: https://github.com/adoptium/ci-jenkins-pipelines/issues/435 