### PR TITLE
Improving status propagation code in pipelines

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -923,7 +923,7 @@ class Builder implements Serializable {
                                     context.println("Attempting to set pipeline result to \""+downstreamJob.getResult()+"\".")
                                     currentBuild.result = downstreamJob.getResult()
                                 } else {
-                                    context.println("Attempting to set pipeline result to \"FAILED\".")
+                                    context.println("Attempting to set pipeline result to \"FAILURE\".")
                                     currentBuild.result = 'FAILURE'
                                 }
                                 context.println("Attempt complete. Pipeline status was \""+previousPipelineStatus+"\", and is now \""+currentBuild.result+"\".")

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -919,7 +919,7 @@ class Builder implements Serializable {
                                 context.println("Propagating downstream job result: ${downstreamJobName}, Result: "+downstreamJob.getResult()+" CopyArtifactsSuccess: "+copyArtifactSuccess)
                                 if (copyArtifactSuccess) {
                                     // currentBuild.result only allows itself to be set if the new status is worse than its current status.
-                                    // So FAILED overrides UNSTABLE, and UNSTABLE overrides PASSED.
+                                    // So FAILURE overrides UNSTABLE, and UNSTABLE overrides PASSED.
                                     context.println("Attempting to set pipeline result to \""+downstreamJob.getResult()+"\".")
                                     currentBuild.result = downstreamJob.getResult()
                                 } else {

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -919,7 +919,7 @@ class Builder implements Serializable {
                                 context.println("Propagating downstream job result: ${downstreamJobName}, Result: "+downstreamJob.getResult()+" CopyArtifactsSuccess: "+copyArtifactSuccess)
                                 if (copyArtifactSuccess) {
                                     // currentBuild.result only allows itself to be set if the new status is worse than its current status.
-                                    // So FAILURE overrides UNSTABLE, and UNSTABLE overrides PASSED.
+                                    // So FAILURE overrides UNSTABLE, and UNSTABLE overrides SUCCESS.
                                     context.println("Attempting to set pipeline result to \""+downstreamJob.getResult()+"\".")
                                     currentBuild.result = downstreamJob.getResult()
                                 } else {

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -914,13 +914,19 @@ class Builder implements Serializable {
                             }
                             context.println '[NODE SHIFT] OUT OF CONTROLLER NODE!'
 
-                            if ((downstreamJob.getResult() != 'SUCCESS' || !copyArtifactSuccess) && propagateFailures) {
+                            if (propagateFailures) {
+                                String previousPipelineStatus = currentBuild.result
                                 context.println("Propagating downstream job result: ${downstreamJobName}, Result: "+downstreamJob.getResult()+" CopyArtifactsSuccess: "+copyArtifactSuccess)
-                                if (copyArtifactSuccess && downstreamJob.getResult() == 'UNSTABLE' && (currentBuild.result == 'SUCCESS' || currentBuild.result == 'UNSTABLE' )) {
-                                    currentBuild.result = 'UNSTABLE'
+                                if (copyArtifactSuccess) {
+                                    // currentBuild.result only allows itself to be set if the new status is worse than its current status.
+                                    // So FAILED overrides UNSTABLE, and UNSTABLE overrides PASSED.
+                                    context.println("Attempting to set pipeline result to \""+downstreamJob.getResult()+"\".")
+                                    currentBuild.result = downstreamJob.getResult()
                                 } else {
+                                    context.println("Attempting to set pipeline result to \"FAILED\".")
                                     currentBuild.result = 'FAILURE'
                                 }
+                                context.println("Attempt complete. Pipeline status was \""+previousPipelineStatus+"\", and is now \""+currentBuild.result+"\".")
                             }
                         }
                     }


### PR DESCRIPTION
We don't seem to allow for the pipeline to have a null status, which the API tells us is possible when calling getResult().

I've patched this logic gap and added some better logging to aid future debugging.