### PR TITLE
Fix: wrong env variable to determinate auth matrix

### DIFF
--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -66,7 +66,7 @@ pipelineJob("$buildFolder/$JOB_NAME") {
     }
     properties {
         // Hide all non Temurin builds or release builds from public view on the Adoptium CI instance
-        if ((JENKINS_URL.contains('adopt')) && ((VARIANT != 'temurin') || (JENKINS_URL.contains('release')))) {
+        if ((JENKINS_URL.contains('adopt') && (VARIANT != 'temurin')) || ((JENKINS_URL.contains('adopt') && JOB_NAME.contains('release')))) {
             authorizationMatrix {
                 inheritanceStrategy {
                     // Do not inherit permissions from global configuration


### PR DESCRIPTION
JENKINS_URL will get the one from the seed job, not the to-be-generated release job
JOB_NAME should be the one for the release job.

Ref: https://github.com/adoptium/ci-jenkins-pipelines/issues/618