### PR TITLE
Update evaluation_pipeline_generator.groovy so it generates "tip" version

### DIFF
--- a/pipelines/build/regeneration/evaluation_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/evaluation_pipeline_generator.groovy
@@ -189,8 +189,12 @@ node('worker') {
                                 targetEvaluation = load nonUFile2
                             }
                         } catch (NoSuchFileException e2) {
-                            throw new Exception("[ERROR] enable to load jdk${javaVersion}u_evaluation.groovy nor jdk${javaVersion}_evaluation.groovy does not exist!")
+                            println "[WARNING] No evaluation config found for JDK${javaVersion} in the User's or Adopt's repository. Skipping generation..."
+                            // break and move to next element in the loop
+                            // groovylint-disable-next-line
+                            return
                         }
+                        checkoutUserPipelines()
                     }
                     config.put('targetConfigurations', targetEvaluation.targetConfigurations)
 

--- a/pipelines/build/regeneration/evaluation_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/evaluation_pipeline_generator.groovy
@@ -48,7 +48,7 @@ node('worker') {
         }
 
         timestamps {
-            def validVersion = [8, 11, 17, 20]
+            def retiredVersions = [9, 10, 12, 13, 14, 15, 16, 18, 19]
             def generatedPipelines = []
 
             // Load git url and branch and gitBranch. These determine where we will be pulling user configs from.
@@ -146,7 +146,10 @@ node('worker') {
             int headVersion = (int) response[('tip_version')]
 
             (8..headVersion + 1).each({ javaVersion ->
-                if (validVersion.contains(javaVersion)) {
+                if (retiredVersions.contains(javaVersion)) {
+                    println "[INFO] $javaVersion is a retired version that isn't currently built. Skipping generation..."
+                    return
+                } else {
                     
                     def config = [
                         TEST                : false,


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/706

Refactored slightly so it loops through versions, skipping retiredVersions, just like in https://github.com/adoptium/ci-jenkins-pipelines/blob/86519fe4d5b73269cb179333fbf7b0ab9ec71cd6/pipelines/build/regeneration/build_pipeline_generator.groovy#L51