### PR TITLE
For Temurin jck jdk url use direct tarball url rather than forcing zip compression

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -472,15 +472,10 @@ class Build {
     }
 
     // Temurin remote jck trigger
-    def remoteTriggerJckTests(String platform) {
+    def remoteTriggerJckTests(String platform, String jdkFileName) {
         def jdkVersion = getJavaVersionNumber()
-        //def sdkUrl="https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk${jdkVersion}-pipeline/${env.BUILD_NUMBER}/"
         // We just need the JDK for Jck tests
-        def filter = "*-jdk_*.tar.gz"
-        if (buildConfig.TARGET_OS.contains("windows")) {
-        	filter = "*-jdk_*.zip"
-        }
-        def sdkUrl = "${env.BUILD_URL}/artifact/workspace/target/${filter}/*zip*/target.zip"
+        def sdkUrl = "${env.BUILD_URL}/artifact/workspace/target/${jdkFileName}"
         context.echo "sdkUrl is ${sdkUrl}"
         def remoteTargets = [:]
         def additionalTestLabel = buildConfig.ADDITIONAL_TEST_LABEL
@@ -1845,7 +1840,7 @@ class Build {
                             if ( !(platform  == 'riscv64_linux' || platform =='aarch64_windows') ) {
                                 if ( !(buildConfig.JAVA_TO_BUILD == 'jdk8u' && platform == 's390x_linux') ) {
                                     context.echo "Remote trigger Eclipse temurin AQA_Test_Pipeline job with ${platform} ${buildConfig.JAVA_TO_BUILD}"
-                                    def remoteTargets = remoteTriggerJckTests(platform)
+                                    def remoteTargets = remoteTriggerJckTests(platform, filename)
                                     context.parallel remoteTargets
                                 }
                             }


### PR DESCRIPTION
For temurin jck trigger use the actual filename.tar.gz rather than \*jdk\*/\*zip\*/target.zip, as that causes nginx to use chunked compressed streaming which means curl does not know how much data is expected, and if a issue occurs, eg.a keep alive, then it doesn't know it has not received all the data. With this change the download can now retry as it gets an rc=18 from curl. eg.
```
20:18:46  + ./get.sh -s /home/jenkins/workspace/Test_openjdk19_hs_sanity.jck_s390x_linux/aqa-tests/.. -p s390x_linux -r customized -j 19 -i hotspot -c https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk19u/job/jdk19u-linux-s390x-temurin/38//artifact/workspace/target/OpenJDK19U-jdk_s390x_linux_hotspot_2022-12-16-19-24.tar.gz --openj9_repo https://github.com/eclipse-openj9/openj9.git --openj9_branch master --tkg_repo https://github.com/adoptium/TKG.git --tkg_branch master
20:18:46  TESTDIR: /home/jenkins/workspace/Test_openjdk19_hs_sanity.jck_s390x_linux/aqa-tests
20:18:46  get jdk binary...
20:18:46  _ENCODE_FILE_NEW=UNTAGGED curl -OLJSks --user ****:**** https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk19u/job/jdk19u-linux-s390x-temurin/38//artifact/workspace/target/OpenJDK19U-jdk_s390x_linux_hotspot_2022-12-16-19-24.tar.gz
20:19:56  curl: (18) transfer closed with 157335124 bytes remaining to read
20:19:56  error code: 18. Sleep 300 secs, then retry 1...
20:24:50  check for OpenJDK19U-jdk_s390x_linux_hotspot_2022-12-16-19-24.tar.gz. If found, the file will be removed.
20:24:50  remove OpenJDK19U-jdk_s390x_linux_hotspot_2022-12-16-19-24.tar.gz before retry...
20:24:50  _ENCODE_FILE_NEW=UNTAGGED curl -OLJSks --user ****:**** https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk19u/job/jdk19u-linux-s390x-temurin/38//artifact/workspace/target/OpenJDK19U-jdk_s390x_linux_hotspot_2022-12-16-19-24.tar.gz
20:27:44  Uncompressing file: OpenJDK19U-jdk_s390x_linux_hotspot_2022-12-16-19-24.tar.gz ...
```

Fixes: temurin-compliance issue 283

Signed-off-by: Andrew Leonard <anleonar@redhat.com>