### PR TITLE
fix: pr-tester missing new field releaseType

### DIFF
--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -65,14 +65,14 @@ class PullRequestTestPipeline implements Serializable {
         Map<String, ?> config = generateConfig(javaVersion)
         context.checkout([$class: 'GitSCM', userRemoteConfigs: [[url: config.GIT_URL]], branches: [[name: branch]]])
 
-        context.println "JDK${javaVersion} disableJob = ${config.disableJob}" 
+        context.println "JDK${javaVersion} disableJob = ${config.disableJob}"
         context.jobDsl targets: DEFAULTS_JSON['templateDirectories']['upstream'], ignoreExisting: false, additionalParameters: config
     }
 
     /*
     * Main function, called from kick_off_tester.groovy by job "openjdk-build-pr-tester"
     */
-    def runTests() { 
+    def runTests() {
         def jobs = [:]
         Boolean pipelineFailed = false
 

--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -52,7 +52,8 @@ class PullRequestTestPipeline implements Serializable {
                 CHECKOUT_CREDENTIALS: '',
                 adoptScripts        : true,
                 enableTests         : false,
-                enableTestDynamicParallel : false
+                enableTestDynamicParallel : false,
+                releaseType         : "pr-tester"
         ]
     }
 
@@ -64,14 +65,14 @@ class PullRequestTestPipeline implements Serializable {
         Map<String, ?> config = generateConfig(javaVersion)
         context.checkout([$class: 'GitSCM', userRemoteConfigs: [[url: config.GIT_URL]], branches: [[name: branch]]])
 
-        context.println "JDK${javaVersion} disableJob = ${config.disableJob}"
+        context.println "JDK${javaVersion} disableJob = ${config.disableJob}" 
         context.jobDsl targets: DEFAULTS_JSON['templateDirectories']['upstream'], ignoreExisting: false, additionalParameters: config
     }
 
     /*
     * Main function, called from kick_off_tester.groovy by job "openjdk-build-pr-tester"
     */
-    def runTests() {
+    def runTests() { 
         def jobs = [:]
         Boolean pipelineFailed = false
 


### PR DESCRIPTION
when introducing releaseType for release and evaluation pipeline, it was not set for the pr-tester
so we see errors in https://ci.adoptopenjdk.net/job/build-scripts-pr-tester/job/openjdk-build-pr-tester/1786/console
`ERROR: (pipeline_job_template.groovy, line 12) No such property: releaseType for class: pipeline_job_template`


change has been tested in 
https://ci.adoptopenjdk.net/job/build-scripts-pr-tester/job/openjdk-build-pr-tester/1787 
https://ci.adoptopenjdk.net/job/build-scripts-pr-tester/job/build-test/job/openjdk19-pipeline/100/console
