### PR TITLE
Fix user ci pipeline setup usage

### DIFF
--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -268,7 +268,7 @@ node('worker') {
                 } catch (Exception e) {
                     println "${e}\n[WARNING] Something went wrong when creating the weekly job dsl. It may be because we are trying to pull the template inside a user repository. Using Adopt's template instead..."
                     checkoutAdoptPipelines()
-                    jobDsl targets: ADOPT_DEFAULTS_JSON['templateDirectories']['weeklyTemplatePath'], ignoreExisting: false, additionalParameters: config
+                    jobDsl targets: ADOPT_DEFAULTS_JSON['templateDirectories']['weekly'], ignoreExisting: false, additionalParameters: config
                     checkoutUserPipelines()
                 }
 

--- a/pipelines/build/regeneration/evaluation_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/evaluation_pipeline_generator.groovy
@@ -273,7 +273,7 @@ node('worker') {
                     } catch (Exception e) {
                         println "${e}\n[WARNING] Something went wrong when creating the weekly evaluation job dsl. It may be because we are trying to pull the template inside a user repository. Using Adopt's template instead..."
                         checkoutAdoptPipelines()
-                        jobDsl targets: ADOPT_DEFAULTS_JSON['templateDirectories']['weeklyTemplatePath'], ignoreExisting: false, additionalParameters: config
+                        jobDsl targets: ADOPT_DEFAULTS_JSON['templateDirectories']['weekly'], ignoreExisting: false, additionalParameters: config
                         checkoutUserPipelines()
                     }
                     // add into list


### PR DESCRIPTION
Noticed a problem in build-pipeline-generator when trying to use a User config repository, the fallback to use the weekly job template has the wrong json value.

It should be "weekly", not "weeklyTemplatePath": 
https://github.com/adoptium/ci-jenkins-pipelines/blob/b743ba02353aeef2942dae87c20173c19b7f79ee/pipelines/defaults.json#L17
