### PR TITLE
Add AIX to jdk17&19 release configuration

### DIFF
--- a/pipelines/jobs/configurations/jdk17u_release.groovy
+++ b/pipelines/jobs/configurations/jdk17u_release.groovy
@@ -17,6 +17,9 @@ targetConfigurations = [
         'ppc64leLinux': [
                 'temurin'
         ],
+        'ppc64Aix'    : [
+                'temurin'
+        ],
         's390xLinux'  : [
                 'temurin'
         ],

--- a/pipelines/jobs/configurations/jdk19u_release.groovy
+++ b/pipelines/jobs/configurations/jdk19u_release.groovy
@@ -17,6 +17,9 @@ targetConfigurations = [
         'ppc64leLinux': [
                 'temurin'
         ],
+        'ppc64Aix'    : [
+                'temurin'
+        ],
         's390xLinux'  : [
                 'temurin'
         ],


### PR DESCRIPTION
AIX was missing from the jdk-17 and jdk-19 release pipeline configuration and hence was not being built.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>