### PR TITLE
Use rhel7_build_image for Linux/s390x builds (#642)

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -103,6 +103,7 @@ class Config11 {
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
+                dockerImage         : 'rhel7_build_image',
                 test                : 'default',
                 configureArgs       : '--enable-dtrace=auto',
                 buildArgs           : [

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -97,6 +97,7 @@ class Config17 {
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
+                dockerImage         : 'rhel7_build_image',
                 test                : 'default',
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [

--- a/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
@@ -87,6 +87,7 @@ class Config20 {
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
+                dockerImage         : 'rhel7_build_image',
                 test                : 'default',
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [

--- a/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
@@ -87,6 +87,7 @@ class Config21 {
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
+                dockerImage         : 'rhel7_build_image',
                 test                : 'default',
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -96,6 +96,7 @@ class Config8 {
                         temurin: ['sanity.openjdk'],
                         openj9: 'default'
                 ],
+                dockerImage         : 'rhel7_build_image',
                 buildArgs           : [
                         'temurin'   : '--create-sbom'
                 ]


### PR DESCRIPTION
Cherry picked across to release branch. May be subsequently superceded if we push the image to dockerhub (Ref https://github.com/adoptium/ci-jenkins-pipelines/pull/611#issuecomment-1458490322) but this puts it in line with master for now.