### PR TITLE
Fixed typo in jdk8 variable

### DIFF
--- a/tools/code-tools/jcov.sh
+++ b/tools/code-tools/jcov.sh
@@ -135,7 +135,7 @@ pushd $REPO_DIR
   getAsmDeps "8.0.1"
   getJavatest
   pushd build
-    export JAVA_HOME="$jdk8"
+    export JAVA_HOME="$jdk08"
     ant $ASM_PROPS build
   popd
   pushd $BUILD_PATH/jcov*/


### PR DESCRIPTION
A typo sneaked in https://github.com/adoptium/ci-jenkins-pipelines/pull/786. I do not understand how that was possible, as the build faisl also locally. I'm afraid it was some unlucky "after all" typed "backspace"  in IDE, where I thought I'm in browser. My apologise!