### PR TITLE
Move JDK20/21 on Linux/x64 to CentOS7 instead of CentOS6

### DIFF
--- a/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
@@ -18,10 +18,7 @@ class Config20 {
         x64Linux  : [
                 os                  : 'linux',
                 arch                : 'x64',
-                dockerImage: [
-                        temurin     : 'adoptopenjdk/centos6_build_image',
-                        openj9      : 'adoptopenjdk/centos7_build_image'
-                ],
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
                 dockerFile: [
                         openj9      : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],

--- a/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
@@ -18,10 +18,7 @@ class Config21 {
         x64Linux  : [
                 os                  : 'linux',
                 arch                : 'x64',
-                dockerImage: [
-                        temurin     : 'adoptopenjdk/centos6_build_image',
-                        openj9      : 'adoptopenjdk/centos7_build_image'
-                ],
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
                 dockerFile: [
                         openj9      : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],


### PR DESCRIPTION
Red Hat's portable builds of all LTS versions already support only 7 and later. This will bring our X64 builds for JDK20 and the new LTS release of 21 later this year in line with the other Linux architectures and move the required glibc level up accordingly for consistency.
For now I am nor proposing any change to the prior LTS releases.
Similar to the changes we have proposed for Win32 and AIX, we will use the short-term-support JDK20 to gauge response in advance of the next LTS release.