### PR TITLE
Update jdk20_21 pipelines to run on win2022

### DIFF
--- a/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
@@ -60,7 +60,7 @@ class Config20 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
-                additionalNodeLabels: 'win2012&&vs2019',
+                additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'

--- a/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
@@ -60,7 +60,7 @@ class Config21 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
-                additionalNodeLabels: 'win2012&&vs2019',
+                additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'


### PR DESCRIPTION
Cherry pick Update jdk20\_21 pipelines to run on win2022