### PR TITLE
Add jdkVersion to AqaTestPipline job displayName so we can identify weekly jdk versions

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -516,7 +516,7 @@ class Build {
             try {
                 context.println "Remote trigger: ${targetTests}"
                 remoteTargets["${targetTests}"] = {
-                    def displayName = "${buildConfig.SCM_REF} : ${platform} : ${targetTests}"
+                    def displayName = "jdk${jdkVersion} : ${buildConfig.SCM_REF} : ${platform} : ${targetTests}"
                     def parallel = 'None'
                     def num_machines = '1'
                     if ("${targetMode}" == 'parallel') {


### PR DESCRIPTION
Add jdkVersion to the AqaTestPipline job displayName so we can easily identify jdk versions for weekly run that don't build a SCM_REF.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>