### PR TITLE
Pass AdoptDefaults and buildConfig CI/BUILD_REF overrides to RepoHandler

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -813,7 +813,12 @@ class Builder implements Serializable {
                         // Execute build job for configuration i.e jdk11u/job/jdk11u-linux-x64-hotspot
                         context.stage(configuration.key) {
                             // Triggering downstream job ${downstreamJobName}
-                            def downstreamJob = context.build job: downstreamJobName, propagate: false, parameters: config.toBuildParams()
+
+                            def buildJobParams = config.toBuildParams()
+                            // Pass down DEFAULTS_JSON
+                            buildJobParams.add(['$class': 'TextParameterValue', name: 'DEFAULTS_JSON', value: JsonOutput.prettyPrint(JsonOutput.toJson(DEFAULTS_JSON)) ])
+
+                            def downstreamJob = context.build job: downstreamJobName, propagate: false, parameters: buildJobParams
 
                             if (downstreamJob.getResult() == 'SUCCESS') {
                                 // copy artifacts from build

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1277,6 +1277,16 @@ class Build {
     }
 
     /*
+     Display the current git repo information
+     */
+    def printGitRepoInfo() {
+        context.println 'Checked out pipeline scripts:'
+        context.sh(script: 'git status')
+        context.println 'Checked out HEAD commit SHA:'
+        context.sh(script: 'git rev-parse HEAD')
+    }
+
+    /*
     Executed on a build node, the function checks out the repository and executes the build via ./make-adopt-build-farm.sh
     Once the build completes, it will calculate its version output, commit the first metadata writeout, and archive the build results.
     Running in downstream job jdk-*-*-* build stage, called by build()
@@ -1344,6 +1354,8 @@ class Build {
                         repoHandler.setUserDefaultsJson(context, DEFAULTS_JSON)
                         repoHandler.checkoutUserPipelines(context)
                     }
+                    printGitRepoInfo()
+
                     // Perform a git clean outside of checkout to avoid the Jenkins enforced 10 minute timeout
                     // https://github.com/adoptium/infrastucture/issues/1553
                     context.sh(script: 'git clean -fdx')
@@ -1378,6 +1390,7 @@ class Build {
                             if (useAdoptShellScripts) {
                                 context.println '[CHECKOUT] Checking out to adoptium/temurin-build...'
                                 repoHandler.checkoutAdoptBuild(context)
+                                printGitRepoInfo()
                                 if (buildConfig.TARGET_OS == 'mac' && buildConfig.JAVA_TO_BUILD != 'jdk8u') {
                                     def macSignBuildArgs
                                     if (env.BUILD_ARGS != null && !env.BUILD_ARGS.isEmpty()) {
@@ -1408,6 +1421,7 @@ class Build {
                                         context.sh "rm -rf ${macos_base_path}/* || true"
 
                                         repoHandler.checkoutAdoptBuild(context)
+                                        printGitRepoInfo()
 
                                         // Copy pre assembled binary ready for JMODs to be codesigned
                                         context.unstash 'jmods'
@@ -1468,14 +1482,17 @@ class Build {
                                 } else {
                                     repoHandler.setUserDefaultsJson(context, DEFAULTS_JSON)
                                     repoHandler.checkoutUserPipelines(context)
+                                    printGitRepoInfo()
                                 }
                             } else {
                                 context.println "[CHECKOUT] Checking out to the user's temurin-build..."
                                 repoHandler.setUserDefaultsJson(context, DEFAULTS_JSON)
                                 repoHandler.checkoutUserBuild(context)
+                                printGitRepoInfo()
                                 context.sh(script: "./${DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
                                 context.println '[CHECKOUT] Reverting pre-build user temurin-build checkout...'
                                 repoHandler.checkoutUserPipelines(context)
+                                printGitRepoInfo()
                             }
                         }
                     } catch (FlowInterruptedException e) {
@@ -1748,6 +1765,7 @@ class Build {
                                         } else {
                                             repoHandler.checkoutUserPipelines(context)
                                         }
+                                        printGitRepoInfo()
 
                                         // Perform a git clean outside of checkout to avoid the Jenkins enforced 10 minute timeout
                                         // https://github.com/adoptium/infrastucture/issues/1553

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1280,7 +1280,7 @@ class Build {
      Display the current git repo information
      */
     def printGitRepoInfo() {
-        context.println 'Checked out pipeline scripts:'
+        context.println 'Checked out repo:'
         context.sh(script: 'git status')
         context.println 'Checked out HEAD commit SHA:'
         context.sh(script: 'git rev-parse HEAD')

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1301,9 +1301,10 @@ class Build {
             context.println JsonOutput.toJson(DEFAULTS_JSON)
             context.println 'ADOPT_DEFAULTS_JSON: '
             context.println JsonOutput.toJson(ADOPT_DEFAULTS_JSON)
-            context.println 'buildConfig.CI_REF: ' + buildConfig.CI_REF
-            context.println 'buildConfig.BUILD_REF: ' + buildConfig.BUILD_REF
-            context.println 'buildConfig.HELPER_REF: ' + buildConfig.HELPER_REF
+            context.println 'Optional branch/tag/commitSHA overrides:'
+            context.println '    buildConfig.CI_REF: ' + buildConfig.CI_REF
+            context.println '    buildConfig.BUILD_REF: ' + buildConfig.BUILD_REF
+            context.println '    buildConfig.HELPER_REF: ' + buildConfig.HELPER_REF
 
             if (cleanWorkspace) {
                 try {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1357,7 +1357,7 @@ class Build {
                 envVars.add("FILENAME=${filename}" as String)
 
                 // Use BUILD_REF override if specified
-                def adoptBranch = buildConfig.BUILD_REF ?: ${ADOPT_DEFAULTS_JSON['repository']['build_branch']}
+                def adoptBranch = buildConfig.BUILD_REF ?: ADOPT_DEFAULTS_JSON['repository']['build_branch']
 
                 // Add platform config path so it can be used if the user doesn't have one
                 def splitAdoptUrl = ((String)ADOPT_DEFAULTS_JSON['repository']['build_url']) - ('.git').split('/')

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1354,11 +1354,12 @@ class Build {
                         repoHandler.setUserDefaultsJson(context, DEFAULTS_JSON)
                         repoHandler.checkoutUserPipelines(context)
                     }
-                    printGitRepoInfo()
 
                     // Perform a git clean outside of checkout to avoid the Jenkins enforced 10 minute timeout
                     // https://github.com/adoptium/infrastucture/issues/1553
                     context.sh(script: 'git clean -fdx')
+
+                    printGitRepoInfo()
                 }
             } catch (FlowInterruptedException e) {
                 throw new Exception("[ERROR] Node checkout workspace timeout (${buildTimeouts.NODE_CHECKOUT_TIMEOUT} HOURS) has been reached. Exiting...")
@@ -1482,8 +1483,8 @@ class Build {
                                 } else {
                                     repoHandler.setUserDefaultsJson(context, DEFAULTS_JSON)
                                     repoHandler.checkoutUserPipelines(context)
-                                    printGitRepoInfo()
                                 }
+                                printGitRepoInfo()
                             } else {
                                 context.println "[CHECKOUT] Checking out to the user's temurin-build..."
                                 repoHandler.setUserDefaultsJson(context, DEFAULTS_JSON)
@@ -1765,11 +1766,12 @@ class Build {
                                         } else {
                                             repoHandler.checkoutUserPipelines(context)
                                         }
-                                        printGitRepoInfo()
 
                                         // Perform a git clean outside of checkout to avoid the Jenkins enforced 10 minute timeout
                                         // https://github.com/adoptium/infrastucture/issues/1553
                                         context.sh(script: 'git clean -fdx')
+
+                                        printGitRepoInfo()
                                     }
                                 } catch (FlowInterruptedException e) {
                                     throw new Exception("[ERROR] Controller docker file scm checkout timeout (${buildTimeouts.DOCKER_CHECKOUT_TIMEOUT} HOURS) has been reached. Exiting...")


### PR DESCRIPTION
Pass knowledge of build REF overrides and AdoptDefaults json to the RepoHandler
And ensure all set correctly from ci-jenkins-pipelines

Fixes: https://github.com/adoptium/ci-jenkins-pipelines/issues/603

Signed-off-by: Andrew Leonard <anleonar@redhat.com>