### PR TITLE
feat: pass ghprbActualCommit to pr-test openjdkX-pipeline

### DIFF
--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -593,7 +593,7 @@ class Regeneration implements Serializable {
         context.timestamps {
             def versionNumbers = javaVersion =~ /\d+/
 
-            /*  
+            /*
             * Stage: Check that the pipeline isn't in in-progress or queued up. Once clear, run the regeneration job
             */
             context.stage("Check $javaVersion pipeline status") {

--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -593,7 +593,7 @@ class Regeneration implements Serializable {
         context.timestamps {
             def versionNumbers = javaVersion =~ /\d+/
 
-            /*
+            /*  
             * Stage: Check that the pipeline isn't in in-progress or queued up. Once clear, run the regeneration job
             */
             context.stage("Check $javaVersion pipeline status") {
@@ -703,14 +703,13 @@ class Regeneration implements Serializable {
                             // Skip variant job make if it's marked as excluded
                             if (jobConfigurations.get(name) == EXCLUDED_CONST) {
                                 continue
-                            }
-                                // Make job
-                                else if (jobConfigurations.get(name) != null) {
+                            } // Make job
+                            else if (jobConfigurations.get(name) != null) {
                                 makeJob(jobConfigurations, name)
                                 // Unexpected error when building or getting the configuration
-                                } else {
+                            } else {
                                 throw new Exception("[ERROR] IndividualBuildConfig is malformed or null for key: ${osarch} : ${variant}.")
-                                }
+                            }
                         }
                         } // end variant for loop
 

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1517,10 +1517,14 @@ class Build {
         }
     }
 
+    /* 
+        this function should only be used in pr-test
+    */
     def updateGithubCommitStatus(STATE, MESSAGE) {
         // workaround https://issues.jenkins-ci.org/browse/JENKINS-38674
-        // get url and branch from jenkins job's params not variable USER_REMOTE_CONFIGS
-        String repoUrl = USER_REMOTE_CONFIGS['remotes']['url']
+        // get repourl from job's DEFAULTS_JSON  points to upstream repo
+        String repoUrl = DEFAULTS_JSON['repository']['pipeline_url'] // USER_REMOTE_CONFIGS['remotes']['url']
+        // get branch/commit SHA1 from job's USER_REMOTE_CONFIGS which is the commits from PR
         Map paramUserRemoteConfigs = new JsonSlurper().parseText(context.USER_REMOTE_CONFIGS)
         String commitSha = paramUserRemoteConfigs['branch']
 

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1259,11 +1259,8 @@ class Build {
                     if (useAdoptShellScripts) {
                         repoHandler.checkoutAdoptPipelines(context)
                     } else {
-                        context.println 'DEBUG1--'
                         repoHandler.setUserDefaultsJson(context, DEFAULTS_JSON)
-                        context.println 'DEBUG2--'
                         repoHandler.checkoutUserPipelines(context)
-                        context.println 'DEBUG3--'
                     }
                     // Perform a git clean outside of checkout to avoid the Jenkins enforced 10 minute timeout
                     // https://github.com/adoptium/infrastucture/issues/1553

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1259,8 +1259,11 @@ class Build {
                     if (useAdoptShellScripts) {
                         repoHandler.checkoutAdoptPipelines(context)
                     } else {
+                        context.println 'DEBUG1--'
                         repoHandler.setUserDefaultsJson(context, DEFAULTS_JSON)
+                        context.println 'DEBUG2--'
                         repoHandler.checkoutUserPipelines(context)
+                        context.println 'DEBUG3--'
                     }
                     // Perform a git clean outside of checkout to avoid the Jenkins enforced 10 minute timeout
                     // https://github.com/adoptium/infrastucture/issues/1553

--- a/pipelines/build/prTester/README.md
+++ b/pipelines/build/prTester/README.md
@@ -14,15 +14,15 @@ Every new pull request to this repository that alters any groovy code OR that wi
 
 There are four "groups" of tests that can be run on each PR:
 
-- [#Test](#Test)
-- [#openjdk-build-pr-tester](#openjdk-build-pr-tester) (**OPTIONAL, SEE [#When they're used](#When-they're-used)**)
+- [Test](#Test)
+- [openjdk-build-pr-tester](#openjdk-build-pr-tester) (**OPTIONAL, SEE [#When they're used](#When-they're-used)**)
 
 The results of these jobs will appear as [GitHub Status Check Results](https://docs.github.com/en/github/administering-a-repository/about-required-status-checks) at the bottom of the PR being tested:
 ![Image of PR Tester Checks](./images/pr_tester_checks.png)
 
 ### Test
 
-This group consists of [GitHub Status Checks](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-status-checks) run inside GitHub itself. They unit test any code changes you have made.
+This group consists of [GitHub Status Checks Results](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-status-checks) run inside GitHub itself. They unit-test any code changes you have made.
 
 #### Groovy
 
@@ -39,8 +39,9 @@ cd pipelines/
 
 - **Seen in the PR Status Checks as `pipeline-build-check`, the job is located [here](https://ci.adoptopenjdk.net/job/build-scripts-pr-tester/job/openjdk-build-pr-tester/)**
 - This job runs the a set of [sandbox pipelines](https://ci.adoptopenjdk.net/job/build-scripts-pr-tester/job/build-test/) to test the changes that you have made to our codebase.
-- It first executes [kick_off_tester.groovy](pipelines/build/prTester/kick_off_tester.groovy) which in turn kicks off our [pr_test_pipeline](pipelines/build/prTester/pr_test_pipeline.groovy), the main base file for this job.
-- NOTE: This tester is only really worth running if your code changes affect our groovy code OR Jenkins environment. Otherwise, the [#Build](#Build) jobs are sufficient enough to flag any problems with your code.
+- It first executes [kick_off_tester.groovy](pipelines/build/prTester/kick_off_tester.groovy) which in turn kicks off our [pr_test_pipeline](pipelines/build/prTester/pr_test_pipeline.groovy), then main base file for this job.
+- NOTE: This tester is only really worth running if your code changes affect our groovy code OR Jenkins environment. Otherwise, the [Build](#Build) jobs are sufficient enough to flag any problems with your code.
+- NOTE2: Any PR change made into [kick_off_tester.groovy](pipelines/build/prTester/kick_off_tester.groovy) requires updates in [pipeline-build-check](https://ci.adoptopenjdk.net/job/build-scripts-pr-tester/job/openjdk-build-pr-tester/) asking admin for assistant if you do not have permission to update job config.
 
 #### Usage
 

--- a/pipelines/build/prTester/README.md
+++ b/pipelines/build/prTester/README.md
@@ -6,7 +6,7 @@ The demo pipelines are colloquially known as "The PR Tester" where the others ar
 
 ## When they're used
 
-Except for the [#openjdk-build-pr-tester](#openjdk-build-pr-tester), all of the [test groups](#what-they-are) are executed automatically on every PR and are defined inside the [.github/workflows directory](.github/workflows).
+Except for the [#openjdk-build-pr-tester](#openjdk-build-pr-tester), all of the [test groups](#what they are) are executed automatically on every PR and are defined inside the [.github/workflows directory](.github/workflows).
 These tests lint & compile the code you have altered, as well as executing full JDK builds using your code.
 Every new pull request to this repository that alters any groovy code OR that will likely affect our Jenkins builds should have the PR tester ([#openjdk-build-pr-tester](#openjdk-build-pr-tester)) run on it at least once to verify the changes don't break anything significant inside a Jenkins build environment (documentation changes being excluded from this rule).
 
@@ -14,8 +14,8 @@ Every new pull request to this repository that alters any groovy code OR that wi
 
 There are four "groups" of tests that can be run on each PR:
 
-- [Test](#Test)
-- [openjdk-build-pr-tester](#openjdk-build-pr-tester) (**OPTIONAL, SEE [#When they're used](#When-they're-used)**)
+- GitHub action [Test](#test)
+- Jenkins [openjdk-build-pr-tester](#openjdk-build-pr-tester) (**OPTIONAL, SEE [When they're used](#when they're used)**)
 
 The results of these jobs will appear as [GitHub Status Check Results](https://docs.github.com/en/github/administering-a-repository/about-required-status-checks) at the bottom of the PR being tested:
 ![Image of PR Tester Checks](./images/pr_tester_checks.png)
@@ -35,12 +35,12 @@ cd pipelines/
 ./gradlew --info test
 ```
 
-### openjdk-build-pr-tester
+### Openjdk-build-pr-tester
 
 - **Seen in the PR Status Checks as `pipeline-build-check`, the job is located [here](https://ci.adoptopenjdk.net/job/build-scripts-pr-tester/job/openjdk-build-pr-tester/)**
 - This job runs the a set of [sandbox pipelines](https://ci.adoptopenjdk.net/job/build-scripts-pr-tester/job/build-test/) to test the changes that you have made to our codebase.
 - It first executes [kick_off_tester.groovy](pipelines/build/prTester/kick_off_tester.groovy) which in turn kicks off our [pr_test_pipeline](pipelines/build/prTester/pr_test_pipeline.groovy), then main base file for this job.
-- NOTE: This tester is only really worth running if your code changes affect our groovy code OR Jenkins environment. Otherwise, the [Build](#Build) jobs are sufficient enough to flag any problems with your code.
+- NOTE: This tester is only really worth running if your code changes affect our groovy code OR Jenkins environment. Otherwise, the [Build](https://ci.adoptopenjdk.net/job/build-scripts/) jobs are sufficient enough to flag any problems with your code.
 - NOTE2: Any PR change made into [kick_off_tester.groovy](pipelines/build/prTester/kick_off_tester.groovy) requires updates in [pipeline-build-check](https://ci.adoptopenjdk.net/job/build-scripts-pr-tester/job/openjdk-build-pr-tester/) asking admin for assistant if you do not have permission to update job config.
 
 #### Usage

--- a/pipelines/build/prTester/kick_off_tester.groovy
+++ b/pipelines/build/prTester/kick_off_tester.groovy
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Don't parameterise url as we currently have no need and the job generates its own params anyway
+// Need to set PR's original commit and repo url into downstream job's USER_REMOTE_CONFIGS
 String branch = "${ghprbActualCommit}"
+String gitRemoteConfigs = "${ghprbAuthorRepoGitUrl}"
 String DEFAULTS_FILE_URL = "https://raw.githubusercontent.com/adoptium/ci-jenkins-pipelines/${branch}/pipelines/defaults.json"
 
 // Retrieve User defaults
@@ -25,7 +26,7 @@ if (!DEFAULTS_JSON) {
     throw new Exception("[ERROR] No DEFAULTS_JSON found at ${DEFAULTS_FILE_URL}. Please ensure this path is correct and it leads to a JSON or Map object file.")
 }
 
-String url = DEFAULTS_JSON['repository']['pipeline_url']
+String url = gitRemoteConfigs // DEFAULTS_JSON['repository']['pipeline_url']
 String helperRef = DEFAULTS_JSON['repository']['helper_ref']
 Closure prTest
 

--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -79,6 +79,7 @@ class PullRequestTestPipeline implements Serializable {
         context.node('worker') {
             context.println "loading ${context.WORKSPACE}/${DEFAULTS_JSON['scriptDirectories']['regeneration']}"
             Closure regenerationScript = context.load "${context.WORKSPACE}/${DEFAULTS_JSON['scriptDirectories']['regeneration']}"
+            String actualJavaVersion = ""
 
             javaVersions.each({ javaVersion ->
                 // generate top level job
@@ -98,7 +99,7 @@ class PullRequestTestPipeline implements Serializable {
                     updateRepo = true
                 }
 
-                String actualJavaVersion = updateRepo ? "jdk${javaVersion}u" : "jdk${javaVersion}"
+                actualJavaVersion = updateRepo ? "jdk${javaVersion}u" : "jdk${javaVersion}"
                 def excludedBuilds = ''
 
                 // Generate downstream pipeline jobs

--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -103,7 +103,6 @@ class PullRequestTestPipeline implements Serializable {
                 def excludedBuilds = ''
 
                 // Generate downstream build jobs
-                //TODO
                 regenerationScript(
                     actualJavaVersion,
                     buildConfigurations,
@@ -171,8 +170,7 @@ class PullRequestTestPipeline implements Serializable {
             })
         } // End: node("worker")
 
-        // for debug purpose, stop running job, uncommented later
-        // TODO: context.parallel jobs
+        context.parallel jobs
 
         // Move to "worker" workspace context to perform clean up...
         context.node('worker') {

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -85,7 +85,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
     parameters {
         textParam('targetConfigurations', JsonOutput.prettyPrint(JsonOutput.toJson(targetConfigurations)))
         stringParam('activeNodeTimeout', '0', 'Number of minutes we will wait for a label-matching node to become active.')
-        stringParam('jdkVersion', jdkVersion, 'The JDK version of the pipeline e.g (11, 8, 17).')
+        stringParam('jdkVersion', jdkVersion, 'The JDK version of the pipeline e.g (8, 11, 17).')
         stringParam('dockerExcludes', '', 'Map of targetConfigurations to exclude from docker building. If a targetConfiguration (i.e. { "x64LinuxXL": [ "openj9" ], "aarch64Linux": [ "hotspot", "openj9" ] }) has been entered into this field, jenkins will build the jdk without using docker. This param overrides the dockerImage and dockerFile downstream job parameters.')
         stringParam('baseFilePath', '', "Relative path to where the build_base_file.groovy file is located. This runs the downstream job setup and configuration retrieval services.<br>Default: <code>${defaultsJson['baseFileDirectories']['upstream']}</code>")
         stringParam('buildConfigFilePath', '', "Relative path to where the jdkxx_pipeline_config.groovy file is located. It contains the build configurations for each platform, architecture and variant.<br>Default: <code>${defaultsJson['configDirectories']['build']}/jdkxx_pipeline_config.groovy</code>")


### PR DESCRIPTION
main change is in 
pipelines/build/prTester/kick_off_tester.groovy
pipelines/build/prTester/pr_test_pipeline.groovy
pipelines/build/common/openjdk_build_pipeline.groovy => updateGitHubcommitStatus()

 - disable some options which not need for pr-tests
- set ghprbAuthorRepoGitUrl into "USER_REMOTE_CONFIGS" as remote url
- use upstream git repo when update github commit status

rest are: 
- fixed linter error in README
- fixed variable scope problem: `hudson.remoting.ProxyException: groovy.lang.MissingPropertyException: No such property: actualJavaVersion for class: PullRequestTestPipeline`

Fixes: https://github.com/adoptium/ci-jenkins-pipelines/issues/507