### PR TITLE
Assert IndividualBuildConfig values are defined in the jenkins-helper

### DIFF
--- a/pipelines/src/test/groovy/IndividualBuildConfigTest.groovy
+++ b/pipelines/src/test/groovy/IndividualBuildConfigTest.groovy
@@ -54,15 +54,19 @@ class IndividualBuildConfigTest {
                 ENABLE_REPRODUCIBLE_COMPARE : false,
                 ENABLE_TESTDYNAMICPARALLEL : false
         ]
+        def testConfig = new IndividualBuildConfig(configMap)
 
-        def json = JsonOutput.toJson(configMap)
+        // Serialize and then re-constitute
+        def json = testConfig.toJson()
         def parsedConfig = new IndividualBuildConfig(json)
 
+        // Assert all values set
         parsedConfig.toRawMap()
                 .each { val ->
                     Assertions.assertNotNull(val.value, "${val.key} is null")
                 }
 
+        // Assert serialization round trip matches initial configMap
         Assertions.assertEquals(configMap, parsedConfig.toRawMap())
     }
 


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/726

Correct IndividualBuildConfig map assertion to detect missing/invalid members, not defined in https://github.com/adoptium/jenkins-helper/blob/783ece1c4666bc4092494438e62775cc6701025d/src/common/IndividualBuildConfig.groovy#L19
