### PR TITLE
Build in docker on Linux/ppc64le for supported releases

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -123,7 +123,7 @@ class Config11 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                additionalNodeLabels : 'centos7',
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
                 configureArgs       : [
                         'temurin'     : '--enable-dtrace=auto',

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -107,7 +107,7 @@ class Config17 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                additionalNodeLabels: 'centos7',
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
                 configureArgs       : [
                         'temurin'     : '--enable-dtrace',

--- a/pipelines/jobs/configurations/jdk19u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk19u_pipeline_config.groovy
@@ -110,7 +110,7 @@ class Config19 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                additionalNodeLabels: 'centos7',
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
                 configureArgs       : [
                         'temurin'     : '--enable-dtrace',

--- a/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
@@ -110,7 +110,7 @@ class Config20 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                additionalNodeLabels: 'centos7',
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
                 configureArgs       : [
                         'temurin'     : '--enable-dtrace',

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -122,8 +122,8 @@ class Config8 {
         ppc64leLinux  : [
                 os  : 'linux',
                 arch: 'ppc64le',
-                additionalNodeLabels : 'centos7',
-                test                 : 'default',
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                test                : 'default',
                 configureArgs       : [
                         'openj9'      : '--enable-jitserver'
                 ],


### PR DESCRIPTION
Switching to docker-based builds on Linux/ppc64le for compatibility with x64 and Arm builds in order to help build system isolation

Signed-off-by: Stewart X Addison <sxa@redhat.com>