### PR TITLE
fix: when no target in evaluation pipeline

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_evaluation.groovy
+++ b/pipelines/jobs/configurations/jdk11u_evaluation.groovy
@@ -1,4 +1,6 @@
-targetConfigurations = [
+// when no target for evaluation, set it to null and disable scheduler below
+targetConfigurations = null
+//[
         // 'x64Mac'        : [
         //         'openj9'
         // ],
@@ -30,12 +32,12 @@ targetConfigurations = [
         // 'aarch64Windows': [
         //         'temurin'
         // ]
-]
+//]
 
 // if set to empty string then it wont get triggered
-triggerSchedule_evaluation =  'TZ=UTC\n05 18 * * 2,4'
+triggerSchedule_evaluation = ''
 // if set to empty string then it wont get triggered
-triggerSchedule_weekly_evaluation= 'TZ=UTC\n05 17 * * 6'
+triggerSchedule_weekly_evaluation= ''
 
 // scmReferences to use for weekly evaluation build
 weekly_evaluation_scmReferences = [


### PR DESCRIPTION
	- do not trigger by timer
	- set to null to be clear

For case of jdk11, we do not have any target in evaluation, should disable timer and use "null" to make it clear
e.g https://ci.adoptopenjdk.net/job/build-scripts/job/evaluation-openjdk11-pipeline/
(currently manually disabled but it will get re-enabled when new commit reaches master branch)