### PR TITLE
Enable docker builds when emulated by podman

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1817,6 +1817,14 @@ class Build {
                             } else {
                                 dockerImageDigest = dockerImageDigest.replaceAll("\\[", "").replaceAll("\\]", "")
                                 String dockerRunArg="-e \"BUILDIMAGESHA=$dockerImageDigest\""
+
+                                // Are we running podman in Docker CLI Emulation mode?
+                                def isPodman = context.sh(script: "docker --version | grep podman", returnStatus:true)
+                                if (isPodman == 0) {
+                                    // Note: --userns was introduced in podman 4.3.0
+                                    // Add uid and gid userns mapping required for podman
+                                    dockerRunArg += " --userns keep-id:uid=1000,gid=1000"
+                                }
                                 context.docker.image(buildConfig.DOCKER_IMAGE).inside(buildConfig.DOCKER_ARGS+" "+dockerRunArg) {
                                     buildScripts(
                                         cleanWorkspace,


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/715

Checks if podman is being used as docker emulation, and then adds the docker run arg.
