### PR TITLE
OpenJ9: Remove explicit jitserver enable option

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -27,7 +27,7 @@ class Config11 {
                         weekly : ['extended.openjdk', 'extended.perf', 'special.functional', 'sanity.external']
                 ],
                 configureArgs       : [
-                        'openj9'      : '--enable-jitserver --enable-dtrace=auto',
+                        'openj9'      : '--enable-dtrace=auto',
                         'temurin'     : '--enable-dtrace=auto',
                         'corretto'    : '--enable-dtrace=auto',
                         'SapMachine'  : '--enable-dtrace=auto',
@@ -126,7 +126,7 @@ class Config11 {
                 test                : 'default',
                 configureArgs       : [
                         'temurin'     : '--enable-dtrace=auto',
-                        'openj9'      : '--enable-dtrace=auto --enable-jitserver'
+                        'openj9'      : '--enable-dtrace=auto'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom'

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -30,7 +30,7 @@ class Config17 {
                         openj9      : '!(centos6||rhel6)'
                 ],
                 configureArgs       : [
-                        'openj9'    : '--enable-dtrace --enable-jitserver',
+                        'openj9'    : '--enable-dtrace',
                         'temurin'   : '--enable-dtrace'
                 ],
                 buildArgs           : [
@@ -109,7 +109,7 @@ class Config17 {
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
                 configureArgs       : [
-                        'openj9'      : '--enable-dtrace --enable-jitserver'
+                        'openj9'      : '--enable-dtrace'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'

--- a/pipelines/jobs/configurations/jdk20u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20u_pipeline_config.groovy
@@ -27,7 +27,7 @@ class Config20 {
                         openj9      : '!(centos6||rhel6)'
                 ],
                 configureArgs       : [
-                        'openj9'    : '--enable-dtrace --enable-jitserver',
+                        'openj9'    : '--enable-dtrace',
                         'temurin'   : '--enable-dtrace'
                 ],
                 buildArgs           : [
@@ -102,7 +102,7 @@ class Config20 {
                 test                : 'default',
                 configureArgs       : [
                         'temurin'     : '--enable-dtrace',
-                        'openj9'      : '--enable-dtrace --enable-jitserver'
+                        'openj9'      : '--enable-dtrace'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'

--- a/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
@@ -27,7 +27,7 @@ class Config21 {
                         openj9      : '!(centos6||rhel6)'
                 ],
                 configureArgs       : [
-                        'openj9'    : '--enable-dtrace --enable-jitserver',
+                        'openj9'    : '--enable-dtrace',
                         'temurin'   : '--enable-dtrace'
                 ],
                 buildArgs           : [
@@ -100,7 +100,7 @@ class Config21 {
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
                 configureArgs       : [
-                        'openj9'      : '--enable-dtrace --enable-jitserver'
+                        'openj9'      : '--enable-dtrace'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -25,7 +25,6 @@ class Config8 {
                 ],
                 test                 : 'default',
                 configureArgs       : [
-                        'openj9'      : '--enable-jitserver',
                         'dragonwell'  : '--enable-unlimited-crypto --with-jvm-variants=server  --with-zlib=system',
                 ],
                 buildArgs           : [
@@ -123,9 +122,6 @@ class Config8 {
                 arch: 'ppc64le',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
-                configureArgs       : [
-                        'openj9'      : '--enable-jitserver'
-                ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom'
                 ]


### PR DESCRIPTION
Is enabled by default on x/p/z linux in all versions
Related ibmruntimes/ci-jenkins-pipelines#132