### PR TITLE
enable evaluation builds of 11 and 17 for windows aarch64

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_evaluation.groovy
+++ b/pipelines/jobs/configurations/jdk11u_evaluation.groovy
@@ -1,6 +1,8 @@
 // when no target for evaluation, set it to null and disable scheduler below
-targetConfigurations = null
-//[
+targetConfigurations = [
+        'aarch64Windows': [
+                'temurin'
+        ]
         // 'x64Mac'        : [
         //         'openj9'
         // ],
@@ -28,11 +30,8 @@ targetConfigurations = null
         //         'openj9',
         //         'dragonwell',
         //         'bisheng'
-        // ],
-        // 'aarch64Windows': [
-        //         'temurin'
         // ]
-//]
+]
 
 // if set to empty string then it wont get triggered
 triggerSchedule_evaluation = ''

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -215,7 +215,7 @@ class Config11 {
                 arch                : 'aarch64',
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2016&&vs2019',
-                test                : false,
+                test                : 'default',
                 buildArgs       : [
                         'temurin'   : '--jvm-variant client,server --create-sbom --cross-compile'
                 ]

--- a/pipelines/jobs/configurations/jdk17u_evaluation.groovy
+++ b/pipelines/jobs/configurations/jdk17u_evaluation.groovy
@@ -1,10 +1,10 @@
 targetConfigurations = [
         'aarch64AlpineLinux' : [
                 'temurin'
+        ],
+        'aarch64Windows': [
+                'temurin'
         ]
-        // 'aarch64Windows': [
-        //         'temurin'
-        // ],
         // 'x64Mac'      : [
         //         'openj9'
         // ],

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -161,7 +161,7 @@ class Config17 {
                 arch                : 'aarch64',
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2016&&vs2019',
-                test                : false,
+                test                : 'default',
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile'
                 ]


### PR DESCRIPTION
The JDK20 evaluation pipeline for Windows aarch64 seems stable now so I'd like to enable the 11 and 17 builds (for monitoring)