### PR TITLE
Change build success to mean non failure

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -149,7 +149,7 @@ node('worker') {
                                     pipelineBuildJobsJson.each { buildJob ->
                                         if (buildJob.buildName.contains(buildVariant)) {
                                             buildJobNumber += 1
-                                            if (buildJob.buildResult.equals('FAILED')) {
+                                            if (buildJob.buildResult.equals('FAILURE')) {
                                                 buildJobFailure += 1
                       } else {
                                                 buildJobComplete += 1

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -90,7 +90,7 @@ node('worker') {
                         if (!foundNightly) {
                             def pipeline_id = null
                             def pipelineUrl
-                            def buildJobSuccess = 0
+                            def buildJobComplete = 0
                             def buildJobFailure = 0
                             def testJobSuccess = 0
                             def testJobUnstable = 0
@@ -149,10 +149,10 @@ node('worker') {
                                     pipelineBuildJobsJson.each { buildJob ->
                                         if (buildJob.buildName.contains(buildVariant)) {
                                             buildJobNumber += 1
-                                            if (buildJob.buildResult.equals('SUCCESS')) {
-                                                buildJobSuccess += 1
-                      } else {
+                                            if (buildJob.buildResult.equals('FAILED')) {
                                                 buildJobFailure += 1
+                      } else {
+                                                buildJobComplete += 1
                                             }
                                         }
                                     }
@@ -160,7 +160,7 @@ node('worker') {
 
                                 def testResult = [name: pipelineName, url: pipelineUrl,
                           buildJobNumber:   buildJobNumber,
-                          buildJobSuccess:  buildJobSuccess,
+                          buildJobComplete:  buildJobComplete,
                           buildJobFailure:  buildJobFailure,
                           testJobSuccess:   testJobSuccess,
                           testJobUnstable:  testJobUnstable,
@@ -189,7 +189,7 @@ node('worker') {
             echo "For Variant: ${variant}"
             echo "  Pipeline : ${pipeline.name} : ${pipeline.url}"
             echo "    => Number of Build jobs = ${pipeline.buildJobNumber}"
-            echo "    => Build job SUCCESS   = ${pipeline.buildJobSuccess}"
+            echo "    => Build job COMPLETE   = ${pipeline.buildJobComplete}"
             echo "    => Build job FAILURE   = ${pipeline.buildJobFailure}"
             echo "    => Number of Test jobs = ${pipeline.testJobNumber}"
             echo "    => Test job SUCCESS    = ${pipeline.testJobSuccess}"


### PR DESCRIPTION
Update the criteria for "failed build" to mean a build that literally has the failure status. This prevents downstream test timeouts and instability from affecting the failure rate of builds in the status reporting tooling, as the current criteria for failure is "anything but success". The job status of test jobs now affects the status of the build job that launched them, so this change helps clarify whether failures are associated with the build itself.