### PR TITLE
Exclude evaluation- from daily build status

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -74,8 +74,8 @@ node('worker') {
         def trssBuildNames = sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getTopLevelBuildNames?type=Test")
         def buildNamesJson = new JsonSlurper().parseText(trssBuildNames)
         buildNamesJson.each { build ->
-            // Is it a build Pipeline?
-            if (build._id.buildName.contains('-pipeline')) {
+            // Is it a build Pipeline? Excluding "evaluation-" pipelines
+            if (build._id.buildName.contains('-pipeline') && !build._id.buildName.startsWith('evaluation-')) {
                 echo "Pipeline ${build._id.buildName}"
                 def pipelineName = build._id.buildName
 


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3417

Removed "evaluation-" from build success rating.
We can consider whether to have a separate Evaluation rating, i'm not sure that buys much at the moment.
