### PR TITLE
Propagate downstream build & test results for pipeline.

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -302,7 +302,7 @@ class Build {
 
                 context.catchError {
                     context.build job: jobName,
-                            propagate: false,
+                            propagate: true,
                             parameters: [
                                     context.string(name: 'SDK_RESOURCE', value: 'upstream'),
                                     context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
@@ -423,7 +423,7 @@ class Build {
                         }
                         context.catchError {
                             def testJob = context.build job: jobName,
-                                            propagate: false,
+                                            propagate: true,
                                             parameters: [
                                                 context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
                                                 context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -1,7 +1,7 @@
 import groovy.json.JsonOutput
 
 gitRefSpec = ''
-propagateFailures = false
+propagateFailures = true
 runTests = enableTests
 runParallel = enableTestDynamicParallel
 runInstaller = true
@@ -112,7 +112,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
         booleanParam('cleanWorkspaceBeforeBuild', false, 'Clean out the workspace before the build')
         booleanParam('cleanWorkspaceAfterBuild', false, 'Clean out the workspace after the build')
         booleanParam('cleanWorkspaceBuildOutputAfterBuild', cleanWsBuildOutput, 'Clean out the workspace/build/src/build and workspace/target output only, after the build')
-        booleanParam('propagateFailures', propagateFailures, 'If true, a failure of <b>ANY</b> downstream build (but <b>NOT</b> test) will cause the whole build to fail')
+        booleanParam('propagateFailures', propagateFailures, 'If true, a failure of <b>ANY</b> downstream build will cause the whole build to fail')
         booleanParam('keepTestReportDir', false, 'If true, test report dir (including core files where generated) will be kept even when the testcase passes, failed testcases always keep the report dir. Does not apply to JUnit jobs which are always kept, eg.openjdk.')
         booleanParam('keepReleaseLogs', true, 'If true, "Release" type pipeline Jenkins logs will be marked as "Keep this build forever".')
         stringParam('adoptBuildNumber', '', 'Empty by default. If you ever need to re-release then bump this number. Currently this is only added to the build metadata file.')

--- a/pipelines/jobs/release_pipeline_job_template.groovy
+++ b/pipelines/jobs/release_pipeline_job_template.groovy
@@ -1,7 +1,7 @@
 import groovy.json.JsonOutput
 
 String gitRefSpec = ''
-Boolean propagateFailures = false
+Boolean propagateFailures = true
 Boolean runTests = true
 Boolean runParallel = true
 Boolean runInstaller = true
@@ -88,7 +88,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
         booleanParam('cleanWorkspaceBeforeBuild', false, 'Clean out the workspace before the build')
         booleanParam('cleanWorkspaceAfterBuild', false, 'Clean out the workspace after the build')
         booleanParam('cleanWorkspaceBuildOutputAfterBuild', cleanWsBuildOutput, 'Clean out the workspace/build/src/build and workspace/target output only, after the build')
-        booleanParam('propagateFailures', propagateFailures, 'If true, a failure of <b>ANY</b> downstream build (but <b>NOT</b> test) will cause the whole build to fail')
+        booleanParam('propagateFailures', propagateFailures, 'If true, a failure of <b>ANY</b> downstream build will cause the whole build to fail')
         booleanParam('keepTestReportDir', false, 'If true, test report dir (including core files where generated) will be kept even when the testcase passes, failed testcases always keep the report dir. Does not apply to JUnit jobs which are always kept, eg.openjdk.')
         booleanParam('keepReleaseLogs', true, 'If true, "Release" type pipeline Jenkins logs will be marked as "Keep this build forever".')
         stringParam('adoptBuildNumber', '', 'Empty by default. If you ever need to re-release then bump this number. Currently this is only added to the build metadata file.')


### PR DESCRIPTION
Changes the pipeline propagateFailures param to default to "True".
Also, ensure all sub-jobs including tests are propagated.

Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/234
