### PR TITLE
Add code to support publishing ea builds of JDK21

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -766,25 +766,24 @@ class Builder implements Serializable {
         }
 
         if (javaToBuild=="jdk21" && scmReference && !release) {
-          publishName = scmReference.replace('_adopt','')
-          def firstDot=publishName.indexOf('.')
-          def plusSign=publishName.indexOf('+')
-          def secondDot=publishName.indexOf('.', firstDot+1)
-          // Translate jdk-AA+BB to jdk-AA-0-BB
-          // Translate jdk-AA.B.C+DD to jdk-AA-C-DD-ea-beta
-          // Note that jdk-AA-B-C-D+EE will become jdk-AA-C-D-EE-ea-beta
-          if ( firstDot==-1 ) {
-             publishName=publishName.substring(4,plusSign)+'.0.'+publishName.substring(plusSign+1)
-       
-          } else {
-             publishName=publishName.substring(4,firstDot)+publishName.substring(secondDot).replace("+","-")
-          }
-          publishName='ea_'+publishName.replaceAll("\\.","-")
+            publishName = scmReference.replace('_adopt','')
+            def firstDot=publishName.indexOf('.')
+            def plusSign=publishName.indexOf('+')
+            def secondDot=publishName.indexOf('.', firstDot+1)
+            // Translate jdk-AA+BB to jdk-AA-0-BB
+            // Translate jdk-AA.B.C+DD to jdk-AA-C-DD-ea-beta
+            // Note that jdk-AA-B-C-D+EE will become jdk-AA-C-D-EE-ea-beta
+            if ( firstDot==-1 ) {
+                publishName=publishName.substring(4,plusSign)+'.0.'+publishName.substring(plusSign+1)
+            } else {
+                publishName=publishName.substring(4,firstDot)+publishName.substring(secondDot).replace("+","-")
+            }
+            publishName='ea_'+publishName.replaceAll("\\.","-")
         }
 
         context.stage('publish') {
         context.println "publishing with publishName: ${publishName}"
-         context.build job: 'build-scripts/release/refactor_openjdk_release_tool',
+        context.build job: 'build-scripts/release/refactor_openjdk_release_tool',
                     parameters: [
                         ['$class': 'BooleanParameterValue', name: 'RELEASE', value: release],
                         ['$class': 'BooleanParameterValue', name: 'DRY_RUN', value: ((releaseType=="Weekly" && javaVersion=="jdk21") ? true : false)],

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -765,7 +765,7 @@ class Builder implements Serializable {
             tag = publishName
         }
 
-        if (javaToBuild=="jdk21" && scmReference && !release) {
+        if ((javaToBuild=="jdk21" || javaToBuild=="jdk") && scmReference && !release) {
             publishName = scmReference.replace('_adopt','')
             def firstDot=publishName.indexOf('.')
             def plusSign=publishName.indexOf('+')
@@ -787,8 +787,8 @@ class Builder implements Serializable {
                     parameters: [
                         ['$class': 'BooleanParameterValue', name: 'RELEASE', value: release],
                         ['$class': 'BooleanParameterValue', name: 'DRY_RUN', value: ((releaseType=="Weekly" && javaVersion=="jdk21") ? true : false)],
-                        context.string(name: 'TAG', value: (javaToBuild=="jdk21"?(scmReference.replace('_adopt','')):tag)),
-                        context.string(name: 'TIMESTAMP', value: (javaToBuild=="jdk"?publishName:timestamp)),
+                        context.string(name: 'TAG', value: ((javaToBuild=="jdk21" || javaToBuild=="jdk")?(scmReference.replace('_adopt','')):tag)),
+                        context.string(name: 'TIMESTAMP', value: ((javaToBuild=="jdk21" || javaToBuild=="jdk")?publishName:timestamp)),
                         context.string(name: 'UPSTREAM_JOB_NAME', value: env.JOB_NAME),
                         context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${currentBuild.getNumber()}"),
                         context.string(name: 'VERSION', value: javaVersion)

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -786,8 +786,8 @@ class Builder implements Serializable {
         context.build job: 'build-scripts/release/refactor_openjdk_release_tool',
                     parameters: [
                         ['$class': 'BooleanParameterValue', name: 'RELEASE', value: release],
-                        ['$class': 'BooleanParameterValue', name: 'DRY_RUN', value: ((releaseType=="Weekly" && javaVersion=="jdk21") ? true : false)],
-                        context.string(name: 'TAG', value: ((javaToBuild=="jdk21" || javaToBuild=="jdk")?(scmReference.replace('_adopt','')):tag)),
+                        ['$class': 'BooleanParameterValue', name: 'DRY_RUN', value: false],
+                        context.string(name: 'TAG', value: ((scmReference && (javaToBuild=="jdk21" || javaToBuild=="jdk"))?(scmReference.replace('_adopt','')):tag)),
                         context.string(name: 'TIMESTAMP', value: ((javaToBuild=="jdk21" || javaToBuild=="jdk")?publishName:timestamp)),
                         context.string(name: 'UPSTREAM_JOB_NAME', value: env.JOB_NAME),
                         context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${currentBuild.getNumber()}"),

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -765,16 +765,30 @@ class Builder implements Serializable {
             tag = publishName
         }
 
+        if (javaToBuild=="jdk21" && scmReference && !release) {
+          publishName = scmReference.replace('_adopt','')
+          def firstDot=publishName.indexOf('.')
+          def plusSign=publishName.indexOf('+')
+          def secondDot=publishName.indexOf('.', firstDot+1)
+          // Translate jdk-AA+BB to jdk-AA-0-BB
+          // Translate jdk-AA.B.C+DD to jdk-AA-C-DD-ea-beta
+          // Note that jdk-AA-B-C-D+EE will become jdk-AA-C-D-EE-ea-beta
+          if ( firstDot==-1 ) publishName=publishName.substring(4,plusSign)+'.0.'+publishName.substring(plusSign+1)
+          else publishName=publishName.substring(4,firstDot)+publishName.substring(secondDot).replace("+","-")
+          publishName='ea_'+publishName.replaceAll("\\.","-")
+        }
+
         context.stage('publish') {
-            context.build job: 'build-scripts/release/refactor_openjdk_release_tool',
+        context.println "publishing with publishName: ${publishName}"
+         context.build job: 'build-scripts/release/refactor_openjdk_release_tool',
                     parameters: [
                         ['$class': 'BooleanParameterValue', name: 'RELEASE', value: release],
                         ['$class': 'BooleanParameterValue', name: 'DRY_RUN', value: ((releaseType=="Weekly" && javaVersion=="jdk21") ? true : false)],
-                        context.string(name: 'TAG', value: tag),
-                        context.string(name: 'TIMESTAMP', value: timestamp),
+                        context.string(name: 'TAG', value: (javaToBuild=="jdk21"?(scmReference.replace('_adopt','')):tag)),
+                        context.string(name: 'TIMESTAMP', value: (javaToBuild=="jdk"?publishName:timestamp)),
                         context.string(name: 'UPSTREAM_JOB_NAME', value: env.JOB_NAME),
                         context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${currentBuild.getNumber()}"),
-                        context.string(name: 'VERSION', value: javaVersion )
+                        context.string(name: 'VERSION', value: javaVersion)
                     ]
         }
     }

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -765,7 +765,10 @@ class Builder implements Serializable {
             tag = publishName
         }
 
-        if ((javaToBuild=="jdk21" || javaToBuild=="jdk") && scmReference && !release) {
+        // Definition of filenames when building an EA tag. This is passed
+        // to the release tool in place of the "TIMESTAMP" Criteria for this:
+        // JDK21 or 22 when a scmRef (tag) is specified and it's not a release build
+        if ((javaVersion=="jdk21" || javaVersion=="jdk22") && scmReference && !release) {
             publishName = scmReference.replace('_adopt','')
             def firstDot=publishName.indexOf('.')
             def plusSign=publishName.indexOf('+')
@@ -787,8 +790,8 @@ class Builder implements Serializable {
                     parameters: [
                         ['$class': 'BooleanParameterValue', name: 'RELEASE', value: release],
                         ['$class': 'BooleanParameterValue', name: 'DRY_RUN', value: false],
-                        context.string(name: 'TAG', value: ((scmReference && (javaToBuild=="jdk21" || javaToBuild=="jdk"))?(scmReference.replace('_adopt','')):tag)),
-                        context.string(name: 'TIMESTAMP', value: ((javaToBuild=="jdk21" || javaToBuild=="jdk")?publishName:timestamp)),
+                        context.string(name: 'TAG', value: ((scmReference && (javaVersion=="jdk21" || javaVersion=="jdk22"))?(scmReference.replace('_adopt','')):tag)),
+                        context.string(name: 'TIMESTAMP', value: ((javaVersion=="jdk21" || javaVersion=="jdk22")?publishName:timestamp)),
                         context.string(name: 'UPSTREAM_JOB_NAME', value: env.JOB_NAME),
                         context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${currentBuild.getNumber()}"),
                         context.string(name: 'VERSION', value: javaVersion)

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -791,7 +791,7 @@ class Builder implements Serializable {
                         ['$class': 'BooleanParameterValue', name: 'RELEASE', value: release],
                         ['$class': 'BooleanParameterValue', name: 'DRY_RUN', value: false],
                         context.string(name: 'TAG', value: ((scmReference && (javaVersion=="jdk21" || javaVersion=="jdk22"))?(scmReference.replace('_adopt','')):tag)),
-                        context.string(name: 'TIMESTAMP', value: ((javaVersion=="jdk21" || javaVersion=="jdk22")?publishName:timestamp)),
+                        context.string(name: 'TIMESTAMP', value: ((scmRefetence && (javaVersion=="jdk21" || javaVersion=="jdk22"))?publishName:timestamp)),
                         context.string(name: 'UPSTREAM_JOB_NAME', value: env.JOB_NAME),
                         context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${currentBuild.getNumber()}"),
                         context.string(name: 'VERSION', value: javaVersion)

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -760,21 +760,21 @@ class Builder implements Serializable {
 
         def timestamp = new Date().format('yyyy-MM-dd-HH-mm', TimeZone.getTimeZone('UTC'))
         def tag = "${javaToBuild}-${timestamp}"
+        def javaVersion=determineReleaseToolRepoVersion()
         if (publishName) {
             tag = publishName
         }
 
-       
         context.stage('publish') {
             context.build job: 'build-scripts/release/refactor_openjdk_release_tool',
                     parameters: [
                         ['$class': 'BooleanParameterValue', name: 'RELEASE', value: release],
-                        ['$class': 'BooleanParameterValue', name: 'DRY_RUN', value: (isWeekly ? true : false)],
+                        ['$class': 'BooleanParameterValue', name: 'DRY_RUN', value: ((releaseType=="Weekly" && javaVersion=="jdk21") ? true : false)],
                         context.string(name: 'TAG', value: tag),
                         context.string(name: 'TIMESTAMP', value: timestamp),
                         context.string(name: 'UPSTREAM_JOB_NAME', value: env.JOB_NAME),
                         context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${currentBuild.getNumber()}"),
-                        context.string(name: 'VERSION', value: determineReleaseToolRepoVersion())
+                        context.string(name: 'VERSION', value: javaVersion )
                     ]
         }
     }

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -773,8 +773,12 @@ class Builder implements Serializable {
           // Translate jdk-AA+BB to jdk-AA-0-BB
           // Translate jdk-AA.B.C+DD to jdk-AA-C-DD-ea-beta
           // Note that jdk-AA-B-C-D+EE will become jdk-AA-C-D-EE-ea-beta
-          if ( firstDot==-1 ) publishName=publishName.substring(4,plusSign)+'.0.'+publishName.substring(plusSign+1)
-          else publishName=publishName.substring(4,firstDot)+publishName.substring(secondDot).replace("+","-")
+          if ( firstDot==-1 ) {
+             publishName=publishName.substring(4,plusSign)+'.0.'+publishName.substring(plusSign+1)
+       
+          } else {
+             publishName=publishName.substring(4,firstDot)+publishName.substring(secondDot).replace("+","-")
+          }
           publishName='ea_'+publishName.replaceAll("\\.","-")
         }
 


### PR DESCRIPTION
Final part (probably) of the experiment in https://github.com/adoptium/temurin-build/issues/3355#issuecomment-1568129358

I have no idea if this is the best place to achieve this, but it should work ... Happy to adjust approach later if desired.

[Tested with jdk22](https://ci.adoptium.net/job/build-scripts/job/openjdk22-pipeline/55/) then adjusted back to jdk21 before creating the PR

Note this is based on https://github.com/adoptium/ci-jenkins-pipelines/pull/738 so that needs to be merged first.