### PR TITLE
Trigger remote jck with just the jdkUrl

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -475,9 +475,10 @@ class Build {
     def remoteTriggerJckTests(String platform) {
         def jdkVersion = getJavaVersionNumber()
         //def sdkUrl="https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk${jdkVersion}-pipeline/${env.BUILD_NUMBER}/"
-        def filter = "*.tar.gz"
+        // We just need the JDK for Jck tests
+        def filter = "*-jdk_*.tar.gz"
         if (buildConfig.TARGET_OS.contains("windows")) {
-        	filter = "*.zip"
+        	filter = "*-jdk_*.zip"
         }
         def sdkUrl = "${env.BUILD_URL}/artifact/workspace/target/${filter}/*zip*/target.zip"
         context.echo "sdkUrl is ${sdkUrl}"


### PR DESCRIPTION
The Temurin remote jck trigger was zipping all the artifacts creating a very large zip, when just the jdk is required, which hope might help avoid glitches on the other end during curl downloads..

Signed-off-by: Andrew Leonard <anleonar@redhat.com>