### PR TITLE
Changing error to println to prevent misinterpretation (#752)

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -915,7 +915,7 @@ class Builder implements Serializable {
                             context.println '[NODE SHIFT] OUT OF CONTROLLER NODE!'
 
                             if ((downstreamJob.getResult() != 'SUCCESS' || !copyArtifactSuccess) && propagateFailures) {
-                                context.error("Propagating downstream job result: ${downstreamJobName}, Result: "+downstreamJob.getResult()+" CopyArtifactsSuccess: "+copyArtifactSuccess)
+                                context.println("Propagating downstream job result: ${downstreamJobName}, Result: "+downstreamJob.getResult()+" CopyArtifactsSuccess: "+copyArtifactSuccess)
                                 if (copyArtifactSuccess && downstreamJob.getResult() == 'UNSTABLE' && (currentBuild.result == 'SUCCESS' || currentBuild.result == 'UNSTABLE' )) {
                                     currentBuild.result = 'UNSTABLE'
                                 } else {


### PR DESCRIPTION
To prevent this message being interpreted as cause for failure in and of itself, I'm changing this to a println.