### PR TITLE
fix: pass down ADOPT_DEFAULT_JSON when create downstream job

### DIFF
--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -30,6 +30,7 @@ class Regeneration implements Serializable {
     private final Map<String, Map<String, ?>> buildConfigurations
     private final Map<String, ?> targetConfigurations
     private final Map<String, ?> DEFAULTS_JSON
+    private final Map<String, ?> ADOPT_DEFAULTS_JSON
     private final Map<String, ?> excludedBuilds
     private Integer sleepTime
     private final currentBuild
@@ -504,7 +505,6 @@ class Regeneration implements Serializable {
         repoHandler.setUserDefaultsJson(context, DEFAULTS_JSON)
 
         params.put('DEFAULTS_JSON', JsonOutput.prettyPrint(JsonOutput.toJson(DEFAULTS_JSON)))
-        Map ADOPT_DEFAULTS_JSON = repoHandler.getAdoptDefaultsJson()
         params.put('ADOPT_DEFAULTS_JSON', JsonOutput.prettyPrint(JsonOutput.toJson(ADOPT_DEFAULTS_JSON)))
 
         params.put('BUILD_CONFIG', config.toJson())

--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -109,6 +109,7 @@ class PullRequestTestPipeline implements Serializable {
                     buildConfigurations,
                     testConfigurations,
                     DEFAULTS_JSON,
+                    ADOPT_DEFAULTS_JSON，
                     excludedBuilds,
                     900,
                     currentBuild,

--- a/pipelines/build/regeneration/build_job_generator.groovy
+++ b/pipelines/build/regeneration/build_job_generator.groovy
@@ -223,6 +223,7 @@ node('worker') {
                     buildConfigurations,
                     targetConfigurations,
                     DEFAULTS_JSON,
+                    ADOPT_DEFAULTS_JSON，
                     excludes,
                     sleepTime,
                     currentBuild,
@@ -246,6 +247,7 @@ node('worker') {
                 buildConfigurations,
                 targetConfigurations,
                 DEFAULTS_JSON,
+                ADOPT_DEFAULTS_JSON，
                 excludes,
                 sleepTime,
                 currentBuild,


### PR DESCRIPTION
	- the content might be different if the generator job use a different branch than master