### PR TITLE
migrate win aarch64 jobs to win22 machine

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -213,7 +213,7 @@ class Config11 {
                 os                  : 'windows',
                 arch                : 'aarch64',
                 crossCompile        : 'x64',
-                additionalNodeLabels: 'win2016&&vs2019',
+                additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
                 buildArgs       : [
                         'temurin'   : '--jvm-variant client,server --create-sbom --cross-compile'

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -169,7 +169,7 @@ class Config17 {
                 os                  : 'windows',
                 arch                : 'aarch64',
                 crossCompile        : 'x64',
-                additionalNodeLabels: 'win2016&&vs2019',
+                additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile'

--- a/pipelines/jobs/configurations/jdk19u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk19u_pipeline_config.groovy
@@ -171,7 +171,7 @@ class Config19 {
                 os                  : 'windows',
                 arch                : 'aarch64',
                 crossCompile        : 'x64',
-                additionalNodeLabels: 'win2016&&vs2019',
+                additionalNodeLabels: 'win2022&&vs2019',
                 test                : false,
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile'

--- a/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20_pipeline_config.groovy
@@ -157,7 +157,7 @@ class Config20 {
                 os                  : 'windows',
                 arch                : 'aarch64',
                 crossCompile        : 'x64',
-                additionalNodeLabels: 'win2016&&vs2019',
+                additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile'

--- a/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
@@ -157,7 +157,7 @@ class Config21 {
                 os                  : 'windows',
                 arch                : 'aarch64',
                 crossCompile        : 'x64',
-                additionalNodeLabels: 'win2016&&vs2019',
+                additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile'


### PR DESCRIPTION
Once this has been merged we should be able to delete the win 2016 server CC @sxa 