### PR TITLE
Ensure jdk8u aarch32 release job gets generated, but not added to release pipeline

### DIFF
--- a/pipelines/build/regeneration/release_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/release_pipeline_generator.groovy
@@ -93,6 +93,12 @@ node('worker') {
                     throw new Exception("[ERROR] enable to load jdk${javaVersion}u_release.groovy nor jdk${javaVersion}_release.groovy does not exist!")
                 }
 
+                // For jdk8u remove aarch32 from the pipeline's target so it does not get built automatically,
+                // jdk8u aarch32 is dependent on upstream release in the separate port repository, and will get started manually.
+                if (javaVersion == 8 && target.targetConfigurations.containsKey('arm32Linux')) {
+                    target.targetConfigurations.remove('arm32Linux')
+                }
+
                 config.put('targetConfigurations', target.targetConfigurations)
 
                 config.put('defaultsJson', DEFAULTS_JSON)

--- a/pipelines/jobs/configurations/jdk8u_release.groovy
+++ b/pipelines/jobs/configurations/jdk8u_release.groovy
@@ -23,6 +23,9 @@ targetConfigurations = [
         'aarch64Linux'  : [
                 'temurin'
         ],
+        'arm32Linux'  : [
+                'temurin'
+        ],
         'x64Solaris': [
                 'temurin'
         ],


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/694

Ensure we always generate the release jdk8u aarch32 build job, otherwise we forget!
But exclude from the release jdk8u pipeline target platforms, as will be started manually once port repo available.
 