### PR TITLE
Add loongson support

### DIFF
--- a/.github/regex_labeler.yml
+++ b/.github/regex_labeler.yml
@@ -97,6 +97,10 @@ labels:
     matcher:
       title: "bisheng"
       body: "bisheng"
+  - label: "loongson"
+    matcher:
+      title: "loongson"
+      body: "loongson"
   - label: "docker"
     matcher:
       title: "docker"

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ This tag identifies the architecture the JDK has been built on and it intended t
 ---
 
 - `variant:`
-Example values: [`hotspot`, `temurin`, `openj9`, `corretto`, `dragonwell`, `bisheng`, `fast_startup`]
+Example values: [`hotspot`, `temurin`, `openj9`, `corretto`, `dragonwell`, `bisheng`, `loongson`, `fast_startup`]
 
 This tag identifies the JVM being used by the JDK, "dragonwell" itself is not a JVM but is currently considered a variant in its own right.
 

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -172,6 +172,7 @@ class Build {
             case 'dragonwell': variant = 'dragonwell'; break;
             case 'fast_startup': variant = 'fast_startup'; break;
             case 'bisheng': variant = 'bisheng'; break;
+            case 'loongson': variant = 'loongson'; break;
             default: variant = 'hs'
         }
         def jobName = "Test_openjdk${jobParams['JDK_VERSIONS']}_${variant}_${testType}_${jobParams['ARCH_OS_LIST']}"
@@ -226,6 +227,8 @@ class Build {
                 jdkBranch = 'master'
             } else if (buildConfig.VARIANT == 'bisheng') {
                 jdkBranch = 'master'
+            } else if (buildConfig.VARIANT == 'loongson') {
+                jdkBranch = 'master-ls'
             } else {
                 throw new Exception("Unrecognised build variant: ${buildConfig.VARIANT} ")
             }
@@ -263,6 +266,8 @@ class Build {
             suffix = 'adoptium/jdk11u-fast-startup-incubator'
         } else if (buildConfig.VARIANT == 'bisheng') {
             suffix = "openeuler-mirror/bishengjdk-${javaNumber}"
+        } else if (buildConfig.VARIANT == 'loongson') {
+            suffix = "loongson/jdk8u"
         } else {
             throw new Exception("Unrecognised build variant: ${buildConfig.VARIANT} ")
         }

--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -51,6 +51,9 @@ targetConfigurations = [
         ],
         'sparcv9Solaris': [
                 'temurin'
+        ],
+        'loongarch64Linux': [
+               'loongson'
         ]
 ]
 
@@ -65,7 +68,8 @@ weekly_release_scmReferences = [
         'openj9'         : '',
         'corretto'       : '',
         'dragonwell'     : '',
-        'bisheng'        : ''
+        'bisheng'        : '',
+        'loongson'       : ''
 ]
 
 return this

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -157,6 +157,15 @@ class Config8 {
                         'temurin'   : '--create-sbom'
                 ]
         ],
+
+        loongarch64Linux  : [
+                os                  : 'linux',
+                arch                : 'loongarch64',
+                test                : 'default',
+                buildArgs           : [
+                        'temurin'   : '--create-sbom'
+                ]
+        ],
   ]
 
 }


### PR DESCRIPTION
There are no LoongArch machines available for jenkins, but we are actively seeking solutions to the problem, see:https://github.com/adoptium/infrastructure/issues/2806. For now, this changes is only used to seek advice from everyone.  