### PR TITLE
Fix Release Pipeline Job Generator For None "u" releases

### DIFF
--- a/pipelines/jobs/configurations/jdk20_release.groovy
+++ b/pipelines/jobs/configurations/jdk20_release.groovy
@@ -11,17 +11,19 @@ targetConfigurations = [
         'x64Windows'  : [
                 'temurin'
         ],
-        'ppc64Aix'    : [
+        'x32Windows'  : [
                 'temurin'
         ],
         'ppc64leLinux': [
+                'temurin'
+        ],
+        'ppc64Aix'    : [
                 'temurin'
         ],
         's390xLinux'  : [
                 'temurin'
         ],
         'aarch64Linux': [
-                'hotspot',
                 'temurin'
         ],
         'aarch64Mac': [
@@ -29,25 +31,7 @@ targetConfigurations = [
         ],
         'arm32Linux'  : [
                 'temurin'
-        ],
-        'riscv64Linux': [
-                'temurin'
         ]
-
-]
-
-// 03:30 Wed, Fri
-triggerSchedule_nightly = 'TZ=UTC\n30 03 * * 3,5'
-// 23:30 Sat
-triggerSchedule_weekly = 'TZ=UTC\n30 23 * * 6'
-
-// scmReferences to use for weekly release build
-weekly_release_scmReferences = [
-        'hotspot'        : '',
-        'temurin'        : '',
-        'openj9'         : '',
-        'corretto'       : '',
-        'dragonwell'     : ''
 ]
 
 return this

--- a/pipelines/jobs/configurations/jdk20_release.groovy
+++ b/pipelines/jobs/configurations/jdk20_release.groovy
@@ -1,0 +1,53 @@
+targetConfigurations = [
+        'x64Mac'      : [
+                'temurin'
+        ],
+        'x64Linux'    : [
+                'temurin'
+        ],
+        'x64AlpineLinux' : [
+                'temurin'
+        ],
+        'x64Windows'  : [
+                'temurin'
+        ],
+        'ppc64Aix'    : [
+                'temurin'
+        ],
+        'ppc64leLinux': [
+                'temurin'
+        ],
+        's390xLinux'  : [
+                'temurin'
+        ],
+        'aarch64Linux': [
+                'hotspot',
+                'temurin'
+        ],
+        'aarch64Mac': [
+                'temurin'
+        ],
+        'arm32Linux'  : [
+                'temurin'
+        ],
+        'riscv64Linux': [
+                'temurin'
+        ]
+
+]
+
+// 03:30 Wed, Fri
+triggerSchedule_nightly = 'TZ=UTC\n30 03 * * 3,5'
+// 23:30 Sat
+triggerSchedule_weekly = 'TZ=UTC\n30 23 * * 6'
+
+// scmReferences to use for weekly release build
+weekly_release_scmReferences = [
+        'hotspot'        : '',
+        'temurin'        : '',
+        'openj9'         : '',
+        'corretto'       : '',
+        'dragonwell'     : ''
+]
+
+return this


### PR DESCRIPTION
Fixes the Release Pipeline Job Generator For None "u" releases, it also wraps the pipeline jobs generator inside the main loop.

Fixes #646 