### PR TITLE
Improve resilience of MacOS Code Signing Step

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1508,7 +1508,7 @@ class Build {
                                                         echo "Code Not Signed - Have Another Try"
                                                         sleep 1
                                                         curl --fail -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
-                                                        TESTMACSIGN2=`grep -i "Apple Certification Authority" "$f"|wc -l`
+                                                        TESTMACSIGN2=`grep -i "$MACSIGNSTRING" "$f"|wc -l`
                                                         if [ $TESTMACSIGN2 -gt 0 ]
                                                         then
                                                           echo "$f Signed OK On Attempt $iteration"

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1493,7 +1493,7 @@ class Build {
                                                     dir=$(dirname "$f")
                                                     file=$(basename "$f")
                                                     mv "$f" "${dir}/unsigned_${file}"
-                                                    curl -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
+                                                    curl --fail -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
                                                     TESTMACSIGN=`grep -i "$MACSIGNSTRING" "$f"|wc -l`
                                                     if [ $TESTMACSIGN -gt 0 ]
                                                     then
@@ -1507,7 +1507,7 @@ class Build {
                                                       do
                                                         echo "Code Not Signed - Have Another Try"
                                                         sleep 1
-                                                        curl -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
+                                                        curl --fail -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
                                                         TESTMACSIGN2=`grep -i "Apple Certification Authority" "$f"|wc -l`
                                                         if [ $TESTMACSIGN2 -gt 0 ]
                                                         then

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1507,22 +1507,24 @@ class Build {
                                                         echo "Code Not Signed - Have Another Try"
                                                         sleep 1
                                                         curl -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
-                                                        TESTMACSIGN2=`grep -i "Apple Certification Authority" "$FILE"|wc -l`
+                                                        TESTMACSIGN2=`grep -i "Apple Certification Authority" "$f"|wc -l`
                                                         if [ $TESTMACSIGN2 -gt 0 ]
                                                         then
                                                           echo "$f Signed OK On Attempt $iteration"
+                                                          chmod --reference="${dir}/unsigned_${file}" "$f"
+                                                          rm -rf "${dir}/unsigned_${file}"
                                                           break
                                                         else
                                                           echo "$f Failed Signing On Attempt $iteration"
                                                           iteration=$((iteration+1))
                                                         fi
-                                                        if  [ $iteration -eq $max_iterations ]
+                                                        if [ $iteration -eq $max_iterations ]
                                                         then
                                                           echo "Reached Max Attempts"
                                                           exit 1
                                                         fi
                                                       done
-                                                    fi  
+                                                    fi
                                                 done
                                             '''
                                             } catch (e) {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1497,21 +1497,32 @@ class Build {
                                                     if [ $TESTMACSIGN -gt 0 ]
                                                     then
                                                       echo "Code Signed"
+                                                      chmod --reference="${dir}/unsigned_${file}" "$f"
+                                                      rm -rf "${dir}/unsigned_${file}"
                                                     else
-                                                      echo "Code Not Signed - Have 2nd Attempt"
-                                                      sleep 2
-                                                      curl -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
-                                                      TESTMACSIGN2=`grep -i "Apple Certification Authority" "$f"|wc -l`
-                                                      if [ $TESTMACSIGN2 -gt 0 ]
-                                                      then
-                                                        echo "$f Signed OK On 2nd Attempt"
-                                                        chmod --reference="${dir}/unsigned_${file}" "$f"
-                                                        rm -rf "${dir}/unsigned_${file}"
-                                                      else
-                                                        echo "$f Failed Signing On 2nd Attempt"
-                                                        exit 1
-                                                      fi
-                                                    fi
+                                                      max_iterations=20
+                                                      iteration=1
+                                                      while [ $iteration -le $max_iterations ]
+                                                      do
+                                                        echo "Code Not Signed - Have Another Try"
+                                                        sleep 1
+                                                        curl -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
+                                                        TESTMACSIGN2=`grep -i "Apple Certification Authority" "$FILE"|wc -l`
+                                                        if [ $TESTMACSIGN2 -gt 0 ]
+                                                        then
+                                                          echo "$f Signed OK On Attempt $iteration"
+                                                          break
+                                                        else
+                                                          echo "$f Failed Signing On Attempt $iteration"
+                                                          iteration=$((iteration+1))
+                                                        fi
+                                                        if  [ $iteration -eq $max_iterations ]
+                                                        then
+                                                          echo "Reached Max Attempts"
+                                                          exit 1
+                                                        fi
+                                                      done
+                                                    fi  
                                                 done
                                             '''
                                             } catch (e) {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1484,6 +1484,7 @@ class Build {
                                                 set -eu
                                                 echo "Signing JMOD files"
                                                 TMP_DIR="${macos_base_path}/"
+                                                MACSIGNSTRING="Apple Certification Authority"
                                                 ENTITLEMENTS="$WORKSPACE/entitlements.plist"
                                                 FILES=$(find "${TMP_DIR}" -perm +111 -type f -o -name '*.dylib'  -type f || find "${TMP_DIR}" -perm /111 -type f -o -name '*.dylib'  -type f)
                                                 for f in $FILES
@@ -1493,7 +1494,7 @@ class Build {
                                                     file=$(basename "$f")
                                                     mv "$f" "${dir}/unsigned_${file}"
                                                     curl -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
-                                                    TESTMACSIGN=`grep -i "Apple Certification Authority" "$f"|wc -l`
+                                                    TESTMACSIGN=`grep -i "$MACSIGNSTRING" "$f"|wc -l`
                                                     if [ $TESTMACSIGN -gt 0 ]
                                                     then
                                                       echo "Code Signed"
@@ -1520,7 +1521,7 @@ class Build {
                                                         fi
                                                         if [ $iteration -eq $max_iterations ]
                                                         then
-                                                          echo "Reached Max Attempts"
+                                                          echo "Reached Max Attempts = $max_iterations"
                                                           exit 1
                                                         fi
                                                       done


### PR DESCRIPTION
Fixes Issue #596 

Implements a check for each file signed in the code signing step, validates the results, and has 20 attempts with a minor pause to allow and reduce flooding the code signing service with requests.