### PR TITLE
Fixing code tools 2

### DIFF
--- a/tools/code-tools/Jenkinsfile
+++ b/tools/code-tools/Jenkinsfile
@@ -84,7 +84,7 @@ def build(stageName) {
                 checkout([$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: "${stageName}"]], submoduleCfg: [], userRemoteConfigs: [[url: toolsUrl]]])
             }
             sh label: "${stageName}", script: "./tools/code-tools/${stageName}.sh"
-            archiveArtifacts artifacts: "**/temurin-*-sbom.jar, ${stageName}/*.tar.gz, ${stageName}/${stageName}*.jar, ${stageName}/${stageName}*.jar.*.txt,${stageName}/${stageName}*.tar.gz.*.txt, ${stageName}/*.tar.gz.*sum*.txt, ${stageName}/${stageName}*.jar.html, ${stageName}/${stageName}*.jar.md, ${stageName}/${stageName}*.zip, ${stageName}/javatest*.jar, ${stageName}/javatest.*sum*.txt", followSymlinks: false
+            archiveArtifacts artifacts: "**/temurin-*-sbom.jar, ${stageName}/*.tar.gz, ${stageName}/${stageName}*.jar, ${stageName}/${stageName}*.jar.*.txt,${stageName}/${stageName}*.tar.gz.*.txt, ${stageName}/*.tar.gz.*sum*.txt, ${stageName}/*.zip.*sum*.txt, ${stageName}/${stageName}*.jar.html, ${stageName}/${stageName}*.jar.md, ${stageName}/${stageName}*.zip, ${stageName}/javatest*.jar, ${stageName}/javatest.*sum*.txt", followSymlinks: false
         } catch (Exception e) {
             slackSend channel: 'jenkins', color: 'danger', message: "${env.JOB_NAME} : #${env.BUILD_NUMBER} : ${stageName}() FAILED with following error message:\n${e}", teamDomain: 'adoptium'
             throw new Exception("[ERROR] ${stageName} FAILED\n${e}")

--- a/tools/code-tools/Jenkinsfile
+++ b/tools/code-tools/Jenkinsfile
@@ -84,7 +84,7 @@ def build(stageName) {
                 checkout([$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: "${stageName}"]], submoduleCfg: [], userRemoteConfigs: [[url: toolsUrl]]])
             }
             sh label: "${stageName}", script: "./tools/code-tools/${stageName}.sh"
-            archiveArtifacts artifacts: "**/temurin-*-sbom.jar, ${stageName}/*.tar.gz, ${stageName}/${stageName}*.jar, ${stageName}/${stageName}*.jar.*.txt,${stageName}/${stageName}*.tar.gz.*.txt, ${stageName}/*.tar.gz.*sum*.txt, ${stageName}/*.zip.*sum*.txt, ${stageName}/${stageName}*.jar.html, ${stageName}/${stageName}*.jar.md, ${stageName}/${stageName}*.zip, ${stageName}/javatest*.jar, ${stageName}/javatest.*sum*.txt", followSymlinks: false
+            archiveArtifacts artifacts: "**/temurin-*-sbom.jar, ${stageName}/*.tar.gz, ${stageName}/${stageName}*.jar, ${stageName}/${stageName}*.jar.*.txt,${stageName}/${stageName}*.tar.gz.*.txt, ${stageName}/*.tar.gz.*sum*.txt, ${stageName}/*.zip.*sum*.txt, ${stageName}/${stageName}*.jar.html, ${stageName}/${stageName}*.jar.md, ${stageName}/${stageName}*.zip, ${stageName}/javatest*.jar, ${stageName}/javatest*sum*.txt", followSymlinks: false
         } catch (Exception e) {
             slackSend channel: 'jenkins', color: 'danger', message: "${env.JOB_NAME} : #${env.BUILD_NUMBER} : ${stageName}() FAILED with following error message:\n${e}", teamDomain: 'adoptium'
             throw new Exception("[ERROR] ${stageName} FAILED\n${e}")

--- a/tools/code-tools/jcov.sh
+++ b/tools/code-tools/jcov.sh
@@ -24,7 +24,13 @@ function detectJdks() {
   find ${jvm_dir} -maxdepth 1 | sort
   echo "Available jdks 17 in ${jvm_dir}:"
   find ${jvm_dir} -maxdepth 1 | sort | grep -e java-17-     -e jdk-17
+  echo "Available jdks 11 in ${jvm_dir}:"
+  find ${jvm_dir} -maxdepth 1 | sort | grep -e java-11-     -e jdk-11
+  echo "Available jdks 8 in ${jvm_dir}:"
+  find ${jvm_dir} -maxdepth 1 | sort | grep -e java-1.8.0-  -e jdk-8
   jdk17=$(readlink -f $(find ${jvm_dir} -maxdepth 1 | sort | grep -e java-17-     -e jdk-17  | head -n 1))
+  jdk11=$(readlink -f $(find ${jvm_dir} -maxdepth 1 | sort | grep -e java-11-     -e jdk-11  | head -n 1))
+  jdk08=$(readlink -f $(find ${jvm_dir} -maxdepth 1 | sort | grep -e java-1.8.0-  -e jdk-8   | head -n 1))
 }
 
 function resetRepo() {
@@ -129,6 +135,7 @@ pushd $REPO_DIR
   getAsmDeps "8.0.1"
   getJavatest
   pushd build
+    export JAVA_HOME="$jdk8"
     ant $ASM_PROPS build
   popd
   pushd $BUILD_PATH/jcov*/
@@ -144,6 +151,7 @@ pushd $REPO_DIR
   getAsmDeps "9.0"
   getJavatest
   pushd build
+    export JAVA_HOME="$jdk17"
     ant $ASM_PROPS test | tee ../$main_file-$tip_shortened.tar.gz.txt || true
     ant $ASM_PROPS build
   popd


### PR DESCRIPTION
https://ci.adoptium.net/view/Dependencies/job/dependency_pipeline/898/ jcov failed to build, as its tip picekd up jdk8, but jcov tip no longer is able to build with jdk8, but needs 11 and up.

Also javatest-* (only javatest.jar had) and sigtest zips were missing hashes. That should be fixed now:
https://ci.adoptium.net/view/Dependencies/job/dependency_pipeline/898/artifact/sigtest/
https://ci.adoptium.net/view/Dependencies/job/dependency_pipeline/898/artifact/jtharness/
