### PR TITLE
enable default testing for windows aarch64

### DIFF
--- a/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
@@ -159,7 +159,7 @@ class Config20 {
                 arch                : 'aarch64',
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2016&&vs2019',
-                test                : false,
+                test                : 'default',
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile'
                 ]

--- a/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
@@ -159,7 +159,7 @@ class Config21 {
                 arch                : 'aarch64',
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2016&&vs2019',
-                test                : false,
+                test                : 'default',
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile'
                 ]


### PR DESCRIPTION
Enable AQAvit testing on the windows aarch64 evaluation builds.

Microsoft has been running them internally so they should be coming up green now.

I'm also in the process of adding a second windows aarch64 test machine so we can run the tests more quickly