### PR TITLE
AIX: Update JDK8, 11, 17 to build and test on 7.2

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -89,11 +89,9 @@ class Config11 {
         ppc64Aix    : [
                 os                  : 'aix',
                 arch                : 'ppc64',
-                additionalNodeLabels: [
-                        temurin: 'xlc16&&aix710',
-                        openj9:  'xlc16&&aix715'
-                ],
+                additionalNodeLabels: 'xlc13&&aix720',
                 test                : 'default',
+                additionalTestLabels: 'sw.os.aix.7_2',
                 cleanWorkspaceAfterBuild: true,
                 buildArgs           : [
                         'temurin'   : '--create-sbom'

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -83,11 +83,9 @@ class Config17 {
         ppc64Aix    : [
                 os                  : 'aix',
                 arch                : 'ppc64',
-                additionalNodeLabels: [
-                        temurin: 'xlc16&&aix710',
-                        openj9:  'xlc16&&aix715'
-                ],
+                additionalNodeLabels: 'xlc13&&aix720',
                 test                : 'default',
+                additionalTestLabels: 'sw.os.aix.7_2',
                 cleanWorkspaceAfterBuild: true,
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -78,11 +78,9 @@ class Config8 {
         ppc64Aix      : [
                 os  : 'aix',
                 arch: 'ppc64',
-                additionalNodeLabels: [
-                        temurin: 'xlc13&&aix710',
-                        openj9:  'xlc13&&aix715'
-                ],
+                additionalNodeLabels: 'xlc13&&aix720',
                 test                 : 'default',
+                additionalTestLabels : 'sw.os.aix.7_2',
                 cleanWorkspaceAfterBuild: true,
                 buildArgs           : [
                         'temurin'   : '--create-sbom'


### PR DESCRIPTION
As per recent PMC meeting we are looking at moving up to building on AIX 7.2 for the LTS releases now that AIX 7.1 is due to go out of support in April. This has been discussed with IBM who agree that we should look at ensuring we can build and test on AIX 7.2 going forward (although reserving the right to back it out before April if a decision is reversed!)