### PR TITLE
update: remove aarch32 jdk8 from release-pipeline default setting

### DIFF
--- a/pipelines/build/regeneration/release_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/release_pipeline_generator.groovy
@@ -90,7 +90,7 @@ node('worker') {
                 config.put('defaultsJson', DEFAULTS_JSON)
                 config.put('adoptDefaultsJson', ADOPT_DEFAULTS_JSON)
 
-                if(${javaVersion} != "8") { // for jdk11+, need extra config args to pass down
+                if(${javaVersion} >= "11") { // for jdk11+, need extra config args to pass down
                     config.put('additionalConfigureArgs', "--without-version-pre --without-version-opt")
                 }
 

--- a/pipelines/build/regeneration/release_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/release_pipeline_generator.groovy
@@ -90,6 +90,10 @@ node('worker') {
                 config.put('defaultsJson', DEFAULTS_JSON)
                 config.put('adoptDefaultsJson', ADOPT_DEFAULTS_JSON)
 
+                if(${javaVersion} != "8") { // for jdk11+, need extra config args to pass down
+                    config.put('additionalConfigureArgs', "--without-version-pre --without-version-opt")
+                }
+
                 println "[INFO] FINAL CONFIG FOR RELEASE JDK${javaVersion}"
                 println JsonOutput.prettyPrint(JsonOutput.toJson(config))
 

--- a/pipelines/jobs/configurations/jdk8u_release.groovy
+++ b/pipelines/jobs/configurations/jdk8u_release.groovy
@@ -23,9 +23,6 @@ targetConfigurations = [
         'aarch64Linux'  : [
                 'temurin'
         ],
-        'arm32Linux'  : [
-                'temurin'
-        ],
         'x64Solaris': [
                 'temurin'
         ],

--- a/pipelines/jobs/release_pipeline_job_template.groovy
+++ b/pipelines/jobs/release_pipeline_job_template.groovy
@@ -70,7 +70,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
         stringParam('aqaReference', '', 'Tag name or Branch name of aqa-tests. Defaults to master')
         // special items need to modify per jdk8
         stringParam('overridePublishName', '', 'Most useful for jdk8 arm32 with a different scmReference tag')
-        stringParam('additionalConfigureArgs', "--without-version-pre --without-version-opt", "Additional arguments that will be ultimately passed to OpenJDK's <code>./configure</code>")
+        stringParam('additionalConfigureArgs', '', "Additional arguments that will be ultimately passed to OpenJDK's <code>./configure</code>. jdk8 might have a different one!")
 
         // default value not matter for release
         stringParam('jdkVersion', "${JAVA_VERSION}")


### PR DESCRIPTION
some more for the release pipeline
	- do not have aarch32 in the same batch of build by release-openjdk8-pipeline due to different scmReference
	- good to manually trigger that release by sharing the same pipeline with other jdk8 targets
	- make additionalConfigureArgs only set for jdk11+, default to ' '

Ref: https://github.com/adoptium/ci-jenkins-pipelines/issues/514