### PR TITLE
Update Temurin jck trigger to use PIPELINE_DISPLAY_NAME and optimise test groups submission

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -537,7 +537,7 @@ class Build {
                     def num_machines = '1'
                     def displayName = "${buildConfig.SCM_REF} : ${platform} : ${targetsSingle}"
                     def targets = ""
-                    targetsParallel.each{ target ->
+                    targetsSingle.each{ target ->
                         if (targets == "") {
                             targets = "${target}"
                         } else {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -503,7 +503,7 @@ class Build {
                         if (targets == "") {
                             targets = "${target}"
                         } else {
-                            targets = "${targets},${target}
+                            targets = "${targets},${target}"
                         }
                     }
                     context.triggerRemoteJob abortTriggeredJob: true,
@@ -541,7 +541,7 @@ class Build {
                         if (targets == "") {
                             targets = "${target}"
                         } else {
-                            targets = "${targets},${target}
+                            targets = "${targets},${target}"
                         }
                     }
                     context.triggerRemoteJob abortTriggeredJob: true,

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -491,14 +491,14 @@ class Build {
             targets['parallel'] = 'extended.jck'
         }
 
-        targets.each { targetKey, targetValue -> 
+        targets.each { targetMode, targetTests -> 
             try {
-                context.println "Remote trigger: ${targetValue}"
-                remoteTargets["${targetValue}"] = {
-                    def displayName = "${buildConfig.SCM_REF} : ${platform} : ${targetValue}"
+                context.println "Remote trigger: ${targetTests}"
+                remoteTargets["${targetTests}"] = {
+                    def displayName = "${buildConfig.SCM_REF} : ${platform} : ${targetTests}"
                     def parallel = 'None'
                     def num_machines = '1'
-                    if ("${targetKey}" == 'parallel') {
+                    if ("${targetMode}" == 'parallel') {
                          parallel = 'Dynamic'
                          num_machines = '2'
                     }
@@ -507,7 +507,7 @@ class Build {
                         blockBuildUntilComplete: false,
                         job: 'AQA_Test_Pipeline',
                         parameters: context.MapParameters(parameters: [context.MapParameter(name: 'SDK_RESOURCE', value: 'customized'),
-                                                                context.MapParameter(name: 'TARGETS', value: "${targetValue}"),
+                                                                context.MapParameter(name: 'TARGETS', value: "${targetTests}"),
                                                                 context.MapParameter(name: 'CUSTOMIZED_SDK_URL', value: "${sdkUrl}"),
                                                                 context.MapParameter(name: 'JDK_VERSIONS', value: "${jdkVersion}"),
                                                                 context.MapParameter(name: 'PARALLEL', value: parallel),

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -491,14 +491,14 @@ class Build {
             targets['parallel'] = 'extended.jck'
         }
 
-        targets.each { target -> 
+        targets.each { targetKey, targetValue -> 
             try {
-                context.println "Remote trigger: ${target.value}"
-                remoteTargets["${target.value}"] = {
-                    def displayName = "${buildConfig.SCM_REF} : ${platform} : ${target.value}"
+                context.println "Remote trigger: ${targetValue}"
+                remoteTargets["${targetValue}"] = {
+                    def displayName = "${buildConfig.SCM_REF} : ${platform} : ${targetValue}"
                     def parallel = 'None'
                     def num_machines = '1'
-                    if ( target.key == 'parallel') {
+                    if (targetKey == 'parallel') {
                          parallel = 'Dynamic'
                          num_machines = '2'
                     }
@@ -507,7 +507,7 @@ class Build {
                         blockBuildUntilComplete: false,
                         job: 'AQA_Test_Pipeline',
                         parameters: context.MapParameters(parameters: [context.MapParameter(name: 'SDK_RESOURCE', value: 'customized'),
-                                                                context.MapParameter(name: 'TARGETS', value: ${target.value}),
+                                                                context.MapParameter(name: 'TARGETS', value: ${targetValue}),
                                                                 context.MapParameter(name: 'CUSTOMIZED_SDK_URL', value: "${sdkUrl}"),
                                                                 context.MapParameter(name: 'JDK_VERSIONS', value: "${jdkVersion}"),
                                                                 context.MapParameter(name: 'PARALLEL', value: parallel),

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -498,7 +498,7 @@ class Build {
             excludePlat = "linux"
         }
 
-        def appOptions="customJtx=/home/jenkins/jck_run/jdk${jdkVersion}/${excludePlat}"
+        def appOptions="customJtx=/home/jenkins/jck_run/jdk${jdkVersion}/${excludePlat}/temurin.jtx"
 
         def targets = ['serial': 'sanity.jck,extended.jck,special.jck']
 

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -498,11 +498,19 @@ class Build {
                     def parallel = 'Dynamic'
                     def num_machines = '2'
                     def displayName = "${buildConfig.SCM_REF} : ${platform} : ${targetsParallel}"
+                    def targets = ""
+                    targetsParallel.each{ target ->
+                        if (targets == "") {
+                            targets = "${target}"
+                        } else {
+                            targets = "${targets},${target}
+                        }
+                    }
                     context.triggerRemoteJob abortTriggeredJob: true,
                         blockBuildUntilComplete: false,
                         job: 'AQA_Test_Pipeline',
                         parameters: context.MapParameters(parameters: [context.MapParameter(name: 'SDK_RESOURCE', value: 'customized'),
-                                                                context.MapParameter(name: 'TARGETS', value: target),
+                                                                context.MapParameter(name: 'TARGETS', value: targets),
                                                                 context.MapParameter(name: 'CUSTOMIZED_SDK_URL', value: "${sdkUrl}"),
                                                                 context.MapParameter(name: 'JDK_VERSIONS', value: "${jdkVersion}"),
                                                                 context.MapParameter(name: 'PARALLEL', value: parallel),
@@ -528,11 +536,19 @@ class Build {
                     def parallel = 'None'
                     def num_machines = '1'
                     def displayName = "${buildConfig.SCM_REF} : ${platform} : ${targetsSingle}"
+                    def targets = ""
+                    targetsParallel.each{ target ->
+                        if (targets == "") {
+                            targets = "${target}"
+                        } else {
+                            targets = "${targets},${target}
+                        }
+                    }
                     context.triggerRemoteJob abortTriggeredJob: true,
                         blockBuildUntilComplete: false,
                         job: 'AQA_Test_Pipeline',
                         parameters: context.MapParameters(parameters: [context.MapParameter(name: 'SDK_RESOURCE', value: 'customized'),
-                                                                context.MapParameter(name: 'TARGETS', value: target),
+                                                                context.MapParameter(name: 'TARGETS', value: targets),
                                                                 context.MapParameter(name: 'CUSTOMIZED_SDK_URL', value: "${sdkUrl}"),
                                                                 context.MapParameter(name: 'JDK_VERSIONS', value: "${jdkVersion}"),
                                                                 context.MapParameter(name: 'PARALLEL', value: parallel),

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -498,7 +498,7 @@ class Build {
                     def displayName = "${buildConfig.SCM_REF} : ${platform} : ${targetValue}"
                     def parallel = 'None'
                     def num_machines = '1'
-                    if (targetKey == 'parallel') {
+                    if ("${targetKey}" == 'parallel') {
                          parallel = 'Dynamic'
                          num_machines = '2'
                     }
@@ -507,7 +507,7 @@ class Build {
                         blockBuildUntilComplete: false,
                         job: 'AQA_Test_Pipeline',
                         parameters: context.MapParameters(parameters: [context.MapParameter(name: 'SDK_RESOURCE', value: 'customized'),
-                                                                context.MapParameter(name: 'TARGETS', value: ${targetValue}),
+                                                                context.MapParameter(name: 'TARGETS', value: "${targetValue}"),
                                                                 context.MapParameter(name: 'CUSTOMIZED_SDK_URL', value: "${sdkUrl}"),
                                                                 context.MapParameter(name: 'JDK_VERSIONS', value: "${jdkVersion}"),
                                                                 context.MapParameter(name: 'PARALLEL', value: parallel),

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -481,9 +481,7 @@ class Build {
         def sdkUrl = "${env.BUILD_URL}/artifact/workspace/target/${filter}/*zip*/target.zip"
         context.echo "sdkUrl is ${sdkUrl}"
         def targetsSingle = ['sanity.jck', 'extended.jck', 'special.jck']
-        def parallel = 'None'
         def targetsParallel = []
-        def num_machines = '1'
         def remoteTargets = [:]
         def additionalTestLabel = buildConfig.ADDITIONAL_TEST_LABEL
 
@@ -497,9 +495,9 @@ class Build {
             try {
                 context.println "Remote trigger ${targetsParallel}"
                 remoteTargets["${targetsParallel}"] = {
-                    parallel = 'Dynamic'
-                    num_machines = '2'
-                    displayName = "${buildConfig.SCM_REF} : ${platform} : ${targetsParallel}"
+                    def parallel = 'Dynamic'
+                    def num_machines = '2'
+                    def displayName = "${buildConfig.SCM_REF} : ${platform} : ${targetsParallel}"
                     context.triggerRemoteJob abortTriggeredJob: true,
                         blockBuildUntilComplete: false,
                         job: 'AQA_Test_Pipeline',
@@ -527,9 +525,9 @@ class Build {
             try {
                 context.println "Remote trigger ${targetsSingle}"
                 remoteTargets["${targetsSingle}"] = {
-                    parallel = 'None'
-                    num_machines = '1'
-                    displayName = "${buildConfig.SCM_REF} : ${platform} : ${targetsSingle}"
+                    def parallel = 'None'
+                    def num_machines = '1'
+                    def displayName = "${buildConfig.SCM_REF} : ${platform} : ${targetsSingle}"
                     context.triggerRemoteJob abortTriggeredJob: true,
                         blockBuildUntilComplete: false,
                         job: 'AQA_Test_Pipeline',

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -486,19 +486,22 @@ class Build {
 
         // Determine from the platform the Jck jtx exclude platform
         def excludePlat
+        def excludeRoot = "/home"
         if (platform.contains("aix")) {
             excludePlat = "aix"
         } else if (platform.contains("mac")) {
             excludePlat = "mac"
+            excludeRoot = "/Users"
         } else if (platform.contains("windows")) {
             excludePlat = "windows"
+            excludeRoot = "c:/Users"
         } else if (platform.contains("solaris")) {
             excludePlat = "solaris"
         } else {
             excludePlat = "linux"
         }
 
-        def appOptions="customJtx=/home/jenkins/jck_run/jdk${jdkVersion}/${excludePlat}/temurin.jtx"
+        def appOptions="customJtx=${excludeRoot}/jenkins/jck_run/jdk${jdkVersion}/${excludePlat}/temurin.jtx"
 
         def targets = ['serial': 'sanity.jck,extended.jck,special.jck']
 

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -471,6 +471,7 @@ class Build {
         return testStages
     }
 
+    // Temurin remote jck trigger
     def remoteTriggerJckTests(String platform) {
         def jdkVersion = getJavaVersionNumber()
         //def sdkUrl="https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk${jdkVersion}-pipeline/${env.BUILD_NUMBER}/"
@@ -482,6 +483,22 @@ class Build {
         context.echo "sdkUrl is ${sdkUrl}"
         def remoteTargets = [:]
         def additionalTestLabel = buildConfig.ADDITIONAL_TEST_LABEL
+
+        // Determine from the platform the Jck jtx exclude platform
+        def excludePlat
+        if (platform.contains("aix")) {
+            excludePlat = "aix"
+        } else if (platform.contains("mac")) {
+            excludePlat = "mac"
+        } else if (platform.contains("windows")) {
+            excludePlat = "windows"
+        } else if (platform.contains("solaris")) {
+            excludePlat = "solaris"
+        } else {
+            excludePlat = "linux"
+        }
+
+        def appOptions="customJtx=/home/jenkins/jck_run/jdk${jdkVersion}/${excludePlat}"
 
         def targets = ['serial': 'sanity.jck,extended.jck,special.jck']
 
@@ -514,6 +531,7 @@ class Build {
                                                                 context.MapParameter(name: 'NUM_MACHINES', value: "${num_machines}"),
                                                                 context.MapParameter(name: 'PLATFORMS', value: "${platform}"),
                                                                 context.MapParameter(name: 'PIPELINE_DISPLAY_NAME', value: "${displayName}"),
+                                                                context.MapParameter(name: 'APPLICATION_OPTIONS', value: "${appOptions}"),
                                                                 context.MapParameter(name: 'LABEL_ADDITION', value: additionalTestLabel)]),
                         remoteJenkinsName: 'temurin-compliance',
                         shouldNotFailBuild: true,

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -498,14 +498,7 @@ class Build {
                     def parallel = 'Dynamic'
                     def num_machines = '2'
                     def displayName = "${buildConfig.SCM_REF} : ${platform} : ${targetsParallel}"
-                    def targets = ""
-                    targetsParallel.each{ target ->
-                        if (targets == "") {
-                            targets = "${target}"
-                        } else {
-                            targets = "${targets},${target}"
-                        }
-                    }
+                    def targets = targetsParallel.join(",")
                     context.triggerRemoteJob abortTriggeredJob: true,
                         blockBuildUntilComplete: false,
                         job: 'AQA_Test_Pipeline',
@@ -536,14 +529,7 @@ class Build {
                     def parallel = 'None'
                     def num_machines = '1'
                     def displayName = "${buildConfig.SCM_REF} : ${platform} : ${targetsSingle}"
-                    def targets = ""
-                    targetsSingle.each{ target ->
-                        if (targets == "") {
-                            targets = "${target}"
-                        } else {
-                            targets = "${targets},${target}"
-                        }
-                    }
+                    def targets = targetsSingle.join(",")
                     context.triggerRemoteJob abortTriggeredJob: true,
                         blockBuildUntilComplete: false,
                         job: 'AQA_Test_Pipeline',

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -497,6 +497,7 @@ class Build {
             excludeRoot = "c:/Users"
         } else if (platform.contains("solaris")) {
             excludePlat = "solaris"
+            excludeRoot = "/export/home"
         } else {
             excludePlat = "linux"
         }


### PR DESCRIPTION
Identify the AQA_TEST_PIPELINE submitted with \<tag\>:\<platform\>:\<targets\>

Submit non-parallel targets all together to reduce target number of jobs.
Add APPLICATION_OPTIONS param with Temurin exclude list
 