### PR TITLE
fix: to enable USE_ADOPT_SHELL_SCRIPTS with defaults.json in release pipeline 

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -813,6 +813,12 @@ class Builder implements Serializable {
                         // Execute build job for configuration i.e jdk11u/job/jdk11u-linux-x64-hotspot
                         context.stage(configuration.key) {
                             // Triggering downstream job ${downstreamJobName}
+                            /* special handling for Mac release build issue/571 start*/
+                                if (downstreamJobName.contains("release-mac-x64-temurin") || downstreamJobName.contains("release-mac-aarch64-temurin")) {
+                                    config.USE_ADOPT_SHELL_SCRIPTS = true
+                                }
+                            /* special handling for Mac release build issue/571 done*/
+
                             def downstreamJob = context.build job: downstreamJobName, propagate: false, parameters: config.toBuildParams()
 
                             if (downstreamJob.getResult() == 'SUCCESS') {

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -813,12 +813,6 @@ class Builder implements Serializable {
                         // Execute build job for configuration i.e jdk11u/job/jdk11u-linux-x64-hotspot
                         context.stage(configuration.key) {
                             // Triggering downstream job ${downstreamJobName}
-                            /* special handling for Mac release build issue/571 start*/
-                                if (downstreamJobName.contains("release-mac-x64-temurin") || downstreamJobName.contains("release-mac-aarch64-temurin")) {
-                                    config.USE_ADOPT_SHELL_SCRIPTS = true
-                                }
-                            /* special handling for Mac release build issue/571 done*/
-
                             def downstreamJob = context.build job: downstreamJobName, propagate: false, parameters: config.toBuildParams()
 
                             if (downstreamJob.getResult() == 'SUCCESS') {

--- a/pipelines/build/regeneration/build_job_generator.groovy
+++ b/pipelines/build/regeneration/build_job_generator.groovy
@@ -27,6 +27,9 @@ limitations under the License.
 
 String javaVersion = params.JAVA_VERSION
 String ADOPT_DEFAULTS_FILE_URL = 'https://raw.githubusercontent.com/adoptium/ci-jenkins-pipelines/master/pipelines/defaults.json'
+if (params.REPOSITORY_BRANCH != "") { // mainly for release jobs to use tag
+    ADOPT_DEFAULTS_FILE_URL = "https://raw.githubusercontent.com/adoptium/ci-jenkins-pipelines/${params.REPOSITORY_BRANCH}/pipelines/defaults.json"
+}
 String DEFAULTS_FILE_URL = (params.DEFAULTS_URL) ?: ADOPT_DEFAULTS_FILE_URL
 
 node('worker') {

--- a/pipelines/build/regeneration/release_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/release_pipeline_generator.groovy
@@ -65,7 +65,7 @@ node('worker') {
             println "RELEASE_CONFIG_PATH = ${releaseConfigPath}"
             println "JOB_TEMPLATE_PATH = ${jobTemplatePath}"
             println "ENABLE_PIPELINE_SCHEDULE = false"
-            println "USE_ADOPT_SHELL_SCRIPTS = false"
+            println "USE_ADOPT_SHELL_SCRIPTS = true"
 
             releaseVersions.each({ javaVersion ->
                 def config = [
@@ -77,7 +77,7 @@ node('worker') {
                     JAVA_VERSION                : javaVersion,
                     JOB_NAME                    : "release-openjdk${javaVersion}-pipeline",
                     SCRIPT                      : "${scriptFolderPath}/openjdk_pipeline.groovy",
-                    adoptScripts                : false
+                    adoptScripts                : true // USE_ADOPT_SHELL_SCRIPTS
                 ]
 
                 def target

--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -1,11 +1,11 @@
 {
     "repository"             : {
         "build_url"          : "https://github.com/adoptium/temurin-build.git",
-        "build_branch"       : "v2023.01.03",
+        "build_branch"       : "v2023.01",
         "test_dirs"          : "/test/functional",
         "pipeline_url"       : "https://github.com/adoptium/ci-jenkins-pipelines.git",
-        "pipeline_branch"    : "v2023.01.03",
-        "helper_ref"         : "v2023.01.03"
+        "pipeline_branch"    : "v2023.01",
+        "helper_ref"         : "v2023.01"
     },
     "jenkinsDetails"         : {
         "rootUrl"            : "https://ci.adoptopenjdk.net",

--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -1,11 +1,11 @@
 {
     "repository"             : {
         "build_url"          : "https://github.com/adoptium/temurin-build.git",
-        "build_branch"       : "master",
+        "build_branch"       : "v2023.01.03",
         "test_dirs"          : "/test/functional",
         "pipeline_url"       : "https://github.com/adoptium/ci-jenkins-pipelines.git",
-        "pipeline_branch"    : "master",
-        "helper_ref"         : "master"
+        "pipeline_branch"    : "v2023.01.03",
+        "helper_ref"         : "v2023.01.03"
     },
     "jenkinsDetails"         : {
         "rootUrl"            : "https://ci.adoptopenjdk.net",


### PR DESCRIPTION
set defaults.json to use tag v2023.01.03

also revert the workaround done in previous commit

Ref: https://github.com/adoptium/ci-jenkins-pipelines/issues/571