### PR TITLE
Allow eclipse-temurin-compliance-bot read access to release build job artifacts

### DIFF
--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -78,6 +78,8 @@ pipelineJob("$buildFolder/$JOB_NAME") {
                 'GROUP:hudson.model.Item.Read:AdoptOpenJDK*build', 'GROUP:hudson.model.Item.Read:AdoptOpenJDK*build-triage',
                 // eclipse-temurin-bot needs read access for TRSS
                 'USER:hudson.model.Item.Read:eclipse-temurin-bot',
+                // eclipse-temurin-compliance bot needs read access for https://ci.eclipse.org/temurin-compliance
+                'USER:hudson.model.Item.Read:eclipse-temurin-compliance-bot',
                 'GROUP:hudson.model.Item.Workspace:AdoptOpenJDK*build', 'GROUP:hudson.model.Item.Workspace:AdoptOpenJDK*build-triage',
                 'GROUP:hudson.model.Run.Update:AdoptOpenJDK*build', 'GROUP:hudson.model.Run.Update:AdoptOpenJDK*build-triage'])
             }


### PR DESCRIPTION
The ci.eclipse.org/temurin-compliance needs read access to build job artifacts for triggered TCK execution.