### PR TITLE
feat: disable public visibility for release build job

### DIFF
--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -42,7 +42,7 @@ folder(buildFolder) {
     description 'Automatically generated build jobs.'
 }
 
-pipelineJob("$buildFolder/$JOB_NAME") { 
+pipelineJob("$buildFolder/$JOB_NAME") {
     description('<h1>THIS IS AN AUTOMATICALLY GENERATED JOB DO NOT MODIFY, IT WILL BE OVERWRITTEN.</h1><p>This job is defined in create_job_from_template.groovy in the ci-jenkins-pipelines repo, if you wish to change it modify that</p>')
     definition {
         cpsScm {

--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -42,7 +42,7 @@ folder(buildFolder) {
     description 'Automatically generated build jobs.'
 }
 
-pipelineJob("$buildFolder/$JOB_NAME") {
+pipelineJob("$buildFolder/$JOB_NAME") { 
     description('<h1>THIS IS AN AUTOMATICALLY GENERATED JOB DO NOT MODIFY, IT WILL BE OVERWRITTEN.</h1><p>This job is defined in create_job_from_template.groovy in the ci-jenkins-pipelines repo, if you wish to change it modify that</p>')
     definition {
         cpsScm {
@@ -65,8 +65,8 @@ pipelineJob("$buildFolder/$JOB_NAME") {
         }
     }
     properties {
-        // Hide all non Temurin builds from public view on the Adoptium CI instance
-        if ((JENKINS_URL.contains('adopt')) && (VARIANT != 'temurin')) {
+        // Hide all non Temurin builds or release builds from public view on the Adoptium CI instance
+        if ((JENKINS_URL.contains('adopt')) && ((VARIANT != 'temurin') || (JENKINS_URL.contains('release')))) {
             authorizationMatrix {
                 inheritanceStrategy {
                     // Do not inherit permissions from global configuration


### PR DESCRIPTION
- we only hid the jobs for non temurin variant, but now we want this to be applied to "release" jobs
- permission need to be set on the downstream build job level, not the pipeline level. 
- 
Ref: https://github.com/adoptium/ci-jenkins-pipelines/issues/618

