### PR TITLE
Temporarily disable remote Jck trigger until All Green exclusion task is complete

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -743,6 +743,8 @@ class Builder implements Serializable {
                     }
             }
         }
+        // Temporarily disable remote Jck trigger until All Green exclusion task is complete
+        isTemurin = false
         if (isTemurin) {
             def jdkVersion = getJavaVersionNumber()
             //def sdkUrl="https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk${jdkVersion}-pipeline/${env.BUILD_NUMBER}/"


### PR DESCRIPTION
Jck remote trigger is utilizing all the temurin compliance machines for the half the week, slowing all green exclusion task.
We will re-enable once complete.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>