### PR TITLE
Do not enable dtrace for jdk21 on pLinux and s390xLinux

### DIFF
--- a/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
@@ -89,7 +89,6 @@ class Config21 {
                 arch                : 's390x',
                 dockerImage         : 'rhel7_build_image',
                 test                : 'default',
-                configureArgs       : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
@@ -101,7 +100,6 @@ class Config21 {
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
                 configureArgs       : [
-                        'temurin'     : '--enable-dtrace',
                         'openj9'      : '--enable-dtrace --enable-jitserver'
                 ],
                 buildArgs           : [


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3352

Don't enable dtrace for p & z linux for jdk-21. Ref: 
    https://bugs.openjdk.org/browse/JDK-8304867
    https://bugs.openjdk.org/browse/JDK-8305174
