### PR TITLE
fix: release pipeline checkout by tag not branch need special handle in jenkins git plugin

### DIFF
--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -525,6 +525,11 @@ class Regeneration implements Serializable {
             params.put('PR_BUILDER', true)
         }
 
+        // Makre sure the dsl knows if we are building for release job which checkout by a tag not branch
+        if (jobType == "release") {
+            params.put('CHECKOUT_AS_TAG', true) // in dsl, we convert GIT_BRANCH to a tag then checkout
+        }
+
         // Execute job dsl, using adopt's template if the user doesn't have one
         def create = null
         try {

--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -28,6 +28,10 @@ if (!binding.hasVariable('GIT_BRANCH')) {
     GIT_BRANCH = 'master'
 }
 
+if (binding.hasVariable('CHECKOUT_AS_TAG')) {
+    GIT_BRANCH = "refs/tags/"+GIT_BRANCH
+}
+
 isLightweight = true
 if (binding.hasVariable('PR_BUILDER')) {
     isLightweight = false


### PR DESCRIPTION
when use tag  in the release build job (e.g https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/release/job/jobs/job/jdk17u/job/jdk17u-release-alpine-linux-x64-temurin/1/console) error that git plugin cannot checkout , because it needs a spacial  handling, see doc:
```
<tagName>
This does not work since the tag will not be recognized as tag.
Use refs/tags/<tagName> instead.
E.g. git-2.3.0
refs/tags/<tagName>
Tracks/checks out the specified tag.
E.g. refs/tags/git-2.3.0
```