### PR TITLE
Ensure evaluation pipeline config load resets groovy binding before the load

### DIFF
--- a/pipelines/build/regeneration/evaluation_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/evaluation_pipeline_generator.groovy
@@ -200,9 +200,11 @@ node('worker') {
 
                     // if has a triggerSchedule_evaluation variable set then use it or default to '0 0 31 2 0'/never run
                     if (enablePipelineSchedule.toBoolean()){
-                        config.put('pipelineSchedule', targetEvaluation.triggerSchedule_evaluation)
-                    } else { // empty to not run
-                        config.put('pipelineSchedule', '')
+                        try {
+                            config.put('pipelineSchedule', targetEvaluation.triggerSchedule_evaluation)
+                        } catch (Exception ex) {
+                            config.put('pipelineSchedule', '0 0 31 2 0')
+                        }
                     }
 
                     // hack as jenkins groovy does not seem to allow us to check if disableJob exists
@@ -248,9 +250,11 @@ node('worker') {
                     }
                     config.PIPELINE = "evaluation-openjdk${javaVersion}-pipeline"
                     if (enablePipelineSchedule.toBoolean()) {
-                        config.put('pipelineSchedule', targetEvaluation.triggerSchedule_weekly_evaluation)
-                    } else { // empty string will never run
-                        config.put('pipelineSchedule', '')
+                        try {
+                            config.put('pipelineSchedule', targetEvaluation.triggerSchedule_weekly_evaluation)
+                        } catch (Exception ex) {
+                            config.put('pipelineSchedule', '0 0 31 2 0')
+                        }
                     }
                     config.put('targetConfigurations', targetEvaluation.targetConfigurations) // explicit set it to make things clear
                     config.weekly_release_scmReferences = targetEvaluation.weekly_evaluation_scmReferences
@@ -278,6 +282,13 @@ node('worker') {
                     }
                     // add into list
                     generatedPipelines.add(config['JOB_NAME'])
+
+                    // config.load() loads into the current groovy binding, and returns "this", so we need to reset variables before next load of targetEvaluation
+                    targetEvaluation.targetConfigurations = {} 
+                    targetEvaluation.triggerSchedule_evaluation = '0 0 31 2 0'
+                    targetEvaluation.triggerSchedule_weekly_evaluation = '0 0 31 2 0'
+                    targetEvaluation.weekly_evaluation_scmReferences = {} 
+                    targetEvaluation.disableJob = false
                 }
             })
 

--- a/pipelines/build/regeneration/evaluation_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/evaluation_pipeline_generator.groovy
@@ -198,6 +198,9 @@ node('worker') {
                     }
                     config.put('targetConfigurations', targetEvaluation.targetConfigurations)
 
+                    println "[INFO] JDK${javaVersion}: loaded targetEvaluation configuration:"
+                    println JsonOutput.prettyPrint(JsonOutput.toJson(targetEvaluation))
+
                     // if has a triggerSchedule_evaluation variable set then use it or default to '0 0 31 2 0'/never run
                     if (enablePipelineSchedule.toBoolean()){
                         try {

--- a/pipelines/jobs/configurations/jdk17u_evaluation.groovy
+++ b/pipelines/jobs/configurations/jdk17u_evaluation.groovy
@@ -31,7 +31,7 @@ targetConfigurations = [
 ]
 
 // if set to empty string then it wont get triggered
-triggerSchedule_pevaluation = 'TZ=UTC\n30 23 * * 2,4'
+triggerSchedule_evaluation = 'TZ=UTC\n30 23 * * 2,4'
 // if set to empty string then it wont get triggered
 triggerSchedule_weekly_evaluation = 'TZ=UTC\n05 12 * * 7'
 


### PR DESCRIPTION
Ensure evaluation pipeline config load resets groovy binding before the load, so any old values are not picked up.
Same fix as https://github.com/adoptium/ci-jenkins-pipelines/commit/cedc5010be4424a0da5f85c7c58f4ca404841539
Also fixed typo in jdk17u schedule.

Fixes: https://github.com/adoptium/ci-jenkins-pipelines/issues/789


