### PR TITLE
For JDK head, use alternate file/release name

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -664,7 +664,6 @@ class Builder implements Serializable {
         return "jdk${number}"
     }
 
-
     /*
     Returns the downstream build job's type by checking job folder's path
     can be "evaluation" or "release" or null (in this case it is for the nightly or pr-tester)
@@ -689,7 +688,7 @@ class Builder implements Serializable {
 
     /*
     Returns the jenkins folder of where we assume the downstream build jobs have been regenerated
-    e.g: 
+    e.g:
     nightly:    build-scripts/jobs/jdk11u/jdk11u-linux-aarch64-temurin
     evaluation:  build-scripts/jobs/evaluation/jobs/jdk17u/jdk17u-evaluation-mac-x64-openj9
     release:    build-scripts/jobs/release/jobs/jdk20/jdk20-release-aix-ppc64-temurin
@@ -733,7 +732,7 @@ class Builder implements Serializable {
 
         def timestamp = new Date().format('yyyy-MM-dd-HH-mm', TimeZone.getTimeZone('UTC'))
         if (javaToBuild == "jdk${headVersion}") {
-          timestamp = "ea.${scmReference}".replaceAll("jdk-","").replaceAll("_adopt","").replaceAll("/\.\+/","");
+          timestamp = timestamp = "ea." + "${scmReference}".replaceFirst("jdk-","").replaceFirst("_adopt","").replaceAll("[.+]","-");
         } else {
           timestamp = new Date().format('yyyy-MM-dd-HH-mm', TimeZone.getTimeZone('UTC'))
         }


### PR DESCRIPTION
Part of providing a solution to https://github.com/adoptium/temurin-build/issues/3355

This changes the format of the "nightlies" from: `yyyy-HH-dd-HH-mm` to `ea.21+23` which will be reflected in the filename and also in the published tag. Note that `ea.21+23` was chosen instead of `21+23.ea` as this fits into the [existing regex](https://github.com/adoptium/github-release-scripts/blob/ba2f0167d794c1cf29314292265045453a8ce7bc/sbin/Release.sh#L44).

This is currently in draft for multiple reasons:
1. I have not tested the end to end code
2. We are in the process of [splitting out JDK21 from JDK](https://github.com/adoptium/ci-jenkins-pipelines/issues/717), so headVersion is probably not what we want now
3. Looking for validation on the formatting of the filenames and releases
4. Because of the criteria I've used in this PR, perhaps we should be adjusting the schedule to disable nightlies from new tag before implementing this? Or have a different criteria for these (e.g. "not release but tag specified"). For now we could manually trigger, but a variant of https://github.com/adoptium/mirror-scripts/blob/master/triggerReleasePipeline.sh (called by e.g. https://ci.adoptium.net/job/build-scripts/job/utils/job/releaseTrigger_jdk20u/) which just builds any level that hasn't been built previously rather than working on a static level would be ideal.

_NOTE: If we had such a trigger another option would be to still run the nightly build/test cycles as-is but run them as "nightly without publish" so as not to pollute the binaries repositories._
