### PR TITLE
Ensure we do not publish fast_startup artifacts

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -725,7 +725,8 @@ class Builder implements Serializable {
                         context.string(name: 'TIMESTAMP', value: timestamp),
                         context.string(name: 'UPSTREAM_JOB_NAME', value: env.JOB_NAME),
                         context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${currentBuild.getNumber()}"),
-                        context.string(name: 'VERSION', value: determineReleaseToolRepoVersion())
+                        context.string(name: 'VERSION', value: determineReleaseToolRepoVersion()),
+                        context.string(name: 'ARTIFACTS_TO_SKIP', value: "**/*_fast_startup_*")  // Skip fast_startup variant
                     ]
         }
     }


### PR DESCRIPTION
Fixes failing jdk11u nightly publishing, where the release script publish with the updated publishing validation reports finding fast_startup variant tarballs that should not be published.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>