### PR TITLE
Merge: from v2023.01 to master

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -813,12 +813,6 @@ class Builder implements Serializable {
                         // Execute build job for configuration i.e jdk11u/job/jdk11u-linux-x64-hotspot
                         context.stage(configuration.key) {
                             // Triggering downstream job ${downstreamJobName}
-                            /* special handling for Mac release build issue/571 start*/
-                                if (downstreamJobName.contains("release-mac-x64-temurin") || downstreamJobName.contains("release-mac-aarch64-temurin")) {
-                                    config.USE_ADOPT_SHELL_SCRIPTS = true
-                                }
-                            /* special handling for Mac release build issue/571 done*/
-
                             def downstreamJob = context.build job: downstreamJobName, propagate: false, parameters: config.toBuildParams()
 
                             if (downstreamJob.getResult() == 'SUCCESS') {

--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -28,8 +28,9 @@ if (!binding.hasVariable('GIT_BRANCH')) {
     GIT_BRANCH = 'master'
 }
 
+//TODO: need more logic to handle when it is a tag in format of "refs/tags/<tagName>"
 if (binding.hasVariable('CHECKOUT_AS_TAG')) {
-    GIT_BRANCH = "refs/tags/"+GIT_BRANCH
+    GIT_BRANCH = "refs/heads/"+GIT_BRANCH
 }
 
 isLightweight = true

--- a/pipelines/build/regeneration/build_job_generator.groovy
+++ b/pipelines/build/regeneration/build_job_generator.groovy
@@ -27,6 +27,9 @@ limitations under the License.
 
 String javaVersion = params.JAVA_VERSION
 String ADOPT_DEFAULTS_FILE_URL = 'https://raw.githubusercontent.com/adoptium/ci-jenkins-pipelines/master/pipelines/defaults.json'
+if (params.REPOSITORY_BRANCH != "") { // mainly for release jobs to use tag
+    ADOPT_DEFAULTS_FILE_URL = "https://raw.githubusercontent.com/adoptium/ci-jenkins-pipelines/${params.REPOSITORY_BRANCH}/pipelines/defaults.json"
+}
 String DEFAULTS_FILE_URL = (params.DEFAULTS_URL) ?: ADOPT_DEFAULTS_FILE_URL
 
 node('worker') {

--- a/pipelines/build/regeneration/release_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/release_pipeline_generator.groovy
@@ -65,7 +65,7 @@ node('worker') {
             println "RELEASE_CONFIG_PATH = ${releaseConfigPath}"
             println "JOB_TEMPLATE_PATH = ${jobTemplatePath}"
             println "ENABLE_PIPELINE_SCHEDULE = false"
-            println "USE_ADOPT_SHELL_SCRIPTS = false"
+            println "USE_ADOPT_SHELL_SCRIPTS = true"
 
             releaseVersions.each({ javaVersion ->
                 def config = [
@@ -77,7 +77,7 @@ node('worker') {
                     JAVA_VERSION                : javaVersion,
                     JOB_NAME                    : "release-openjdk${javaVersion}-pipeline",
                     SCRIPT                      : "${scriptFolderPath}/openjdk_pipeline.groovy",
-                    adoptScripts                : false
+                    adoptScripts                : true // USE_ADOPT_SHELL_SCRIPTS
                 ]
 
                 def target

--- a/pipelines/jobs/release_pipeline_job_template.groovy
+++ b/pipelines/jobs/release_pipeline_job_template.groovy
@@ -62,7 +62,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
         // important items to verify before trigger release pipeline
         textParam('targetConfigurations', JsonOutput.prettyPrint(JsonOutput.toJson(targetConfigurations)))
         stringParam('releaseType', 'Release', "only for release purpose")
-        booleanParam('useAdoptBashScripts', false, "If enabled, the downstream job will pull and execute <code>make-adopt-build-farm.sh</code> from adoptium/temurin-build. If disabled, it will use whatever the job is running inside of at the time, usually it's the default repository in the configuration.")
+        booleanParam('useAdoptBashScripts', true, "If enabled, the downstream job will pull and execute <code>make-adopt-build-farm.sh</code> from adoptium/temurin-build. If disabled, it will use whatever the job is running inside of at the time, usually it's the default repository in the configuration.")
         stringParam('scmReference', '', 'Tag name or Branch name from which openjdk source code repo to build')
         stringParam('buildReference', releaseTag, 'SHA1 or Tag name or Branch name of temurin-build repo. Defaults to master')
         stringParam('ciReference', releaseTag, 'SHA1 or Tag name or Branch name of ci-jenkins-pipeline repo. Defaults to master')


### PR DESCRIPTION
 - enable USE_ADOPT_SHELL_SCRIPTS for release pipeline
 - Revert "workaround: to use USE_ADOPT_SHELL_SCRIPTS for Mac build" This reverts commit 680fa255004de10e8596
 - update:change to checkout as a branch not a tag
 - update: set default to "true" for USE_ADOPT_SHELL_SCRIPTS in release



This is cherry-pick the changes from v2023.01 branch to master except the part within defaults.json which is specific for 2023 Jan release

We do not need to branch out after this one merged to "master" but these changes are useful for next release cycle.


Fix: https://github.com/adoptium/ci-jenkins-pipelines/issues/571


