### PR TITLE
feat: add function for generate release pipeline

### DIFF
--- a/.github/linters/.groovylintrc.json
+++ b/.github/linters/.groovylintrc.json
@@ -14,7 +14,7 @@
       "maxNestedBlockDepth": 12
     },
     "size.ParameterCount": {
-      "maxParameters": 18
+      "maxParameters": 19
     },
     "name.ParameterName": "off",
     "name.PropertyName": "off",

--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -47,6 +47,7 @@ class Regeneration implements Serializable {
     private final jenkinsCreds
     private final checkoutCreds
     private final Boolean prBuilder
+    private final Boolean isReleaseBuilder
 
     private String javaToBuild
     private final List<String> defaultTestList = ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external']
@@ -74,7 +75,8 @@ class Regeneration implements Serializable {
         String jenkinsBuildRoot,
         String jenkinsCreds,
         String checkoutCreds,
-        Boolean prBuilder
+        Boolean prBuilder,
+        Boolean isReleaseBuilder
     ) {
         this.javaVersion = javaVersion
         this.buildConfigurations = buildConfigurations
@@ -94,6 +96,7 @@ class Regeneration implements Serializable {
         this.jenkinsCreds = jenkinsCreds
         this.checkoutCreds = checkoutCreds
         this.prBuilder = prBuilder
+        this.isReleaseBuilder = isReleaseBuilder
     }
 
     /*
@@ -586,7 +589,7 @@ class Regeneration implements Serializable {
     }
 
     /**
-    * Main function. Ran from build_job_generator.groovy, this will be what jenkins will run first.
+    * Main function. Ran from pipelines/build/regeneration/build_job_generator.groovy, this will be what jenkins will run first.
     */
     @SuppressWarnings('unused')
     def regenerate() {
@@ -685,9 +688,12 @@ class Regeneration implements Serializable {
                                 keyFound = true
 
                                 def platformConfig = buildConfigurations.get(key) as Map<String, ?>
-
+                                // nightly job name
                                 name = "${platformConfig.os}-${platformConfig.arch}-${variant}"
-
+                                // release job name
+                                if (isReleaseBuilder) {
+                                    name = "release-"+name
+                                }
                                 if (platformConfig.containsKey('additionalFileNameTag')) {
                                     name += "-${platformConfig.additionalFileNameTag}"
                                 }

--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -120,7 +120,8 @@ class PullRequestTestPipeline implements Serializable {
                     'https://ci.adoptopenjdk.net/job/build-scripts-pr-tester/job/build-test',
                     null,
                     null,
-                    true
+                    true,
+                    false
                 ).regenerate()
 
                 context.println "[SUCCESS] Regeneration on ${javaVersion} all done!"

--- a/pipelines/build/regeneration/build_job_generator.groovy
+++ b/pipelines/build/regeneration/build_job_generator.groovy
@@ -16,7 +16,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/* This script is the pipeline script for creating jobs via pipeline_jobs_generator_jdkX */
+/*
+    File used for generate downstream build jobs which are triggered by via [release_]pipeline_jobs_generator_jdkX, e.g:
+    - build-scripts/jobs/jdk11u/jdk11u-linux-arm-temurin
+    - build-scripts/release/jobs/release-jdk17u-mac-x64-temurin
+    - build-scripts-pr-tester/build-test/jobs/jdk19u/jdk19u-alpine-linux-x64-temurin
+*/
 
 String javaVersion = params.JAVA_VERSION
 String ADOPT_DEFAULTS_FILE_URL = 'https://raw.githubusercontent.com/adoptium/ci-jenkins-pipelines/master/pipelines/defaults.json'

--- a/pipelines/build/regeneration/build_job_generator.groovy
+++ b/pipelines/build/regeneration/build_job_generator.groovy
@@ -18,9 +18,9 @@ limitations under the License.
 
 /*
     File used for generate downstream build jobs which are triggered by via [release_]pipeline_jobs_generator_jdkX, e.g:
-    - build-scripts/jobs/jdk11u/jdk11u-linux-arm-temurin
-    - build-scripts/release/jobs/release-jdk17u-mac-x64-temurin
-    - build-scripts-pr-tester/build-test/jobs/jdk19u/jdk19u-alpine-linux-x64-temurin
+    - build-scripts/jobs/jdk11u/jdk11u-linux-arm-temurin (when isReleaseBulider = false)
+    - build-scripts/release/jobs/release-jdk17u-mac-x64-temurin (when isReleaseBulider = true)
+    - build-scripts-pr-tester/build-test/jobs/jdk19u/jdk19u-alpine-linux-x64-temurin (when isReleaseBulider = false)
 */
 
 String javaVersion = params.JAVA_VERSION
@@ -132,6 +132,12 @@ node('worker') {
 
         // Pull in other parametrised values (or use defaults if they're not defined)
         def jobRoot = (params.JOB_ROOT) ?: DEFAULTS_JSON['jenkinsDetails']['rootDirectory']
+        // handle release downstream job
+        Boolean isReleaseBuilder = false
+        if (jobRoot.contains('release')) {
+            isReleaseBuilder = true
+        }
+
         def jenkinsBuildRoot = (params.JENKINS_BUILD_ROOT) ?: "${DEFAULTS_JSON['jenkinsDetails']['rootUrl']}/job/${jobRoot}/"
 
         def jobTemplatePath = (params.JOB_TEMPLATE_PATH) ?: DEFAULTS_JSON['templateDirectories']['downstream']
@@ -181,6 +187,7 @@ node('worker') {
         println "BASE FILE PATH: $baseFilePath"
         println "EXCLUDES LIST: $excludes"
         println "SLEEP_TIME: $sleepTime"
+        println "IS RELEASE JOB:  $isReleaseBuilder" 
         if (jenkinsCreds == '') { println '[WARNING] No Jenkins API Credentials have been provided! If your server does not have anonymous read enabled, you may encounter 403 api request error codes.' }
 
         // Load regen script and execute base file
@@ -220,7 +227,8 @@ node('worker') {
           jenkinsBuildRoot,
           jenkinsCredentials,
           checkoutCreds,
-          false
+          false,
+          isReleaseBuilder
         ).regenerate()
       }
     } else {
@@ -242,7 +250,8 @@ node('worker') {
         jenkinsBuildRoot,
         jenkinsCreds,
         checkoutCreds,
-        false
+        false,
+        isReleaseBuilder
       ).regenerate()
         }
 

--- a/pipelines/build/regeneration/release_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/release_pipeline_generator.groovy
@@ -36,7 +36,7 @@ node('worker') {
             String pipelineUrl = "https://github.com/adoptium/ci-jenkins-pipelines.git"
             def releaseTag = params.releaseTag
 
-            String helperRef = "https://github.com/adoptium/jenkins-helper.git"
+            String helperRef = params.helperTag ?: params.releaseTag
             library(identifier: "openjdk-jenkins-helper@${helperRef}")
 
             // set where generated jobs will be located in the Jenkins

--- a/pipelines/build/regeneration/release_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/release_pipeline_generator.groovy
@@ -1,0 +1,11 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Hello') {
+            steps {
+                echo 'Hello Worlds'
+            }
+        }
+    }
+}

--- a/pipelines/build/regeneration/release_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/release_pipeline_generator.groovy
@@ -1,11 +1,133 @@
-pipeline {
-    agent any
+import java.nio.file.NoSuchFileException
+import groovy.json.JsonSlurper
+import groovy.json.JsonOutput
 
-    stages {
-        stage('Hello') {
-            steps {
-                echo 'Hello Worlds'
+// ensure releaseVersions is updated before create releaseTag
+def releaseVersions = [19] // TODO enable full list when testing done [8,11,17,19]
+
+
+// Regenerate release-openjdkX-pipeline per each jdk version listed in releaseVersions
+node('worker') {
+    try{
+        /*
+            use releaseTag's defaults.json for adoptDefaultsJson and defaultsJson
+            do not really need to set both,
+            but to make jobTemplatePath can handle nightly and release pipeline the same way
+        */
+        String ADOPT_DEFAULTS_FILE_URL = "https://raw.githubusercontent.com/adoptium/ci-jenkins-pipelines/${params.releaseTag}/pipelines/defaults.json"
+
+        // Pull in upstream origin ci-jenkins-pipeline defaults json config
+        def getAdopt = new URL(ADOPT_DEFAULTS_FILE_URL).openConnection()
+        Map<String, ?> ADOPT_DEFAULTS_JSON = new JsonSlurper().parseText(getAdopt.getInputStream().getText()) as Map
+        if (!ADOPT_DEFAULTS_JSON || !Map.isInstance(ADOPT_DEFAULTS_JSON)) {
+            throw new Exception("[ERROR] No ADOPT_DEFAULTS_JSON found at ${ADOPT_DEFAULTS_FILE_URL} or it is not a valid JSON object. Please ensure this path is correct and leads to a JSON or Map object file. NOTE: Since this adopt's defaults and unlikely to change location, this is likely a network or GitHub issue.")
+        }
+
+        // Pull in User's defined json config
+        String DEFAULTS_FILE_URL = (params.DEFAULTS_URL) ?: ADOPT_DEFAULTS_FILE_URL
+        def getUser = new URL(DEFAULTS_FILE_URL).openConnection()
+        Map<String, ?> DEFAULTS_JSON = new JsonSlurper().parseText(getUser.getInputStream().getText()) as Map
+        if (!DEFAULTS_JSON || !Map.isInstance(DEFAULTS_JSON)) {
+            throw new Exception("[ERROR] No DEFAULTS_JSON found at ${DEFAULTS_FILE_URL} or it is not a valid JSON object. Please ensure this path is correct and leads to a JSON or Map object file.")
+        }
+
+        def checkoutAdoptPipelines = { ->
+            checkout([$class: 'GitSCM',
+                branches: [ [ name: params.releaseTag ] ],
+                userRemoteConfigs: [ [ url: "https://github.com/adoptium/ci-jenkins-pipelines.git" ] ]
+            ])
+        }
+        timestamps {
+            def generatedPipelines = []
+
+            String pipelineUrl = "https://github.com/adoptium/ci-jenkins-pipelines.git"
+            def releaseTag = params.releaseTag
+
+            String helperRef = "https://github.com/adoptium/jenkins-helper.git"
+            library(identifier: "openjdk-jenkins-helper@${helperRef}")
+
+            // set where generated jobs will be located in the Jenkins
+            def jobRoot = "build-scripts/job/release/"
+            // set where our generation scripts should be located in the ci-jenkins-pipeline repo
+            def scriptFolderPath = "pipelines/build"
+            // set downstream jobs template path in ci-jenkins-pipleine repo
+            def jobTemplatePath = "pipelines/jobs/release_pipeline_job_template.groovy"
+            // set where release testconfig should be read out from
+            def releaseConfigPath = "pipelines/jobs/configurations"
+
+            println '[INFO] Running official release generator script with the following configuration:'
+            println "REPOSITORY_URL = ${pipelineUrl}"
+            println "REPOSITORY_TAG = ${releaseTag}"
+            println "JOB_ROOT = ${jobRoot}"
+            println "SCRIPT_FOLDER_PATH = ${scriptFolderPath}"
+            println "RELEASE_CONFIG_PATH = ${releaseConfigPath}"
+            println "JOB_TEMPLATE_PATH = ${jobTemplatePath}"
+            println "ENABLE_PIPELINE_SCHEDULE = false"
+            println "USE_ADOPT_SHELL_SCRIPTS = false"
+
+            releaseVersions.each({ javaVersion ->
+                def config = [
+                    TEST                        : false,
+                    GIT_URL                     : pipelineUrl,
+                    releaseTag                  : releaseTag,
+                    BUILD_FOLDER                : jobRoot,
+                    CHECKOUT_CREDENTIALS        : "",
+                    JAVA_VERSION                : javaVersion,
+                    JOB_NAME                    : "release-openjdk${javaVersion}-pipeline",
+                    SCRIPT                      : "${scriptFolderPath}/openjdk_pipeline.groovy",
+                    adoptScripts                : false
+                ]
+
+                def target
+                try {
+                    target = load "${WORKSPACE}/${releaseConfigPath}/jdk${javaVersion}u_release.groovy"
+                } catch (NoSuchFileException e) {
+                    try {
+                        println "[WARNING] jdk${javaVersion}u_release.groovy does not exist, chances are we want a jdk${javaVersion}_release.groovy file. Trying ${WORKSPACE}/${releaseConfigPath}/jdk${javaVersion}_release.groovy"
+                        target = load "${WORKSPACE}/${releaseConfigPath}/jdk${javaVersion}_release.groovy"
+                    } catch (NoSuchFileException e2) {
+                         throw new Exception("[ERROR] jdk${javaVersion}_release.groovy does not exist too.... Horrible!"
+                    }
+                }
+
+                config.put('targetConfigurations', target.targetConfigurations)
+
+                config.put('defaultsJson', DEFAULTS_JSON)
+                config.put('adoptDefaultsJson', ADOPT_DEFAULTS_JSON)
+
+                println "[INFO] FINAL CONFIG FOR RELEASE JDK${javaVersion}"
+                println JsonOutput.prettyPrint(JsonOutput.toJson(config))
+
+                // Create the release job
+                try {
+                    jobDsl targets: jobTemplatePath, ignoreExisting: false, additionalParameters: config
+                } catch (Exception e) {
+                    throw new Exception("[ERROR] Something went wrong when creating the job dsl for jdk${javaVersion}..."
+                }
+                target.disableJob = false
+                // add sucessfully generated pipeline into list
+                generatedPipelines.add(config['JOB_NAME'])
+            })
+
+            // Fail if nothing was generated
+            if (generatedPipelines == []) {
+                throw new Exception('[ERROR] NO PIPELINES WERE GENERATED!')
+            } else {
+                println "[SUCCESS] THE FOLLOWING PIPELINES WERE GENERATED IN THE ${jobRoot} FOLDER"
+                println generatedPipelines
             }
         }
+    } finally {
+        // Always clean up, even on failure (doesn't delete the created jobs)
+        println '[INFO] Cleaning up...'
+        cleanWs deleteDirs: true
     }
+}
+
+// Calling release-pipeline_jobs_generator_jdk11X per each jdk version listed in releaseVersions
+node('worker') {
+    releaseVersions.each({ javaVersion ->
+        def jobName = "releasepipeline/release_pipeline_jobs_generator_jdk${javaVersion}u"
+        def testJob = build job: jobName, propagate: false, wait: true, parameters: [['$class': 'StringParameterValue', name: 'REPOSITORY_BRANCH', value: params.releaseTag]]
+    })
 }

--- a/pipelines/jobs/configurations/jdk11u_release.groovy
+++ b/pipelines/jobs/configurations/jdk11u_release.groovy
@@ -1,0 +1,15 @@
+targetConfigurations = [
+        'x64Mac'        : [    'temurin'],
+        'x64Linux'      : [    'temurin'],
+        'x64AlpineLinux': [    'temurin'],
+        'x64Windows'    : [    'temurin'],
+        'x32Windows'    : [    'temurin'],
+        'ppc64Aix'      : [    'temurin'],
+        'ppc64leLinux'  : [    'temurin'],
+        's390xLinux'    : [    'temurin'],
+        'aarch64Linux'  : [    'temurin'],
+        'aarch64Mac'    : [    'temurin'],
+        'arm32Linux'    : [    'temurin']
+]
+
+return this

--- a/pipelines/jobs/configurations/jdk17u_release.groovy
+++ b/pipelines/jobs/configurations/jdk17u_release.groovy
@@ -1,0 +1,33 @@
+targetConfigurations = [
+        'x64Mac'      : [
+                'temurin'
+        ],
+        'x64Linux'    : [
+                'temurin'
+        ],
+        'x64AlpineLinux' : [
+                'temurin'
+        ],
+        'x64Windows'  : [
+                'temurin'
+        ],
+        'x32Windows'  : [
+                'temurin'
+        ],
+        'ppc64leLinux': [
+                'temurin'
+        ],
+        's390xLinux'  : [
+                'temurin'
+        ],
+        'aarch64Linux': [
+                'temurin'
+        ],
+        'aarch64Mac': [
+                'temurin'
+        ],
+        'arm32Linux'  : [
+                'temurin'
+        ]
+]
+return this

--- a/pipelines/jobs/configurations/jdk19u_release.groovy
+++ b/pipelines/jobs/configurations/jdk19u_release.groovy
@@ -1,0 +1,37 @@
+targetConfigurations = [
+        'x64Mac'      : [
+                'temurin'
+        ],
+        'x64Linux'    : [
+                'temurin'
+        ],
+        'x64AlpineLinux' : [
+                'temurin'
+        ],
+        'x64Windows'  : [
+                'temurin'
+        ],
+        'x32Windows'  : [
+                'temurin'
+        ],
+        'ppc64leLinux': [
+                'temurin'
+        ],
+        's390xLinux'  : [
+                'temurin'
+        ],
+        'aarch64Linux': [
+                'temurin'
+        ],
+        'aarch64AlpineLinux' : [
+                'temurin'
+        ],
+        'aarch64Mac': [
+                'temurin'
+        ],
+        'arm32Linux'  : [
+                'temurin'
+        ]
+]
+
+return this

--- a/pipelines/jobs/configurations/jdk8u_release.groovy
+++ b/pipelines/jobs/configurations/jdk8u_release.groovy
@@ -1,0 +1,40 @@
+targetConfigurations = [
+        'x64Mac'        : [
+                'temurin'
+        ],
+        'x64Linux'      : [
+                'temurin'
+        ],
+        'x64AlpineLinux' : [
+                'temurin'
+        ],
+        'x32Windows'    : [
+                'temurin'
+        ],
+        'x64Windows'    : [
+                'temurin'
+        ],
+        'ppc64Aix'      : [
+                'temurin'
+        ],
+        'ppc64leLinux'  : [
+                'temurin'
+        ],
+        's390xLinux'    : [
+                'temurin'
+        ],
+        'aarch64Linux'  : [
+                'temurin'
+        ],
+        'arm32Linux'  : [
+                'temurin'
+        ],
+        'x64Solaris': [
+                'temurin'
+        ],
+        'sparcv9Solaris': [
+                'temurin'
+        ]
+]
+
+return this

--- a/pipelines/jobs/release_pipeline_job_template.groovy
+++ b/pipelines/jobs/release_pipeline_job_template.groovy
@@ -1,0 +1,99 @@
+import groovy.json.JsonOutput
+
+gitRefSpec = ''
+propagateFailures = false
+runTests = true
+runParallel = true
+runInstaller = true
+runSigner = true
+cleanWsBuildOutput = true
+isLightweight = true
+
+folder("${BUILD_FOLDER}")
+folder("${BUILD_FOLDER}/jobs")
+
+pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
+    description('<h1>THIS IS AN AUTOMATICALLY GENERATED JOB DO NOT MODIFY, IT WILL BE OVERWRITTEN.</h1><p>This job is defined in release_pipeline_job_template.groovy in the ci-jenkins-pipelines repo, if you wish to change it modify that.</p>')
+    definition {
+        cpsScm {
+            scm {
+                git {
+                    remote {
+                        url("${GIT_URL}")
+                        refspec("${BgitRefSpec}")
+                    }
+                    branch("${releaseTag}")
+                }
+            }
+            scriptPath("${SCRIPT}")
+            lightweight("${isLightweight}")
+        }
+    }
+    disabled(false)
+
+    logRotator {
+        numToKeep(60)
+        artifactNumToKeep(2)
+    }
+
+    properties {
+        // Hide top level pipeline access from the public as they contain non Temurin artefacts
+        authorizationMatrix {
+            inheritanceStrategy {
+                // Do not inherit permissions from global configuration
+                nonInheriting()
+            }
+            permissions(['hudson.model.Item.Build:AdoptOpenJDK*build', 'hudson.model.Item.Build:AdoptOpenJDK*build-triage',
+            'hudson.model.Item.Cancel:AdoptOpenJDK*build', 'hudson.model.Item.Cancel:AdoptOpenJDK*build-triage',
+            'hudson.model.Item.Configure:AdoptOpenJDK*build', 'hudson.model.Item.Configure:AdoptOpenJDK*build-triage',
+            'hudson.model.Item.Read:AdoptOpenJDK*build', 'hudson.model.Item.Read:AdoptOpenJDK*build-triage',
+            // eclipse-temurin-bot needs read access for TRSS
+            'hudson.model.Item.Read:eclipse-temurin-bot',
+            // eclipse-temurin-compliance bot needs read access for https://ci.eclipse.org/temurin-compliance
+            'hudson.model.Item.Read:eclipse-temurin-compliance-bot',
+            'hudson.model.Item.Workspace:AdoptOpenJDK*build', 'hudson.model.Item.Workspace:AdoptOpenJDK*build-triage',
+            'hudson.model.Run.Update:AdoptOpenJDK*build', 'hudson.model.Run.Update:AdoptOpenJDK*build-triage'])
+        }
+        copyArtifactPermission {
+            projectNames('*')
+        }
+    }
+
+    parameters {
+        // important items to verify before trigger release pipeline
+        textParam('targetConfigurations', JsonOutput.prettyPrint(JsonOutput.toJson(targetConfigurations)))
+        stringParam('releaseType', 'Release', "only for release purpose")
+        booleanParam('useAdoptBashScripts', false, "If enabled, the downstream job will pull and execute <code>make-adopt-build-farm.sh</code> from adoptium/temurin-build. If disabled, it will use whatever the job is running inside of at the time, usually it's the default repository in the configuration.")
+        tringParam('scmReference', "${releaseTag}", 'Tag name or Branch name from which openjdk source code repo to build. Nightly builds: Defaults to, Hotspot=dev, OpenJ9=openj9, others=master.</br>Release builds: For hotspot JDK8 this would be the OpenJDK tag, for hotspot JDK11+ this would be the Adopt merge tag for the desired OpenJDK tag eg.jdk-11.0.4+10_adopt, and for OpenJ9 this will be the release branch, eg.openj9-0.14.0.')
+        stringParam('buildReference', "${releaseTag}", 'SHA1 or Tag name or Branch name of temurin-build repo. Defaults to master')
+        stringParam('ciReference', "${releaseTag}", 'SHA1 or Tag name or Branch name of ci-jenkins-pipeline repo. Defaults to master')
+        stringParam('helperReference', "${releaseTag}", 'Tag name or Branch name of jenkins-helper repo. Defaults to master')
+        stringParam('aqaReference', '', 'Tag name or Branch name of aqa-tests. Defaults to master')
+        // special items need to modify per jdk8
+        stringParam('overridePublishName', '', 'Most useful for jdk8 arm32 with a different scmReference tag')
+        stringParam('additionalConfigureArgs', "--without-version-pre --without-version-opt", "Additional arguments that will be ultimately passed to OpenJDK's <code>./configure</code>")
+
+        // default value not matter for release
+        stringParam('jdkVersion', "${JAVA_VERSION}")
+        stringParam('activeNodeTimeout', '0', 'Number of minutes we will wait for a label-matching node to become active.')
+        stringParam('dockerExcludes', '', 'Map of targetConfigurations to exclude from docker building. If a targetConfiguration (i.e. { "x64LinuxXL": [ "openj9" ], "aarch64Linux": [ "hotspot", "openj9" ] }) has been entered into this field, jenkins will build the jdk without using docker. This param overrides the dockerImage and dockerFile downstream job parameters.')
+        stringParam('baseFilePath', '', "Relative path to where the build_base_file.groovy file is located. This runs the downstream job setup and configuration retrieval services.<br>Default: <code>${defaultsJson['baseFileDirectories']['upstream']}</code>")
+        stringParam('buildConfigFilePath', '', "Relative path to where the jdkxx_pipeline_config.groovy file is located. It contains the build configurations for each platform, architecture and variant.<br>Default: <code>${defaultsJson['configDirectories']['build']}/jdkxx_pipeline_config.groovy</code>")
+        booleanParam('aqaAutoGen', false, 'If set to true, force auto generate AQA test jobs. Defaults to false')
+        booleanParam('enableTests', runTests, 'If set to true the test pipeline will be executed')
+        booleanParam('enableTestDynamicParallel', runParallel, 'If set to true test will be run parallel')
+        booleanParam('enableInstallers', runInstaller, 'If set to true the installer pipeline will be executed')
+        booleanParam('enableSigner', runSigner, 'If set to true the signer pipeline will be executed')
+        stringParam('additionalBuildArgs', '', 'Additional arguments to be passed to <code>makejdk-any-platform.sh</code>')
+        stringParam('overrideFileNameVersion', '', "When forming the filename, ignore the part of the filename derived from the publishName or timestamp and override it.<br/>For instance if you set this to 'FOO' the final file name will be of the form: <code>OpenJDK8U-jre_ppc64le_linux_openj9_FOO.tar.gz</code>")
+        booleanParam('cleanWorkspaceBeforeBuild', false, 'Clean out the workspace before the build')
+        booleanParam('cleanWorkspaceAfterBuild', false, 'Clean out the workspace after the build')
+        booleanParam('cleanWorkspaceBuildOutputAfterBuild', cleanWsBuildOutput, 'Clean out the workspace/build/src/build and workspace/target output only, after the build')
+        booleanParam('propagateFailures', propagateFailures, 'If true, a failure of <b>ANY</b> downstream build (but <b>NOT</b> test) will cause the whole build to fail')
+        booleanParam('keepTestReportDir', false, 'If true, test report dir (including core files where generated) will be kept even when the testcase passes, failed testcases always keep the report dir. Does not apply to JUnit jobs which are always kept, eg.openjdk.')
+        booleanParam('keepReleaseLogs', true, 'If true, "Release" type pipeline Jenkins logs will be marked as "Keep this build forever".')
+        stringParam('adoptBuildNumber', '', 'Empty by default. If you ever need to re-release then bump this number. Currently this is only added to the build metadata file.')
+        textParam('defaultsJson', JsonOutput.prettyPrint(JsonOutput.toJson(defaultsJson)), '<strong>DO NOT ALTER THIS PARAM UNLESS YOU KNOW WHAT YOU ARE DOING!</strong> This passes down the user\'s default constants to the downstream jobs.')
+        textParam('adoptDefaultsJson', JsonOutput.prettyPrint(JsonOutput.toJson(adoptDefaultsJson)), '<strong>DO NOT ALTER THIS PARAM UNDER ANY CIRCUMSTANCES!</strong> This passes down adoptium\'s default constants to the downstream jobs. NOTE: <code>defaultsJson</code> has priority, the constants contained within this param will only be used as a failsafe.')
+    }
+}


### PR DESCRIPTION
**NO NEED REVIEW THIS PR, IT IS FOR TESTING IN A FEATURE BRANCH**


Generate new seed jobs in Jenkins
- release-build-pipeline-generator: to create release pipeline "release-openjdkX-pipeline" with mini input parameters required by official release build
- release_pipeline_jobs_generator_jdkXu: to create downstream build jobs "release-jdkXu-<arch>-<os>-<variant>"




REF: [#3163](https://github.com/adoptium/temurin-build/issues/3163)