### PR TITLE
Enabled head jdk-22 pipeline builds

### DIFF
--- a/pipelines/jobs/configurations/jdk21.groovy
+++ b/pipelines/jobs/configurations/jdk21.groovy
@@ -33,9 +33,9 @@ targetConfigurations = [
 ]
 
 // 23:30 Mon, Wed, Fri
-// triggerSchedule_nightly = 'TZ=UTC\n30 23 * * 1,3,5'
+//Uses releaseTrigger_21ea: triggerSchedule_nightly = 'TZ=UTC\n30 23 * * 1,3,5'
 // 23:30 Sat
-triggerSchedule_weekly = 'TZ=UTC\n30 23 * * 6'
+//Replaced by releaseTrigger_21ea: triggerSchedule_weekly = 'TZ=UTC\n30 23 * * 6'
 
 // scmReferences to use for weekly release build
 weekly_release_scmReferences = [

--- a/pipelines/jobs/configurations/jdk21_evaluation.groovy
+++ b/pipelines/jobs/configurations/jdk21_evaluation.groovy
@@ -13,9 +13,9 @@ targetConfigurations = [
 // if set to empty string then it wont get triggered
 
 // 23:40 Mon, Wed
-// triggerSchedule_evaluation = 'TZ=UTC\n40 23 * * 1,3'
+//Uses releaseTrigger_21ea: triggerSchedule_evaluation = 'TZ=UTC\n40 23 * * 1,3'
 // 23:40 Sat
-triggerSchedule_weekly_evaluation = 'TZ=UTC\n40 23 * * 6'
+//Replaced by releaseTrigger_21ea:triggerSchedule_weekly_evaluation = 'TZ=UTC\n40 23 * * 6'
 
 // scmReferences to use for weekly evaluation release build
 weekly_evaluation_scmReferences = [

--- a/pipelines/jobs/configurations/jdk22.groovy
+++ b/pipelines/jobs/configurations/jdk22.groovy
@@ -33,7 +33,7 @@ targetConfigurations = [
 ]
 
 // 23:30 Mon, Wed, Fri
-triggerSchedule_nightly = 'TZ=UTC\n30 23 * * 1,3,5'
+//Uses releaseTrigger_22ea: triggerSchedule_nightly = 'TZ=UTC\n30 23 * * 1,3,5'
 // 23:30 Sat
 triggerSchedule_weekly = 'TZ=UTC\n30 23 * * 6'
 
@@ -45,8 +45,5 @@ weekly_release_scmReferences = [
         'corretto'       : '',
         'dragonwell'     : ''
 ]
-
-// Disable for the moment, choose appropriate schedule above^ when enabling!
-disableJob = true
 
 return this

--- a/pipelines/jobs/configurations/jdk22.groovy
+++ b/pipelines/jobs/configurations/jdk22.groovy
@@ -35,7 +35,7 @@ targetConfigurations = [
 // 23:30 Mon, Wed, Fri
 //Uses releaseTrigger_22ea: triggerSchedule_nightly = 'TZ=UTC\n30 23 * * 1,3,5'
 // 23:30 Sat
-triggerSchedule_weekly = 'TZ=UTC\n30 23 * * 6'
+//Replaced by releaseTrigger_22ea: triggerSchedule_weekly = 'TZ=UTC\n30 23 * * 6'
 
 // scmReferences to use for weekly release build
 weekly_release_scmReferences = [

--- a/pipelines/jobs/configurations/jdk22_evaluation.groovy
+++ b/pipelines/jobs/configurations/jdk22_evaluation.groovy
@@ -13,7 +13,7 @@ targetConfigurations = [
 // if set to empty string then it wont get triggered
 
 // 23:40 Mon, Wed
-triggerSchedule_evaluation = 'TZ=UTC\n40 23 * * 1,3'
+//Uses releaseTrigger_22ea: triggerSchedule_evaluation = 'TZ=UTC\n40 23 * * 1,3'
 // 23:40 Sat
 triggerSchedule_weekly_evaluation = 'TZ=UTC\n40 23 * * 6'
 
@@ -22,8 +22,5 @@ weekly_evaluation_scmReferences = [
         'hotspot'        : '',
         'temurin'        : ''
 ]
-
-// Disable for the moment, choose appropriate schedule above^ when enabling!
-disableJob = true
 
 return this

--- a/pipelines/jobs/configurations/jdk22_evaluation.groovy
+++ b/pipelines/jobs/configurations/jdk22_evaluation.groovy
@@ -15,7 +15,7 @@ targetConfigurations = [
 // 23:40 Mon, Wed
 //Uses releaseTrigger_22ea: triggerSchedule_evaluation = 'TZ=UTC\n40 23 * * 1,3'
 // 23:40 Sat
-triggerSchedule_weekly_evaluation = 'TZ=UTC\n40 23 * * 6'
+//Replaced by releaseTrigger_22ea: triggerSchedule_weekly_evaluation = 'TZ=UTC\n40 23 * * 6'
 
 // scmReferences to use for weekly evaluation release build
 weekly_evaluation_scmReferences = [


### PR DESCRIPTION
temurin22-binaries repo is now created.
The [releaseTrigger_22ea](https://ci.adoptium.net/job/build-scripts/job/utils/job/releaseTrigger_22ea/) is also enabled to trigger builds when tags are available.

This PR also disables the jdk21 & 22 Weekly schedule, in favour of the tag triggered builds.
