### PR TITLE
Disable dtrace for jdk17 on Linux ppcle

### DIFF
--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -109,7 +109,6 @@ class Config17 {
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
                 configureArgs       : [
-                        'temurin'     : '--enable-dtrace',
                         'openj9'      : '--enable-dtrace --enable-jitserver'
                 ],
                 buildArgs           : [


### PR DESCRIPTION
Because dtrace [has been disabled](https://github.com/openjdk/jdk17u-dev/pull/1338) on jdk17 for linux ppcle.

When this was disabled for later versions of [openjdk](https://bugs.openjdk.org/browse/JDK-8304867), we started to see [build failures](https://github.com/adoptium/temurin-build/issues/3352), so we [removed that option](https://github.com/adoptium/ci-jenkins-pipelines/pull/703/files) from our builds. This PR does the same for JDK17 because the [aforementioned change](https://github.com/openjdk/jdk17u-dev/pull/1338) was backported to jdk17.

Note: I'm not removing the option from s390x builds because the [dtrace disabling that was done on s390x](https://bugs.openjdk.org/browse/JDK-8305174) has not (yet, anyway) been backported.

