### PR TITLE
Enable kick_off_build to load User remoteConfigs ci-jenkins-pipelines when requested

### DIFF
--- a/pipelines/build/common/kick_off_build.groovy
+++ b/pipelines/build/common/kick_off_build.groovy
@@ -60,7 +60,7 @@ node('worker') {
         def useAdoptShellScripts = Boolean.valueOf(buildConf.get('USE_ADOPT_SHELL_SCRIPTS'))
         if (useAdoptShellScripts && params.USER_REMOTE_CONFIGS) {
             println "Checking out User pipelines url from userRemoteConfigs: ${userRemoteConfigs}"
-            context.checkout([$class: 'GitSCM', userRemoteConfigs: userRemoteConfigs])
+            checkout([$class: 'GitSCM', userRemoteConfigs: userRemoteConfigs])
         }
     }
 

--- a/pipelines/build/common/kick_off_build.groovy
+++ b/pipelines/build/common/kick_off_build.groovy
@@ -60,7 +60,7 @@ node('worker') {
         def useAdoptShellScripts = Boolean.valueOf(buildConf.get('USE_ADOPT_SHELL_SCRIPTS'))
         if (useAdoptShellScripts && params.USER_REMOTE_CONFIGS) {
             println "Checking out User pipelines url from userRemoteConfigs: ${userRemoteConfigs}"
-            context.checkout([$class: 'GitSCM', userRemoteConfigs: userRemoteConfigs)
+            context.checkout([$class: 'GitSCM', userRemoteConfigs: userRemoteConfigs])
         }
     }
 

--- a/pipelines/build/common/kick_off_build.groovy
+++ b/pipelines/build/common/kick_off_build.groovy
@@ -55,6 +55,13 @@ node('worker') {
     if (BUILD_CONFIGURATION) { // overwrite branch from USER_REMOTE_CONFIGS if the value is not empty or null
         buildConf = new JsonSlurper().parseText(BUILD_CONFIGURATION) as Map
         userRemoteConfigs['branch'] = buildConf.get('CI_REF') ?: userRemoteConfigs['branch']
+
+        // If using User scripts and USER_REMOTE_CONFIGS supplied ensure downstreamBuilder is loaded from the user repo
+        def useAdoptShellScripts = Boolean.valueOf(buildConf.get('USE_ADOPT_SHELL_SCRIPTS'))
+        if (useAdoptShellScripts && params.USER_REMOTE_CONFIGS) {
+            println "Checking out User pipelines url from userRemoteConfigs: ${userRemoteConfigs}"
+            context.checkout([$class: 'GitSCM', userRemoteConfigs: userRemoteConfigs)
+        }
     }
 
     String helperRef = buildConf.get('HELPER_REF') ?: LOCAL_DEFAULTS_JSON['repository']['helper_ref']

--- a/pipelines/build/common/kick_off_build.groovy
+++ b/pipelines/build/common/kick_off_build.groovy
@@ -58,7 +58,7 @@ node('worker') {
 
         // If using User scripts and USER_REMOTE_CONFIGS supplied ensure downstreamBuilder is loaded from the user repo
         def useAdoptShellScripts = Boolean.valueOf(buildConf.get('USE_ADOPT_SHELL_SCRIPTS'))
-        if (useAdoptShellScripts && params.USER_REMOTE_CONFIGS) {
+        if (!useAdoptShellScripts && params.USER_REMOTE_CONFIGS) {
             println "Checking out User pipelines url from userRemoteConfigs: ${userRemoteConfigs}"
             checkout([$class: 'GitSCM', userRemoteConfigs: [[url: userRemoteConfigs['remotes']['url']]], branches: [[name: userRemoteConfigs['branch']]] ])
         }

--- a/pipelines/build/common/kick_off_build.groovy
+++ b/pipelines/build/common/kick_off_build.groovy
@@ -60,7 +60,7 @@ node('worker') {
         def useAdoptShellScripts = Boolean.valueOf(buildConf.get('USE_ADOPT_SHELL_SCRIPTS'))
         if (useAdoptShellScripts && params.USER_REMOTE_CONFIGS) {
             println "Checking out User pipelines url from userRemoteConfigs: ${userRemoteConfigs}"
-            checkout([$class: 'GitSCM', userRemoteConfigs: userRemoteConfigs])
+            checkout([$class: 'GitSCM', userRemoteConfigs: [[url: userRemoteConfigs['remotes']['url']]], branches: [[name: userRemoteConfigs['branch']]] ])
         }
     }
 


### PR DESCRIPTION
Currently build jobs never run pipelines/build/common/openjdk_build_pipeline.groovy from the User remoteConfigs, even when useAdoptScripts=false, it currently always uses the ci-jenkins-pipelines that is hardcoded into the generated build job scm.

This PR fixes pipelines/build/common/kick_off_build.groovy so that if useAdoptScripts=false and userRemoteConfigs is set, it loads pipelines/build/common/openjdk_build_pipeline.groovy from the userRemoteConfigs.

With this PR, the building using User remoteconfigs pointing at user ci-jenkins-pipelines repo/branch and user defaults for temurin-build&branch, is possible from the top level "pipeline" job.

Fixes: https://github.com/adoptium/ci-jenkins-pipelines/issues/612

