### PR TITLE
Rewritten asmtool builder

### DIFF
--- a/tools/code-tools/Jenkinsfile
+++ b/tools/code-tools/Jenkinsfile
@@ -38,7 +38,7 @@ def build(stageName) {
             checkout scm
             checkout([$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: "${stageName}"]], submoduleCfg: [], userRemoteConfigs: [[url: "https://github.com/openjdk/${stageName}"]]])
             sh label: "${stageName}", script: "./tools/code-tools/${stageName}.sh"
-            archiveArtifacts artifacts: "${stageName}/*.tar.gz, ${stageName}/${stageName}.jar, ${stageName}/${stageName}.jar.*.txt, ${stageName}/*.tar.gz.*sum*.txt", followSymlinks: false
+            archiveArtifacts artifacts: "${stageName}/*.tar.gz, ${stageName}/${stageName}*.jar, ${stageName}/${stageName}*.jar.*.txt, ${stageName}/*.tar.gz.*sum*.txt", followSymlinks: false
         } catch (Exception e) {
             slackSend channel: 'jenkins', color: 'danger', message: "${env.JOB_NAME} : #${env.BUILD_NUMBER} : ${stageName}() FAILED with following error message:\n${e}", teamDomain: 'adoptium'
             throw new Exception("[ERROR] ${stageName} FAILED\n${e}")

--- a/tools/code-tools/asmtools.sh
+++ b/tools/code-tools/asmtools.sh
@@ -1,80 +1,58 @@
+
 #!/bin/bash
 # shellcheck disable=SC2035,SC2155
-set -eu
+set -euo pipefail
+WORKSPACE=$PWD
 
 function generateArtifact() {
-    tag=$1
-    version=$2
-
-    echo "tag=$tag"
-    echo "version=$version"
-
-    artifact=asmtools-$version
-
-    tagName=$(git describe --tags "$(git rev-list --tags --max-count=1)")
-    echo "Tag: ${tagName}"
-
-    git checkout "${tagName}"
-
-    # In WORKSPACE until here
-    echo "Moving into build..."
-    cd build
-
-    perl -p -i -e 's/"9"/"1.8"/g' build.xml
-
-    export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
-
-    echo "Building asmtools"
-
-    ant build
-
-    # WORKSPACE/asmtools/build/BUILD_DIR
-    echo "Moving down to ${BUILD_DIR}"
-    cd "${BUILD_DIR}"
-
-    echo "Asmtools artifact = $artifact"
-
-    echo "Copying release/lib/asmtools*.jar file to ../"
-    cp release/lib/asmtools*.jar ..
-
-    # WORKSPACE/asmtools/build/BUILD_DIR/dist
-    echo "Moving into $artifact-build/dist"
-    cd dist
-
-    echo "tar-ing ${artifact}.zip into ${artifact}.tar"
-    tar fcv "$artifact.tar" *.zip
-
-    echo "Moving ${artifact}.tar to ../.."
-    mv "$artifact.tar" ../..
-    # WORKSPACE/asmtools/build/
-    cd ../..
-
-    echo "gzipping ${artifact}.tar"
-    gzip -9 -f "${artifact}.tar"
-
-    if [ -d "$artifact-build" ];
-    then
-        mv "$artifact-build" asmtools/
-    fi
-
-    echo "Creating checksums for asmtools.jar and ${artifact}.tar.gz"
-    sha256sum asmtools.jar > asmtools.jar.sha256sum.txt
-    sha256sum "${artifact}.tar.gz" > "${artifact}.tar.gz.sha256sum.txt"
-
-    echo "Moving into asmtools"
-    cd asmtools
+    local  branchOrTag=$1
+    export JAVA_HOME=$2
+    git checkout $branchOrTag
+    echo "Moving into maven build..."
+    pushd maven
+      #export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8 -Xdoclint:none -Dmaven.javadoc.skip=true -Dgpg.skip"
+      echo "Generating asmtools maven wrapper"
+      sh mvngen.sh
+      echo "Cleaning possible previous run"
+      mvn clean
+      echo "Running asmtools tests"
+      mvn test || echo "Test now correctly fails, this have to be fixed upstream"
+      echo "Running asmtools build"
+      mvn package -DskipTests # mvn install will do much more, but I doubt we wish that (javadoc, sources, gpg sign...)
+      echo "Moving down to target"
+      pushd target
+        echo "Asmtools artifact:"
+        ls -l
+        local mainArtifact=`ls asmtools*.jar`
+        echo "Copying maven/target/$mainArtifact file to WORKSPACE($WORKSPACE)"
+        cp  $mainArtifact $WORKSPACE
+        if [ -e surefire-reports ] ; then
+          local testResults=`echo $mainArtifact | sed "s/.jar/-tests.tar.gz/"`
+          echo "Compressing and archiving test results as $testResults"
+          tar -czf $testResults surefire-reports
+          echo "Copying maven/target/$testResults file to WORKSPACE($WORKSPACE)"
+          cp  $testResults $WORKSPACE
+        else
+          echo "No test results!"
+        fi
+      popd
+    popd
 }
 
-cd asmtools
+if [ ! -e asmtools ] ; then
+  git clone https://github.com/openjdk/asmtools.git
+fi
 
-export PRODUCT_VERSION=$(grep "PRODUCT_VERSION     \= " build/productinfo.properties | awk '{print $3}')
-# shellcheck disable=SC2005,SC2046
-export BUILD_DIR=$(echo $(eval echo $(grep "BUILD_DIR = " build/build.properties | awk '{print $3}')))
+pushd asmtools
+  latestRelease=`git tag -l | tail -n 2 | head -n 1`
+  generateArtifact "master" /usr/lib/jvm/java-1.8.0-openjdk
+  generateArtifact "at8" /usr/lib/jvm/java-17-openjdk
+  # 7.0-b09 had not yet have maven integration, enable with b10 out
+  # generateArtifact "$latestRelease" /usr/lib/jvm/java-1.8.0-openjdk 
+popd
 
-generateArtifact "tip" "${PRODUCT_VERSION}"
+echo "Creating checksums all asmtools*.jar"
+for file in `ls asmtools*.jar asmtools*-tests.tar.gz` ; do
+    sha256sum $file > $file.sha256sum.txt
+done
 
-cd ..
-mv *.jar.sha256sum.txt asmtools
-mv *.tar.gz.sha256sum.txt asmtools
-mv *.jar asmtools
-mv *.tar.gz asmtools


### PR DESCRIPTION
currently fails javadoc (thus skipped)
using pushd/popd instead of cd/cd ..
builds both master branch and developer branch. Ready to  build released tag.
Archiving test results
sets -o pipefails
added asmtool8