### PR TITLE
Pin actions and restrict permissions

### DIFF
--- a/.github/workflows/comment-bot.yml
+++ b/.github/workflows/comment-bot.yml
@@ -4,14 +4,20 @@ on:
   pull_request_target:
     types: [ opened ]
 
+permissions:
+  contents: read
+
 jobs:
   Comment:
+    permissions:
+      issues: write  # for peter-evans/create-or-update-comment to create or update comment
+      pull-requests: write  # for peter-evans/create-or-update-comment to create or update comment
     name: Add Comment
     runs-on: ubuntu-latest
 
     steps:
       - name: Create comment
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@5adcb0bb0f9fb3f95ef05400558bdb3f329ee808 # v2.1.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,9 +21,15 @@ on:
 ###############
 # Set the Job #
 ###############
+permissions:
+  contents: read
+
 jobs:
   linter:
     # Name the Job
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      statuses: write  # for github/super-linter to mark status of each linter run
     name: Lint Code Base
     # Set the agent to run on
     runs-on: ubuntu-latest
@@ -36,7 +42,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
@@ -45,7 +51,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v4.9.7
+        uses: github/super-linter@bb2d833b08b6c288608686672b93a8a4589cdc49 # v4.9.7
         env:
           VALIDATE_ALL_CODEBASE: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,15 +4,18 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   test_groovy:
     name: Groovy
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc # v3.6.0
       with:
         java-version: '11'
         distribution: 'temurin'


### PR DESCRIPTION
Pins GitHub action dependencies to specific hashes and restricts permissions to those required.
Part of https://github.com/adoptium/adoptium/issues/187