### PR TITLE
Disable JDK21 nightlies, set Weekly builds to not publish

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -760,15 +760,16 @@ class Builder implements Serializable {
 
         def timestamp = new Date().format('yyyy-MM-dd-HH-mm', TimeZone.getTimeZone('UTC'))
         def tag = "${javaToBuild}-${timestamp}"
-
         if (publishName) {
             tag = publishName
         }
 
+       
         context.stage('publish') {
             context.build job: 'build-scripts/release/refactor_openjdk_release_tool',
                     parameters: [
                         ['$class': 'BooleanParameterValue', name: 'RELEASE', value: release],
+                        ['$class': 'BooleanParameterValue', name: 'DRY_RUN', value: (isWeekly ? true : false)],
                         context.string(name: 'TAG', value: tag),
                         context.string(name: 'TIMESTAMP', value: timestamp),
                         context.string(name: 'UPSTREAM_JOB_NAME', value: env.JOB_NAME),

--- a/pipelines/jobs/configurations/jdk21.groovy
+++ b/pipelines/jobs/configurations/jdk21.groovy
@@ -33,7 +33,7 @@ targetConfigurations = [
 ]
 
 // 23:30 Mon, Wed, Fri
-triggerSchedule_nightly = 'TZ=UTC\n30 23 * * 1,3,5'
+// triggerSchedule_nightly = 'TZ=UTC\n30 23 * * 1,3,5'
 // 23:30 Sat
 triggerSchedule_weekly = 'TZ=UTC\n30 23 * * 6'
 

--- a/pipelines/jobs/configurations/jdk21_evaluation.groovy
+++ b/pipelines/jobs/configurations/jdk21_evaluation.groovy
@@ -13,7 +13,7 @@ targetConfigurations = [
 // if set to empty string then it wont get triggered
 
 // 23:40 Mon, Wed
-triggerSchedule_evaluation = 'TZ=UTC\n40 23 * * 1,3'
+// triggerSchedule_evaluation = 'TZ=UTC\n40 23 * * 1,3'
 // 23:40 Sat
 triggerSchedule_weekly_evaluation = 'TZ=UTC\n40 23 * * 6'
 


### PR DESCRIPTION
Part of the master plan for https://github.com/adoptium/temurin-build/issues/3355
We should ONLY publish the tagged ea builds as nightlies so there are known code levels available via the adoptium API for nightly builds.