### PR TITLE
fix: override USE_ADOPT_SHELL_SCRIPTS to true for mac in release pipeline

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -799,7 +799,8 @@ class Builder implements Serializable {
                 jobs[configuration.key] = {
                     // jdk20-linux-x64-temurin
                     def jobTopName = getJobName(configuration.key)
-                    def jobFolder = getJobFolder()
+                    //TODO: uncomment def jobFolder = getJobFolder()
+                    def jobFolder = "build-scripts/jobs/release/jobs/jdk17u/" // mocking test
                     /*
                         build-scripts/jobs/jdk20/jdk20-linux-x64-temurin for nightly
                         build-scripts/evaluation/jobs/jdk20/jdk20-evaluation-linux-aarch64-hotspot for evaluation

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -813,6 +813,12 @@ class Builder implements Serializable {
                         // Execute build job for configuration i.e jdk11u/job/jdk11u-linux-x64-hotspot
                         context.stage(configuration.key) {
                             // Triggering downstream job ${downstreamJobName}
+                            /* special handling for Mac release build issue/571 start*/
+                                if (downstreamJobName.contains("release-mac-x64-temurin") || downstreamJobName.contains("release-mac-aarch64-temurin")) {
+                                    config.USE_ADOPT_SHELL_SCRIPTS = true
+                                }
+                            /* special handling for Mac release build issue/571 done*/
+
                             def downstreamJob = context.build job: downstreamJobName, propagate: false, parameters: config.toBuildParams()
 
                             if (downstreamJob.getResult() == 'SUCCESS') {

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -798,9 +798,10 @@ class Builder implements Serializable {
             jobConfigurations.each { configuration ->
                 jobs[configuration.key] = {
                     // jdk20-linux-x64-temurin
-                    def jobTopName = getJobName(configuration.key)
+                    //TODO: uncomment def jobTopName = getJobName(configuration.key)
                     //TODO: uncomment def jobFolder = getJobFolder()
-                    def jobFolder = "build-scripts/jobs/release/jobs/jdk17u/" // mocking test
+                    def jobTopName = "jdk11u-release-mac-x64-temurin" //mocking test
+                    def jobFolder = "build-scripts/jobs/release/jobs/jdk17u" // mocking test
                     /*
                         build-scripts/jobs/jdk20/jdk20-linux-x64-temurin for nightly
                         build-scripts/evaluation/jobs/jdk20/jdk20-evaluation-linux-aarch64-hotspot for evaluation

--- a/pipelines/build/regeneration/build_job_generator.groovy
+++ b/pipelines/build/regeneration/build_job_generator.groovy
@@ -20,8 +20,8 @@ limitations under the License.
     File used for generate downstream build jobs which are triggered by via [release_]pipeline_jobs_generator_jdkX, e.g:
     
     - build-scripts/jobs/jdk11u/jdk11u-linux-arm-temurin (jobType = "nightly")
-    - build-scripts/jobs/jdk11u/evaluation-jdk11u-linux-arm-temurin (when jobType = "evaluation")
-    - build-scripts/release/jobs/release-jdk17u-mac-x64-temurin (when jobType = "release")
+    - build-scripts/jobs/evaluation/jobs/jdk11u/evaluation-jdk11u-linux-arm-temurin (when jobType = "evaluation")
+    - build-scripts/jobs/release/jobs/release-jdk17u-mac-x64-temurin (when jobType = "release")
     - build-scripts-pr-tester/build-test/jobs/jdk19u/jdk19u-alpine-linux-x64-temurin (when "pr-tester")
 */
 


### PR DESCRIPTION
fix error:
`groovy.lang.ReadOnlyPropertyException: Cannot set readonly property: USE_ADOPT_SHELL_SCRIPTS for class: common.IndividualBuildConfig`

ref: https://github.com/adoptium/ci-jenkins-pipelines/issues/571 workaround