### PR TITLE
Add configuration for jdk17u on riscv64

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -261,6 +261,16 @@ class Build {
                     suffix = "adoptium/${buildConfig.JAVA_TO_BUILD}"
                 }
                 break
+            case 'hotspot':
+                if (buildConfig.ARCHITECTURE == "riscv64"
+                     && (buildConfig.JAVA_TO_BUILD == "jdk8u"
+                        || buildConfig.JAVA_TO_BUILD == "jdk11u"
+                        || buildConfig.JAVA_TO_BUILD == "jdk17u")) {
+                    suffix = "openjdk/riscv-port-${buildConfig.JAVA_TO_BUILD}";
+                } else {
+                    suffix = "openjdk/${buildConfig.JAVA_TO_BUILD}"
+                }
+                break
             case 'dragonwell':
                 suffix = "alibaba/dragonwell${javaNumber}"
                 break

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -155,6 +155,16 @@ class Config17 {
                 ]
         ],
 
+        riscv64Linux      :  [
+                os                  : 'linux',
+                arch                : 'riscv64',
+                test                : 'default',
+                configureArgs       : '--enable-dtrace',
+                buildArgs           : [
+                        'hotspot'   : '--create-jre-image --create-sbom'
+                ]
+        ],
+
         aarch64Windows: [
                 os                  : 'windows',
                 arch                : 'aarch64',


### PR DESCRIPTION
The backports of Linux/RISC-V to JDK 8, 11, and 17 are in progress. To get a head's start on building and testing these backports, we want to special-case these repositories.