### PR TITLE
Ensure target is reset before loading a jdk pipeline config file

### DIFF
--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -194,7 +194,7 @@ node('worker') {
                     }
                 }
                 println "[INFO] JDK${javaVersion}: loaded target configuration:"
-                println target.toJson()
+                println JsonOutput.prettyPrint(JsonOutput.toJson(target))
 
                 config.put('targetConfigurations', target.targetConfigurations)
 

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -198,11 +198,11 @@ node('worker') {
                 config.put('targetConfigurations', target.targetConfigurations)
 
                 // Set disableJob if in target
-                if (target.hasProperty('target.disableJob')) {
+                if (target.metaClass.hasProperty(target, 'disableJob')) {
                     config.put('disableJob', target.disableJob)
                 }
 
-                if (enablePipelineSchedule.toBoolean() && target.hasProperty('triggerSchedule_nightly')) {
+                if (enablePipelineSchedule.toBoolean() && target.metaClass.hasProperty(target, 'triggerSchedule_nightly')) {
                     config.put('pipelineSchedule', target.triggerSchedule_nightly)
                 }
 
@@ -249,7 +249,7 @@ node('worker') {
                 // Load weeklyTemplatePath. This is where the weekly_release_pipeline_job_template.groovy code is located compared to the repository root. This actually sets up the weekly pipeline job using the parameters above.
                 def weeklyTemplatePath = (params.WEEKLY_TEMPLATE_PATH) ?: DEFAULTS_JSON['templateDirectories']['weekly']
 
-                if (enablePipelineSchedule.toBoolean() && target.hasProperty('triggerSchedule_weekly')) {
+                if (enablePipelineSchedule.toBoolean() && target.metaClass.hasProperty(target, 'triggerSchedule_weekly')) {
                     config.put('pipelineSchedule', target.triggerSchedule_weekly)
                 }
                 config.releaseType = "Weekly"

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -201,12 +201,8 @@ node('worker') {
                     config.put('disableJob', target.disableJob)
                 }
 
-                if (enablePipelineSchedule.toBoolean()) {
-                    try {
-                        config.put('pipelineSchedule', target.triggerSchedule_nightly)
-                    } catch (Exception ex) {
-                        config.put('pipelineSchedule', '0 0 31 2 0') // 31st Feb, so will never run
-                    }
+                if (enablePipelineSchedule.toBoolean() && target.hasProperty('triggerSchedule_nightly')) {
+                    config.put('pipelineSchedule', target.triggerSchedule_nightly)
                 }
 
                 if (useAdoptShellScripts.toBoolean()) {
@@ -252,12 +248,8 @@ node('worker') {
                 // Load weeklyTemplatePath. This is where the weekly_release_pipeline_job_template.groovy code is located compared to the repository root. This actually sets up the weekly pipeline job using the parameters above.
                 def weeklyTemplatePath = (params.WEEKLY_TEMPLATE_PATH) ?: DEFAULTS_JSON['templateDirectories']['weekly']
 
-                if (enablePipelineSchedule.toBoolean()) {
-                    try {
-                        config.put('pipelineSchedule', target.triggerSchedule_weekly)
-                    } catch (Exception ex) {
-                        config.put('pipelineSchedule', '0 0 31 2 0') // 31st Feb, so will never run
-                    }
+                if (enablePipelineSchedule.toBoolean() && target.hasProperty('triggerSchedule_weekly')) {
+                    config.put('pipelineSchedule', target.triggerSchedule_weekly)
                 }
                 config.releaseType = "Weekly"
 

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -166,14 +166,6 @@ node('worker') {
                     releaseType         : 'Nightly' 
                 ]
 
-                // Clear any pre-existing variable bindings from previous iteration load..
-                def variables = ['targetConfigurations', 'triggerSchedule_nightly', 'triggerSchedule_weekly', 'weekly_release_scmReferences', 'disableJob'] 
-                variables.each({ variable ->
-                    if (binding.hasVariable(variable)) {
-                        binding.removeVariable(variable)
-                    }
-                })
-
                 def target
                 try {
                     target = load "${WORKSPACE}/${nightlyFolderPath}/jdk${javaVersion}.groovy"
@@ -286,6 +278,12 @@ node('worker') {
                 }
 
                 generatedPipelines.add(config['JOB_NAME'])
+
+                // config.load() loads into the current groovy binding, and returns "this", so we need to reset variables before next load of target
+                def variables = ['targetConfigurations', 'triggerSchedule_nightly', 'triggerSchedule_weekly', 'weekly_release_scmReferences', 'disableJob']
+                variables.each({ variable ->
+                    target[variable] = null
+                })
             })
 
             // Fail if nothing was generated

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -280,10 +280,10 @@ node('worker') {
                 generatedPipelines.add(config['JOB_NAME'])
 
                 // config.load() loads into the current groovy binding, and returns "this", so we need to reset variables before next load of target
-                target.targetConfigurations = []
+                target.targetConfigurations = {} 
                 target.triggerSchedule_nightly = '0 0 31 2 0'
                 target.triggerSchedule_weekly = '0 0 31 2 0'
-                target.weekly_release_scmReferences = []
+                target.weekly_release_scmReferences = {} 
                 target.disableJob = false
             })
 

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -197,12 +197,19 @@ node('worker') {
 
                 config.put('targetConfigurations', target.targetConfigurations)
 
-                if (target.hasProperty('disableJob')) {
+                // hack as jenkins groovy does not seem to allow us to check if disableJob exists
+                try {
                     config.put('disableJob', target.disableJob)
+                } catch (Exception ex) {
+                    config.put('disableJob', false)
                 }
 
-                if (enablePipelineSchedule.toBoolean() && target.hasProperty('triggerSchedule_nightly')) {
-                    config.put('pipelineSchedule', target.triggerSchedule_nightly)
+                if (enablePipelineSchedule.toBoolean()) {
+                    try {
+                        config.put('pipelineSchedule', target.triggerSchedule_nightly)
+                    } catch (Exception ex) {
+                        config.put('pipelineSchedule', '0 0 31 2 0')
+                    }
                 }
 
                 if (useAdoptShellScripts.toBoolean()) {
@@ -248,8 +255,12 @@ node('worker') {
                 // Load weeklyTemplatePath. This is where the weekly_release_pipeline_job_template.groovy code is located compared to the repository root. This actually sets up the weekly pipeline job using the parameters above.
                 def weeklyTemplatePath = (params.WEEKLY_TEMPLATE_PATH) ?: DEFAULTS_JSON['templateDirectories']['weekly']
 
-                if (enablePipelineSchedule.toBoolean() && target.hasProperty('triggerSchedule_weekly')) {
-                    config.put('pipelineSchedule', target.triggerSchedule_weekly)
+                if (enablePipelineSchedule.toBoolean()) {
+                    try {
+                        config.put('pipelineSchedule', target.triggerSchedule_weekly)
+                    } catch (Exception ex) {
+                        config.put('pipelineSchedule', '0 0 31 2 0')
+                    }
                 }
                 config.releaseType = "Weekly"
 

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -167,7 +167,8 @@ node('worker') {
                 ]
 
                 // Ensure target is initialized to [], otherwise groovy uses previous iteration state...!
-                def target = [] 
+                def target = []
+                target.clear()
                 try {
                     target = load "${WORKSPACE}/${nightlyFolderPath}/jdk${javaVersion}.groovy"
                 } catch (NoSuchFileException e) {

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -280,10 +280,11 @@ node('worker') {
                 generatedPipelines.add(config['JOB_NAME'])
 
                 // config.load() loads into the current groovy binding, and returns "this", so we need to reset variables before next load of target
-                def variables = ['targetConfigurations', 'triggerSchedule_nightly', 'triggerSchedule_weekly', 'weekly_release_scmReferences', 'disableJob']
-                variables.each({ variable ->
-                    target[variable] = null
-                })
+                target.targetConfigurations = []
+                target.triggerSchedule_nightly = '0 0 31 2 0'
+                target.triggerSchedule_weekly = '0 0 31 2 0'
+                target.weekly_release_scmReferences = []
+                target.disableJob = false
             })
 
             // Fail if nothing was generated

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -205,7 +205,7 @@ node('worker') {
 
                 config.put('targetConfigurations', target.targetConfigurations)
 
-                if (target.hasVariable('disableJob')) {
+                if (target.hasProperty('disableJob')) {
                     config.put('disableJob', target.disableJob)
                 }
 


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/773

When pipeline config is loaded via a groovy "target = load <config>", target is set to the current groovy binding, and all the variables loaded are set in the groovy variable binding.
When a 2nd load is performed the target return is the same "current groovy binding", thus any previous version loaded variable values will still be set... hence why the jdk21 schedule was being set to the jdk17u schedule!

This PR ensures at the end of each iteration the target binding values are reset.
 
