### PR TITLE
Also build jtreg version 7.3.1+1

### DIFF
--- a/tools/code-tools/jtreg.sh
+++ b/tools/code-tools/jtreg.sh
@@ -2,7 +2,7 @@
 
 ###################################################################
 # Script to build jtreg test suite harness                        #
-# currently builds tip, 5.1, 6, 6.1, 7, 7.1, 7.2, 7.3             #
+# currently builds tip, 5.1, 6, 6.1, 7, 7.1.1, 7.2, 7.3, 7.3.1    #
 ###################################################################
 
 # shellcheck disable=SC2035,SC2116
@@ -16,6 +16,7 @@ readonly JTREG_7='jtreg-7+1'
 readonly JTREG_7_1='jtreg-7.1.1+1'
 readonly JTREG_7_2='jtreg-7.2+1'
 readonly JTREG_7_3='jtreg-7.3+1'
+readonly JTREG_7_3_1='jtreg-7.3.1+1'
 
 function checkWorkspaceVar()
 {
@@ -73,6 +74,11 @@ buildJTReg()
     elif [ "$1" == "$JTREG_7_3" ]; then
       export JTREG_BUILD_NUMBER="1"
       export BUILD_VERSION="7.3"
+      export JAVA_HOME=/usr/lib/jvm/jdk-11
+      export PATH=$PATH:$JAVA_HOME/bin
+    elif [ "$1" == "$JTREG_7_3_1" ]; then
+      export JTREG_BUILD_NUMBER="1"
+      export BUILD_VERSION="7.3.1"
       export JAVA_HOME=/usr/lib/jvm/jdk-11
       export PATH=$PATH:$JAVA_HOME/bin
     fi
@@ -148,5 +154,6 @@ buildJTReg "$JTREG_7"
 buildJTReg "$JTREG_7_1"
 buildJTReg "$JTREG_7_2"
 buildJTReg "$JTREG_7_3"
+buildJTReg "$JTREG_7_3_1"
 buildJTReg
 echo '...finished with build process.'


### PR DESCRIPTION
The minimum version was changed from 7.3 to 7.3.1; see https://bugs.openjdk.org/browse/JDK-8314495.