### PR TITLE
Launch Temurin aix remoteJckTrigger for jdk19+ with sw.os.aix.7_2

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -485,11 +485,7 @@ class Build {
         def parallel = 'None'
         def num_machines = '1'
         def remoteTargets = [:]
-        def additionalLabel = ''
-        if (jdkVersion >= 19 && platform == 'ppc64_aix') {
-                // Jck19+ AIX must run on AIX 7.2
-                additionalLabel = 'sw.os.aix.7_2'
-        }
+        def additionalTestLabel = buildConfig.ADDITIONAL_TEST_LABEL
 
         targets.each { target ->
             // For each requested test, i.e 'sanity.jck', 'extended.jck', 'special.jck', call test job
@@ -510,7 +506,7 @@ class Build {
                                                                 context.MapParameter(name: 'PARALLEL', value: parallel),
                                                                 context.MapParameter(name: 'NUM_MACHINES', value: "${num_machines}"),
                                                                 context.MapParameter(name: 'PLATFORMS', value: "${platform}"),
-                                                                context.MapParameter(name: 'LABEL_ADDITION', value: additionalLabel)]),
+                                                                context.MapParameter(name: 'LABEL_ADDITION', value: additionalTestLabel)]),
                         remoteJenkinsName: 'temurin-compliance',
                         shouldNotFailBuild: true,
                         token: 'RemoteTrigger',

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1812,7 +1812,7 @@ class Build {
                             if (buildConfig.ARCHITECTURE.contains('x64')) {
                                 platform = 'x86-64_' + buildConfig.TARGET_OS
                             } else {
-                                platform = config.buildConfig.ARCHITECTURE + '_' + buildConfig.TARGET_OS
+                                platform = buildConfig.ARCHITECTURE + '_' + buildConfig.TARGET_OS
                             }           
                             if ( !(platform  == 'riscv64_linux' || platform =='aarch64_windows') ) {
                                 if ( !(buildConfig.JAVA_TO_BUILD == 'jdk8u' && platform == 's390x_linux') ) {

--- a/pipelines/jobs/configurations/jdk19u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk19u_pipeline_config.groovy
@@ -89,7 +89,7 @@ class Config19 {
                 ],
                 test                : 'default',
                 additionalTestLabels: [
-                        temurin      : 'aix720'
+                        temurin      : 'sw.os.aix.7_2'
                 ],
                 cleanWorkspaceAfterBuild: true,
                 buildArgs           : [

--- a/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
@@ -89,7 +89,7 @@ class Config20 {
                 ],
                 test                : 'default',
                 additionalTestLabels: [
-                        temurin      : 'aix720'
+                        temurin      : 'sw.os.aix.7_2'
                 ],
                 cleanWorkspaceAfterBuild: true,
                 buildArgs           : [


### PR DESCRIPTION
Launch the AIX jdk19+ jck remote trigger with sw.os.aix.7_2

Also fixes failure to launch for non-x64 platforms.

Fixes: https://github.com/adoptium/ci-jenkins-pipelines/issues/521
