### PR TITLE
update: weekly evaluation need to set to Weekly not Nightly to run aqa weekly test

### DIFF
--- a/pipelines/build/regeneration/evaluation_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/evaluation_pipeline_generator.groovy
@@ -247,6 +247,7 @@ node('worker') {
                     }
                     config.put('targetConfigurations', targetEvaluation.targetConfigurations) // explicit set it to make things clear
                     config.weekly_release_scmReferences = targetEvaluation.weekly_evaluation_scmReferences
+                    config.releaseType = "Weekly" // overwrite releaseType for weekly evalucation pipeline: not set to Release(avoid trigger TCK but aqa weekly and no reproducible)
 
                     println "[INFO] CREATING JDK${javaVersion} WEEKLY EVALUATION PIPELINE WITH NEW CONFIG VALUES:"
                     println "JOB_NAME = ${config.JOB_NAME}"


### PR DESCRIPTION
need overwrite releaseType for weekly-evaluation, to be able to run Aqa weekly tests but not trigger TCK

Ref: https://github.com/adoptium/ci-jenkins-pipelines/issues/473 