### PR TITLE
Switch testing for riscv64Linux to default

### DIFF
--- a/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
@@ -157,14 +157,12 @@ class Config20 {
         ],
 
         riscv64Linux      :  [
-                os                   : 'linux',
-                arch                 : 'riscv64',
-                configureArgs        : '--enable-dtrace',
+                os                  : 'linux',
+                arch                : 'riscv64',
+                test                : 'default',
+                configureArgs       : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
-                ],
-                test                : [
-                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
                 ]
         ]
 


### PR DESCRIPTION
It's passing all nightly builds in ~15hrs already, so we should be good to run it nightly. Also, it would be very worthwhile to get more test coverages, similarly to other platforms.