### PR TITLE
workaround: to use USE_ADOPT_SHELL_SCRIPTS for Mac build

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -815,7 +815,7 @@ class Builder implements Serializable {
                             // Triggering downstream job ${downstreamJobName}
                             /* special handling for Mac release build issue/571 start*/
                                 if (downstreamJobName.contains("release-mac-x64-temurin") || downstreamJobName.contains("release-mac-aarch64-temurin")) {
-                                    config.USE_ADOPT_SHELL_SCRIPTS = "true"  
+                                    config.USE_ADOPT_SHELL_SCRIPTS = true
                                 }
                             /* special handling for Mac release build issue/571 done*/
 

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -813,6 +813,12 @@ class Builder implements Serializable {
                         // Execute build job for configuration i.e jdk11u/job/jdk11u-linux-x64-hotspot
                         context.stage(configuration.key) {
                             // Triggering downstream job ${downstreamJobName}
+                            /* special handling for Mac release build issue/571 start*/
+                                if (downstreamJobName.contains("release-mac-x64-temurin") || downstreamJobName.contains("release-mac-aarch64-temurin")) {
+                                    config.USE_ADOPT_SHELL_SCRIPTS = "true"  
+                                }
+                            /* special handling for Mac release build issue/571 done*/
+
                             def downstreamJob = context.build job: downstreamJobName, propagate: false, parameters: config.toBuildParams()
 
                             if (downstreamJob.getResult() == 'SUCCESS') {


### PR DESCRIPTION
	- this is a workaround to make release work on mac
	- code should be reverted when we have a formal solution
Ref: https://github.com/adoptium/ci-jenkins-pipelines/issues/571 