### PR TITLE
fix: broken jdk20 pipeline when missing nightly as entity

### DIFF
--- a/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
@@ -164,6 +164,7 @@ class Config20 {
                         'temurin'   : '--create-jre-image --create-sbom'
                 ],
                 test                : [
+                        nightly: [],
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
                 ]
         ]


### PR DESCRIPTION
Fix: https://github.com/adoptium/ci-jenkins-pipelines/issues/538