### PR TITLE
Remove riscv64Linux from jdk20/21 nightly config, as already in evaluation

### DIFF
--- a/pipelines/jobs/configurations/jdk20.groovy
+++ b/pipelines/jobs/configurations/jdk20.groovy
@@ -29,11 +29,7 @@ targetConfigurations = [
         ],
         'arm32Linux'  : [
                 'temurin'
-        ],
-        'riscv64Linux': [
-                'temurin'
         ]
-
 ]
 
 // 03:30 Wed, Fri

--- a/pipelines/jobs/configurations/jdk21.groovy
+++ b/pipelines/jobs/configurations/jdk21.groovy
@@ -29,11 +29,7 @@ targetConfigurations = [
         ],
         'arm32Linux'  : [
                 'temurin'
-        ],
-        'riscv64Linux': [
-                'temurin'
         ]
-
 ]
 
 // 23:30 Mon, Wed, Fri


### PR DESCRIPTION
jdk20/21 riscv64Linux is in nightly and in evaluation pipelines.
Already in evaluation: https://github.com/adoptium/ci-jenkins-pipelines/blob/d8615aeb7bbb74e0560eacb550a4a644b678458d/pipelines/jobs/configurations/jdk20_evaluation.groovy#L2
