### PR TITLE
Fixup isWeekly check

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -760,21 +760,21 @@ class Builder implements Serializable {
 
         def timestamp = new Date().format('yyyy-MM-dd-HH-mm', TimeZone.getTimeZone('UTC'))
         def tag = "${javaToBuild}-${timestamp}"
+        def javaVersion=determineReleaseToolRepoVersion()
         if (publishName) {
             tag = publishName
         }
 
-       
         context.stage('publish') {
             context.build job: 'build-scripts/release/refactor_openjdk_release_tool',
                     parameters: [
                         ['$class': 'BooleanParameterValue', name: 'RELEASE', value: release],
-                        ['$class': 'BooleanParameterValue', name: 'DRY_RUN', value: (isWeekly ? true : false)],
+                        ['$class': 'BooleanParameterValue', name: 'DRY_RUN', value: ((releaseType=="Weekly" && javaVersion=="jdk21") ? true : false)],
                         context.string(name: 'TAG', value: tag),
                         context.string(name: 'TIMESTAMP', value: timestamp),
                         context.string(name: 'UPSTREAM_JOB_NAME', value: env.JOB_NAME),
                         context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${currentBuild.getNumber()}"),
-                        context.string(name: 'VERSION', value: determineReleaseToolRepoVersion())
+                        context.string(name: 'VERSION', value: javaVersion )
                     ]
         }
     }


### PR DESCRIPTION
A check in [the previous PR](https://github.com/adoptium/ci-jenkins-pipelines/pull/736) did not work as the `isWeekly` was defined on a different object from the one being tested. Unfortunately the PR testing did not pick this up (probably due to not triggering the publish job). This should fix it.

```
[Pipeline] End of Pipeline
hudson.remoting.ProxyException: groovy.lang.MissingPropertyException: No such property: isWeekly for class: Builder
```