### PR TITLE
Prefix all permissions in generated jenkins jobs

### DIFF
--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -72,14 +72,14 @@ pipelineJob("$buildFolder/$JOB_NAME") {
                     // Do not inherit permissions from global configuration
                     nonInheriting()
                 }
-                permissions(['hudson.model.Item.Build:AdoptOpenJDK*build', 'hudson.model.Item.Build:AdoptOpenJDK*build-triage',
-                'hudson.model.Item.Cancel:AdoptOpenJDK*build', 'hudson.model.Item.Cancel:AdoptOpenJDK*build-triage',
-                'hudson.model.Item.Configure:AdoptOpenJDK*build', 'hudson.model.Item.Configure:AdoptOpenJDK*build-triage',
-                'hudson.model.Item.Read:AdoptOpenJDK*build', 'hudson.model.Item.Read:AdoptOpenJDK*build-triage',
+                permissions(['GROUP:hudson.model.Item.Build:AdoptOpenJDK*build', 'GROUP:hudson.model.Item.Build:AdoptOpenJDK*build-triage',
+                'GROUP:hudson.model.Item.Cancel:AdoptOpenJDK*build', 'GROUP:hudson.model.Item.Cancel:AdoptOpenJDK*build-triage',
+                'GROUP:hudson.model.Item.Configure:AdoptOpenJDK*build', 'GROUP:hudson.model.Item.Configure:AdoptOpenJDK*build-triage',
+                'GROUP:hudson.model.Item.Read:AdoptOpenJDK*build', 'GROUP:hudson.model.Item.Read:AdoptOpenJDK*build-triage',
                 // eclipse-temurin-bot needs read access for TRSS
-                'hudson.model.Item.Read:eclipse-temurin-bot',
-                'hudson.model.Item.Workspace:AdoptOpenJDK*build', 'hudson.model.Item.Workspace:AdoptOpenJDK*build-triage',
-                'hudson.model.Run.Update:AdoptOpenJDK*build', 'hudson.model.Run.Update:AdoptOpenJDK*build-triage'])
+                'USER:hudson.model.Item.Read:eclipse-temurin-bot',
+                'GROUP:hudson.model.Item.Workspace:AdoptOpenJDK*build', 'GROUP:hudson.model.Item.Workspace:AdoptOpenJDK*build-triage',
+                'GROUP:hudson.model.Run.Update:AdoptOpenJDK*build', 'GROUP:hudson.model.Run.Update:AdoptOpenJDK*build-triage'])
             }
         }
         disableConcurrentBuilds()

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -62,16 +62,16 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
                     // Do not inherit permissions from global configuration
                     nonInheriting()
                 }
-                permissions(['hudson.model.Item.Build:AdoptOpenJDK*build', 'hudson.model.Item.Build:AdoptOpenJDK*build-triage',
-                'hudson.model.Item.Cancel:AdoptOpenJDK*build', 'hudson.model.Item.Cancel:AdoptOpenJDK*build-triage',
-                'hudson.model.Item.Configure:AdoptOpenJDK*build', 'hudson.model.Item.Configure:AdoptOpenJDK*build-triage',
-                'hudson.model.Item.Read:AdoptOpenJDK*build', 'hudson.model.Item.Read:AdoptOpenJDK*build-triage',
+                permissions(['GROUP:hudson.model.Item.Build:AdoptOpenJDK*build', 'GROUP:hudson.model.Item.Build:AdoptOpenJDK*build-triage',
+                'GROUP:hudson.model.Item.Cancel:AdoptOpenJDK*build', 'GROUP:hudson.model.Item.Cancel:AdoptOpenJDK*build-triage',
+                'GROUP:hudson.model.Item.Configure:AdoptOpenJDK*build', 'GROUP:hudson.model.Item.Configure:AdoptOpenJDK*build-triage',
+                'GROUP:hudson.model.Item.Read:AdoptOpenJDK*build', 'GROUP:hudson.model.Item.Read:AdoptOpenJDK*build-triage',
                 // eclipse-temurin-bot needs read access for TRSS
-                'hudson.model.Item.Read:eclipse-temurin-bot',
+                'GROUP:hudson.model.Item.Read:eclipse-temurin-bot',
                 // eclipse-temurin-compliance bot needs read access for https://ci.eclipse.org/temurin-compliance
-                'hudson.model.Item.Read:eclipse-temurin-compliance-bot',
-                'hudson.model.Item.Workspace:AdoptOpenJDK*build', 'hudson.model.Item.Workspace:AdoptOpenJDK*build-triage',
-                'hudson.model.Run.Update:AdoptOpenJDK*build', 'hudson.model.Run.Update:AdoptOpenJDK*build-triage'])
+                'GROUP:hudson.model.Item.Read:eclipse-temurin-compliance-bot',
+                'GROUP:hudson.model.Item.Workspace:AdoptOpenJDK*build', 'GROUP:hudson.model.Item.Workspace:AdoptOpenJDK*build-triage',
+                'GROUP:hudson.model.Run.Update:AdoptOpenJDK*build', 'GROUP:hudson.model.Run.Update:AdoptOpenJDK*build-triage'])
             }
         }
         pipelineTriggers {

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -69,7 +69,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
                 // eclipse-temurin-bot needs read access for TRSS
                 'GROUP:hudson.model.Item.Read:eclipse-temurin-bot',
                 // eclipse-temurin-compliance bot needs read access for https://ci.eclipse.org/temurin-compliance
-                'GROUP:hudson.model.Item.Read:eclipse-temurin-compliance-bot',
+                'USER:hudson.model.Item.Read:eclipse-temurin-compliance-bot',
                 'GROUP:hudson.model.Item.Workspace:AdoptOpenJDK*build', 'GROUP:hudson.model.Item.Workspace:AdoptOpenJDK*build-triage',
                 'GROUP:hudson.model.Run.Update:AdoptOpenJDK*build', 'GROUP:hudson.model.Run.Update:AdoptOpenJDK*build-triage'])
             }

--- a/pipelines/jobs/release_pipeline_job_template.groovy
+++ b/pipelines/jobs/release_pipeline_job_template.groovy
@@ -42,16 +42,16 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
                 // Do not inherit permissions from global configuration
                 nonInheriting()
             }
-            permissions(['hudson.model.Item.Build:AdoptOpenJDK*build', 'hudson.model.Item.Build:AdoptOpenJDK*build-triage',
-            'hudson.model.Item.Cancel:AdoptOpenJDK*build', 'hudson.model.Item.Cancel:AdoptOpenJDK*build-triage',
-            'hudson.model.Item.Configure:AdoptOpenJDK*build', 'hudson.model.Item.Configure:AdoptOpenJDK*build-triage',
-            'hudson.model.Item.Read:AdoptOpenJDK*build', 'hudson.model.Item.Read:AdoptOpenJDK*build-triage',
+            permissions(['GROUP:hudson.model.Item.Build:AdoptOpenJDK*build', 'GROUP:hudson.model.Item.Build:AdoptOpenJDK*build-triage',
+            'GROUP:hudson.model.Item.Cancel:AdoptOpenJDK*build', 'GROUP:hudson.model.Item.Cancel:AdoptOpenJDK*build-triage',
+            'GROUP:hudson.model.Item.Configure:AdoptOpenJDK*build', 'GROUP:hudson.model.Item.Configure:AdoptOpenJDK*build-triage',
+            'GROUP:hudson.model.Item.Read:AdoptOpenJDK*build', 'GROUP:hudson.model.Item.Read:AdoptOpenJDK*build-triage',
             // eclipse-temurin-bot needs read access for TRSS
-            'hudson.model.Item.Read:eclipse-temurin-bot',
+            'USER:hudson.model.Item.Read:eclipse-temurin-bot',
             // eclipse-temurin-compliance bot needs read access for https://ci.eclipse.org/temurin-compliance
-            'hudson.model.Item.Read:eclipse-temurin-compliance-bot',
-            'hudson.model.Item.Workspace:AdoptOpenJDK*build', 'hudson.model.Item.Workspace:AdoptOpenJDK*build-triage',
-            'hudson.model.Run.Update:AdoptOpenJDK*build', 'hudson.model.Run.Update:AdoptOpenJDK*build-triage'])
+            'USER:hudson.model.Item.Read:eclipse-temurin-compliance-bot',
+            'GROUP:hudson.model.Item.Workspace:AdoptOpenJDK*build', 'GROUP:hudson.model.Item.Workspace:AdoptOpenJDK*build-triage',
+            'GROUP:hudson.model.Run.Update:AdoptOpenJDK*build', 'GROUP:hudson.model.Run.Update:AdoptOpenJDK*build-triage'])
         }
         copyArtifactPermission {
             projectNames('*')


### PR DESCRIPTION
Ref: https://github.com/jenkinsci/matrix-auth-plugin/releases/tag/matrix-auth-3.0
The latest matrix authorization plugin in jenkins puts up warnings for permissions specifications which are not prefixed with `USER:` or `GROUP:`.
This changes the generation jobs to add the appropriate prefix.

To reviewers: Please check that I've added the correct prefix on this because my eyes are going fuzzy at this point.
I've updated a number of the non-generated jobs manually already, but not touched any autogenerated ones.
