### PR TITLE
Update: use jenkins built-in variable to get job url

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -21,7 +21,6 @@ import java.time.temporal.ChronoUnit
 
 node('worker') {
     def variant = "${params.VARIANT}"
-    def jenkinsUrl = "${params.JENKINS_URL}"
     def trssUrl    = "${params.TRSS_URL}"
     def apiUrl    = "${params.API_URL}"
     def slackChannel = "${params.SLACK_CHANNEL}"
@@ -248,7 +247,7 @@ node('worker') {
         }
 
         // Slack message:
-        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium Nightly Build Success : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + jenkinsUrl + '/view/Tooling/job/nightlyBuildAndTestStats_' + variant + '/' + BUILD_NUMBER + '/console|Detail>')
+        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium Nightly Build Success : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
     }
 
     stage('printPublishStats') {


### PR DESCRIPTION
Easy to skip setting of jenkins_url from parameters and job can point to the running one.
not always use https://ci.adoptium.net/view/Tooling/job/nightlyBuildAndTestStats_*