### PR TITLE
Create jdk-21 pipeline configs

### DIFF
--- a/pipelines/jobs/configurations/jdk21.groovy
+++ b/pipelines/jobs/configurations/jdk21.groovy
@@ -1,0 +1,56 @@
+targetConfigurations = [
+        'x64Mac'      : [
+                'temurin'
+        ],
+        'x64Linux'    : [
+                'temurin'
+        ],
+        'x64AlpineLinux' : [
+                'temurin'
+        ],
+        'x64Windows'  : [
+                'temurin'
+        ],
+        'x32Windows'  : [
+                'temurin'
+        ],
+        'ppc64Aix'    : [
+                'temurin'
+        ],
+        'ppc64leLinux': [
+                'temurin'
+        ],
+        's390xLinux'  : [
+                'temurin'
+        ],
+        'aarch64Linux': [
+                'hotspot',
+                'temurin'
+        ],
+        'aarch64Mac': [
+                'temurin'
+        ],
+        'arm32Linux'  : [
+                'temurin'
+        ],
+        'riscv64Linux': [
+                'temurin'
+        ]
+
+]
+
+// 23:30 Mon, Wed, Fri
+triggerSchedule_nightly = 'TZ=UTC\n30 23 * * 1,3,5'
+// 23:30 Sat
+triggerSchedule_weekly = 'TZ=UTC\n30 23 * * 6'
+
+// scmReferences to use for weekly release build
+weekly_release_scmReferences = [
+        'hotspot'        : '',
+        'temurin'        : '',
+        'openj9'         : '',
+        'corretto'       : '',
+        'dragonwell'     : ''
+]
+
+return this

--- a/pipelines/jobs/configurations/jdk21_evaluation.groovy
+++ b/pipelines/jobs/configurations/jdk21_evaluation.groovy
@@ -1,0 +1,29 @@
+targetConfigurations = [
+        'riscv64Linux': [
+                'temurin'
+        ],
+        'aarch64AlpineLinux' : [
+                'temurin'
+        ]
+]
+        // 'aarch64Linux': [
+        //         'hotspot'
+        // ],
+        // 'aarch64Windows' : [
+        //         'temurin'
+        // ],
+
+// if set to empty string then it wont get triggered
+
+// 23:40 Mon, Wed
+triggerSchedule_evaluation = 'TZ=UTC\n40 23 * * 1,3'
+// 23:40 Sat
+triggerSchedule_weekly_evaluation = 'TZ=UTC\n40 23 * * 6'
+
+// scmReferences to use for weekly evaluation release build
+weekly_evaluation_scmReferences = [
+        'hotspot'        : '',
+        'temurin'        : ''
+]
+
+return this

--- a/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
@@ -1,0 +1,185 @@
+class Config21 {
+
+    final Map<String, Map<String, ?>> buildConfigurations = [
+        x64Mac    : [
+                os                  : 'mac',
+                arch                : 'x64',
+                additionalNodeLabels: 'macos10.14',
+                additionalTestLabels: [
+                        openj9      : '!sw.os.osx.10_11'
+                ],
+                test                : 'default',
+                configureArgs       : '--enable-dtrace',
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom'
+                ]
+        ],
+
+        x64Linux  : [
+                os                  : 'linux',
+                arch                : 'x64',
+                dockerImage: [
+                        temurin     : 'adoptopenjdk/centos6_build_image',
+                        openj9      : 'adoptopenjdk/centos7_build_image'
+                ],
+                dockerFile: [
+                        openj9      : 'pipelines/build/dockerFiles/cuda.dockerfile'
+                ],
+                test                : 'default',
+                additionalTestLabels: [
+                        openj9      : '!(centos6||rhel6)'
+                ],
+                configureArgs       : [
+                        'openj9'    : '--enable-dtrace --enable-jitserver',
+                        'temurin'   : '--enable-dtrace'
+                ],
+                buildArgs           : [
+                        'temurin'   : '--create-source-archive --create-jre-image --create-sbom'
+                ]
+        ],
+
+        x64AlpineLinux  : [
+                os                  : 'alpine-linux',
+                arch                : 'x64',
+                dockerImage         : 'adoptopenjdk/alpine3_build_image',
+                test                : 'default',
+                configureArgs       : '--enable-headless-only=yes',
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom'
+                ]
+        ],
+
+        aarch64AlpineLinux  : [
+                os                  : 'alpine-linux',
+                arch                : 'aarch64',
+                dockerImage         : 'adoptopenjdk/alpine3_build_image',
+                test                : 'default',
+                configureArgs       : '--enable-headless-only=yes',
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom'
+                ]
+        ],
+
+        x64Windows: [
+                os                  : 'windows',
+                arch                : 'x64',
+                additionalNodeLabels: 'win2012&&vs2019',
+                test                : 'default',
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom'
+                ]
+        ],
+
+        x32Windows: [
+                os                  : 'windows',
+                arch                : 'x86-32',
+                additionalNodeLabels: 'win2012&&vs2019',
+                test                : 'default',
+                buildArgs           : [
+                        'temurin'   : '--jvm-variant client,server --create-jre-image --create-sbom'
+                ]
+        ],
+
+        ppc64Aix    : [
+                os                  : 'aix',
+                arch                : 'ppc64',
+                additionalNodeLabels: [
+                        temurin: 'xlc16&&aix720',
+                        openj9:  'xlc16&&aix715'
+                ],
+                test                : 'default',
+                additionalTestLabels: [
+                        temurin      : 'sw.os.aix.7_2'
+                ],
+                cleanWorkspaceAfterBuild: true,
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom'
+                ]
+        ],
+
+        s390xLinux    : [
+                os                  : 'linux',
+                arch                : 's390x',
+                test                : 'default',
+                configureArgs       : '--enable-dtrace',
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom'
+                ]
+        ],
+
+        ppc64leLinux    : [
+                os                  : 'linux',
+                arch                : 'ppc64le',
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                test                : 'default',
+                configureArgs       : [
+                        'temurin'     : '--enable-dtrace',
+                        'openj9'      : '--enable-dtrace --enable-jitserver'
+                ],
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom'
+                ]
+        ],
+
+        aarch64Linux    : [
+                os                  : 'linux',
+                arch                : 'aarch64',
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                test                : 'default',
+                configureArgs : '--enable-dtrace',
+                testDynamic          : false,
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom'
+                ]
+        ],
+
+        aarch64Mac: [
+                os                  : 'mac',
+                arch                : 'aarch64',
+                additionalNodeLabels: 'macos11',
+                test                : 'default',
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom'
+                ]
+        ],
+
+        arm32Linux    : [
+                os                  : 'linux',
+                arch                : 'arm',
+                crossCompile        : 'aarch64',
+                dockerImage         : 'adoptopenjdk/ubuntu1604_build_image',
+                dockerArgs          : '--platform linux/arm/v7',
+                test                : 'default',
+                configureArgs       : '--enable-dtrace',
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom'
+                ]
+        ],
+
+        riscv64Linux      :  [
+                os                  : 'linux',
+                arch                : 'riscv64',
+                test                : 'default',
+                configureArgs       : '--enable-dtrace',
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom'
+                ]
+        ],
+
+        aarch64Windows: [
+                os                  : 'windows',
+                arch                : 'aarch64',
+                crossCompile        : 'x64',
+                additionalNodeLabels: 'win2016&&vs2019',
+                test                : false,
+                buildArgs       : [
+                        'temurin'   : '--create-jre-image --create-sbom --cross-compile'
+                ]
+
+        ]
+  ]
+
+}
+
+Config21 config = new Config21()
+return config.buildConfigurations


### PR DESCRIPTION
Create jdk-21 configs so we can re-start the jdk(head) builds which are now jdk-21.

I have set the nightly schedule to where jdk-18 was: https://adoptium.slack.com/archives/C09NW3L2J/p1641473782003000