### PR TITLE
Copy downstream test jobs' Tap files no matter test jobs' result

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -441,50 +441,45 @@ class Build {
                                 }
                             }
                         }
-                        context.catchError {
-                            def testJob = context.build job: jobName,
-                                            propagate: true,
-                                            parameters: [
-                                                context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
-                                                context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
-                                                context.string(name: 'SDK_RESOURCE', value: 'upstream'),
-                                                context.string(name: 'JDK_REPO', value: jdkRepo),
-                                                context.string(name: 'JDK_BRANCH', value: jdkBranch),
-                                                context.string(name: 'OPENJ9_BRANCH', value: openj9Branch),
-                                                context.string(name: 'LABEL_ADDITION', value: additionalTestLabel),
-                                                context.booleanParam(name: 'KEEP_REPORTDIR', value: keep_test_reportdir),
-                                                context.string(name: 'PARALLEL', value: parallel),
-                                                context.string(name: 'NUM_MACHINES', value: "${numMachinesPerTest}"),
-                                                context.booleanParam(name: 'USE_TESTENV_PROPERTIES', value: useTestEnvProperties),
-                                                context.booleanParam(name: 'GENERATE_JOBS', value: aqaAutoGen),
-                                                context.string(name: 'ADOPTOPENJDK_BRANCH', value: aqaBranch),
-                                                context.string(name: 'ACTIVE_NODE_TIMEOUT', value: "${buildConfig.ACTIVE_NODE_TIMEOUT}"),
-                                                context.booleanParam(name: 'DYNAMIC_COMPILE', value: DYNAMIC_COMPILE)],
-                                            wait: true
-                            context.node('worker') {
-                                def result = testJob.getResult()
-                                context.echo " ${jobName} result is ${result}"
-                                if (result == 'SUCCESS' || result == 'UNSTABLE') {
-                                    context.sh 'rm -f workspace/target/AQAvitTaps/*.tap'
-                                    try {
-                                        context.timeout(time: 2, unit: 'HOURS') {
-                                            context.copyArtifacts(
-                                                projectName:jobName,
-                                                selector:context.specific("${testJob.getNumber()}"),
-                                                filter: "**/${jobName}*.tap",
-                                                target: 'workspace/target/AQAvitTaps/',
-                                                fingerprintArtifacts: true,
-                                                flatten: true
-                                            )
-                                        }
-                                    } catch (Exception e) {
-                                        context.echo "Cannot run copyArtifacts from job ${jobName}. Exception: ${e.message}. Skipping copyArtifacts..."
-                                    }
-                                    context.archiveArtifacts artifacts: 'workspace/target/AQAvitTaps/*.tap', fingerprint: true
-                                } else {
-                                    context.echo "Warning: ${jobName} result is ${result}, no tap file is archived"
+
+                        def testJob = context.build job: jobName,
+                                        propagate: false,
+                                        parameters: [
+                                            context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
+                                            context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
+                                            context.string(name: 'SDK_RESOURCE', value: 'upstream'),
+                                            context.string(name: 'JDK_REPO', value: jdkRepo),
+                                            context.string(name: 'JDK_BRANCH', value: jdkBranch),
+                                            context.string(name: 'OPENJ9_BRANCH', value: openj9Branch),
+                                            context.string(name: 'LABEL_ADDITION', value: additionalTestLabel),
+                                            context.booleanParam(name: 'KEEP_REPORTDIR', value: keep_test_reportdir),
+                                            context.string(name: 'PARALLEL', value: parallel),
+                                            context.string(name: 'NUM_MACHINES', value: "${numMachinesPerTest}"),
+                                            context.booleanParam(name: 'USE_TESTENV_PROPERTIES', value: useTestEnvProperties),
+                                            context.booleanParam(name: 'GENERATE_JOBS', value: aqaAutoGen),
+                                            context.string(name: 'ADOPTOPENJDK_BRANCH', value: aqaBranch),
+                                            context.string(name: 'ACTIVE_NODE_TIMEOUT', value: "${buildConfig.ACTIVE_NODE_TIMEOUT}"),
+                                            context.booleanParam(name: 'DYNAMIC_COMPILE', value: DYNAMIC_COMPILE)],
+                                        wait: true
+                        currentBuild.result = testJob.getResult()
+                        context.node('worker') {
+                            //Copy Taps files from downstream test jobs if files available. 
+                            context.sh 'rm -f workspace/target/AQAvitTaps/*.tap'
+                            try {
+                                context.timeout(time: 2, unit: 'HOURS') {
+                                    context.copyArtifacts(
+                                        projectName:jobName,
+                                        selector:context.specific("${testJob.getNumber()}"),
+                                        filter: "**/${jobName}*.tap",
+                                        target: 'workspace/target/AQAvitTaps/',
+                                        fingerprintArtifacts: true,
+                                        flatten: true
+                                    )
                                 }
+                            } catch (Exception e) {
+                                context.echo "Cannot run copyArtifacts from job ${jobName}. Exception: ${e.message}. Skipping copyArtifacts..."
                             }
+                            context.archiveArtifacts allowEmptyArchive: true, artifacts: 'workspace/target/AQAvitTaps/*.tap', fingerprint: true
                         }
                     }
                 }


### PR DESCRIPTION
Copy downstream test jobs' Tap files no matter test jobs' result

- Set propagate=false to access build job return object
- Explicitly set currentBuild.result by downstream job result
- AllowEmptyArchive so if no artifacts copied will not fail the build

Fix #683 

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>