### PR TITLE
Refactor daily status health check to handle triggered builds and verify published assets

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -454,10 +454,12 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                     def slackColor = 'good'
                     def health = "healthy"
                     def errorMsg = ""
-                    if (!latestTagBuilt) {
+                    def missingAssets = []
+                    if (status['assets'] != "Complete") {
                         slackColor = 'danger'
                         health = "unhealthy"
-                        errorMsg = "Expected build tag: "+status['expectedReleaseName']
+                        errorMsg = " Artifact status: "+status['assets']
+                        missingAssets = status['missingAssets']
                     } else if (maxDays <= days) {
                         slackColor = 'warning'
                         health = "unhealthy"
@@ -465,6 +467,9 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                     }
                     def fullMessage = "JDK ${featureRelease} latest pipeline publish status: ${health}. Build: ${releaseName}. Published: ${msg}.${errorMsg}"
                     echo "===> ${fullMessage}"
+                    if (missingAssets.size() > 0) {
+                        echo "==>     Missing artifacts: "+missingAssets
+                    }
                     // One slack message per JDK version:
                     //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
                 } else {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -200,7 +200,8 @@ node('worker') {
             def latestOpenjdkBuild = getLatestOpenjdkBuildTag("jdk")
             def tipVersion = tipRelease.replaceAll("u", "").replaceAll("jdk", "").toInteger()
             def releaseName = getLatestBinariesTag("${tipVersion}")
-            status = [releaseName: releaseName, expectedReleaseName: "${latestOpenjdkBuild}-ea-beta"]
+            def escLatestOpenjdkBuild = latestOpenjdkBuild.replaceAll("\+", "%2B")
+            status = [releaseName: releaseName, expectedReleaseName: "${escLatestOpenjdkBuild}-ea-beta"]
             verifyReleaseContent(tipRelease, releaseName, status)
             healthStatus[tipVersion] = status
            

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -51,7 +51,8 @@ echo "==>${releaseAssetsUrl}"
     // Get list of assets, concatenate into a single string
 def rrc = sh(script: "curl -L -o releaseAssets.json '${releaseAssetsUrl}'", returnStatus: true)
 echo "rc = $rrc"
-cat releaseAssets.json
+def out = sh(script: "cat releaseAssets.json", returnStdout: true)
+echo "out = ${out}"
     def releaseAssets = sh(script: "curl -L \"${releaseAssetsUrl}\" | grep '\"name\"' | tr '\\n' '#'", returnStdout: true)
     if (releaseAssets == "") {
         echo "Error loading release assets list for ${releaseAssetsUrl}"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -453,7 +453,6 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                     if (status['assets'] != 'Complete') {
                         slackColor = 'danger'
                         health = "unhealthy"
-echo status['assets']
                         errorMsg = " Artifact status: "+status['assets']
 echo "$status['missingAssets']"
                         missingAssets = status['missingAssets']
@@ -464,8 +463,26 @@ echo "$status['missingAssets']"
                     }
                     def fullMessage = "JDK ${featureRelease} latest pipeline publish status: ${health}. Build: ${releaseName}. Published: ${msg}.${errorMsg}"
                     echo "===> ${fullMessage}"
+                    // Print out formatted missing artifacts if any missing
                     if (missingAssets.size() > 0) {
-                        echo "==>     Missing artifacts: "+missingAssets
+                        // Collate by arch, array is sequenced by architecture
+                        def archName = ""
+                        def missingFiles = ""
+                        missingAssets.each { missing ->
+                            def missingFile = missing.split("[ :]+")
+                            if (missingFile[0] != archName) {
+                                if (archName != "") {
+                                    echo "==>    Missing artifacts, ${archName}: ${missingFiles}"
+                                }
+                                archName = missingFile[0]
+                                missingFiles = missingFile[1]+missingFile[2]
+                            } else {
+                                missingFiles += ","+missingFile[1]+missingFile[2]
+                            }                        
+                        } 
+                        if (missingFiles != "") {
+                            echo "==>    Missing artifacts, ${archName}: ${missingFiles}"
+                        }
                     }
                     // One slack message per JDK version:
                     //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -97,11 +97,11 @@ echo "AA${releaseAssets}AA"
                 if (osarch.contains("Windows")) {
                     filetypes =        ["\\.zip", "\\.zip\\.json", "\\.zip\\.sha256\\.txt", "\\.zip\\.sig"]
                     jdkjre_filetypes = ["\\.msi", "\\.msi\\.json", "\\.msi\\.sha256\\.txt", "\\.msi\\.sig"]
-                    jdkjre_filetypes.add(filetypes)
+                    jdkjre_filetypes.addAll(filetypes)
                 } else if (osarch.contains("Mac")) {
                     filetypes        = ["\\.tar\\.gz", "\\.tar\\.gz\\.json", "\\.tar\\.gz\\.sha256\\.txt", "\\.tar\\.gz\\.sig"]
                     jdkjre_filetypes = ["\\.pkg", "\\.pkg\\.json", "\\.pkg\\.sha256\\.txt", "\\.pkg\\.sig"]
-                    jdkjre_filetypes.add(filetypes)
+                    jdkjre_filetypes.addAll(filetypes)
                 } else {
                     filetypes = ["\\.tar\\.gz", "\\.tar\\.gz\\.json", "\\.tar\\.gz\\.sha256\\.txt", "\\.tar\\.gz\\.sig"]
                     jdkjre_filetypes = filetypes

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -130,9 +130,9 @@ echo "AA${releaseAssets}AA"
                     }
                     ftypes.each { ftype ->
                         def arch_fname = archToAsset[osarch]
-echo "/.*{$file_image}_{$arch_fname}_[^\\.\"]*{$ftype}\".*/"
+echo "/.*${file_image}_${arch_fname}_[^\\.\"]*${ftype}\".*/"
                         //def findAsset = releaseAssets =~/"(?s).*${file_image}_${arch_fname}_[^\"]*${ftype}\".*"/
-                        def findAsset = releaseAssets =~/.*{$file_image}_{$arch_fname}_[^\."]*{$ftype}".*/
+                        def findAsset = releaseAssets =~/.*${file_image}_${arch_fname}_[^\."]*${ftype}".*/
                         if (!findAsset) {
                             def missing="$osarch : $image : $ftype".replaceAll("\\\\", "")
                             echo "    Missing asset: ${missing}"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -49,7 +49,7 @@ def verifyReleaseContent(String version, String release, Map status) {
 echo "==>${releaseAssetsUrl}"
 
     // Get list of assets, concatenate into a single string
-def rrc = sh(script: "curl -L -o releaseAssets.json '${releaseAssetsUrl}'", returnStatus)
+def rrc = sh(script: "curl -L -o releaseAssets.json '${releaseAssetsUrl}'", returnStatus: true)
 echo "rc = $rrc"
 cat releaseAssets.json
     def releaseAssets = sh(script: "curl -L \"${releaseAssetsUrl}\" | grep '\"name\"' | tr '\\n' '#'", returnStdout: true)

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -49,8 +49,8 @@ def verifyReleaseContent(String version, String release, Map status) {
 echo "==>${releaseAssetsUrl}"
 
     // Get list of assets, concatenate into a single string
-def rc = sh(script: "curl -L -o releaseAssets.json '${releaseAssetsUrl}'", returnStatus)
-echo "rc = $rc"
+def rrc = sh(script: "curl -L -o releaseAssets.json '${releaseAssetsUrl}'", returnStatus)
+echo "rc = $rrc"
 cat releaseAssets.json
     def releaseAssets = sh(script: "curl -L \"${releaseAssetsUrl}\" | grep '\"name\"' | tr '\\n' '#'", returnStdout: true)
     if (releaseAssets == "") {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -49,7 +49,7 @@ def verifyReleaseContent(String version, String release, Map status) {
     def releaseAssetsUrl = "https://api.github.com/repos/${params.BINARIES_REPO}/releases/tags/${escRelease}".replaceAll("_NN_", version.replaceAll("u","").replaceAll("jdk",""))
 
     // Get list of assets, concatenate into a single string
-    def rc = sh(script: "rm -f releaseAssets.json && curl -H \"Accept: application/json\" -L -o releaseAssets.json '${releaseAssetsUrl}'", returnStatus: true)
+    def rc = sh(script: "rm -f releaseAssets.json && curl -H \\\\\"Accept: application/json\\\\\" -L -o releaseAssets.json \\\\\"${releaseAssetsUrl}\\\\\"", returnStatus: true)
     def releaseAssets = ""
     if (rc == 0) {
         releaseAssets = sh(script: "cat releaseAssets.json | grep '\"name\"' | tr '\\n' '#'", returnStdout: true)

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -89,7 +89,7 @@ def verifyReleaseContent(String version, String release, Map status) {
                                
             def missingAssets = []
             targetConfigurations.keySet().each { osarch ->
-                echo "    Verifying : $osarch"
+                echo "Verifying : $osarch"
                 def foundAsset = false
                 def missingForArch = []
 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -448,9 +448,9 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                 if (featureReleaseInt < 21) {
                     // Check for stale published build
                     def days = status['actualDays'] as int
-                    lastPublishedMsg = " Published: ${days} day(s) ago" // might actually be days + N hours, where N < 24
+                    lastPublishedMsg = " Published: ${days} day(s) ago. " // might actually be days + N hours, where N < 24
                     if (status['actualDays'] == 0) {
-                        lastPublishedMsg = " Published: less than 24 hours ago"
+                        lastPublishedMsg = " Published: less than 24 hours ago. "
                     }
                     def maxDays = status['maxStaleDays'] as int
                     if (maxDays <= days) {
@@ -476,11 +476,13 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                     missingAssets = status['missingAssets']
                 }
 
-                def fullMessage = "JDK ${featureRelease} latest pipeline publish status: ${health}. Build: ${releaseName}. ${lastPublishedMsg}.${errorMsg}"
+                def fullMessage = "JDK ${featureRelease} latest pipeline publish status: ${health}. Build: ${releaseName}.${lastPublishedMsg}${errorMsg}"
                 echo "===> ${fullMessage}"
+                slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
 
                 // Print out formatted missing artifacts if any missing
                 if (missingAssets.size() > 0) {
+                    def missingMsg
                     // Collate by arch, array is sequenced by architecture
                     def archName = ""
                     def missingFiles = ""
@@ -489,7 +491,9 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                         def missingFile = missing.split("[ :]+")
                         if (missingFile[0] != archName) {
                             if (archName != "") {
-                                echo "==>    Missing artifacts, ${archName}: ${missingFiles}"
+                                missingMsg = "    Missing artifacts, ${archName}: ${missingFiles}"
+                                echo "===> ${missingMsg}"
+                                slackSend(channel: slackChannel, color: slackColor, message: missingMsg)
                             }
                             archName = missingFile[0]
                             missingFiles = missingFile[1]+missingFile[2]
@@ -498,11 +502,11 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                         }                        
                     } 
                     if (missingFiles != "") {
-                        echo "==>    Missing artifacts, ${archName}: ${missingFiles}"
+                        missingMsg = "    Missing artifacts, ${archName}: ${missingFiles}"
+                        echo "===> ${missingMsg}"
+                        slackSend(channel: slackChannel, color: slackColor, message: missingMsg)
                     }
                 }
-                // One slack message per JDK version:
-                //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }
             echo '----------------------------------------------------------------'
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -47,7 +47,9 @@ def verifyReleaseContent(String version, String release, Map status) {
 
     def escRelease = release.replaceAll("\\+", "%2B")
     def releaseAssetsUrl = "https://api.github.com/repos/${params.BINARIES_REPO}/releases/tags/${escRelease}".replaceAll("_NN_", version.replaceAll("u","").replaceAll("jdk",""))
-    status['assetsUrl'] = releaseAssetsUrl
+
+    // Transform to browser URL for use in Slack message link
+    status['assetsUrl'] = releaseAssetsUrl.replaceAll("api.github.com","github.com").replaceAll("/repos/","/").replaceAll("/tags/","/")
 
     // Get list of assets, concatenate into a single string
     def rc = sh(script: 'rm -f releaseAssets.json && curl -L -o releaseAssets.json '+releaseAssetsUrl, returnStatus: true)

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -71,18 +71,19 @@ def verifyReleaseContent(String version, String release, Map status) {
             targetConfigurations = null
             load configFile
 
-            def archToAsset = [x64Linux:   "x64_linux",
-                               x64Windows: "x64_windows",
-                               x64Mac:     "x64_mac",
+            // Map of config architecture to artifact name
+            def archToAsset = [x64Linux:       "x64_linux",
+                               x64Windows:     "x64_windows",
+                               x64Mac:         "x64_mac",
                                x64AlpineLinux: "x64_alpine-linux",
-                               ppc64Aix:   "ppc64_aix",
-                               ppc64leLinux: "ppc64le_linux",
-                               s390xLinux: "s390x_linux",
-                               aarch64Linux: "aarch64_linux",
-                               aarch64Mac: "aarch64_mac",
-                               arm32Linux: "arm_linux",
-                               x32Windows: "x86-32_windows",
-                               x64Solaris: "x64_solaris",
+                               ppc64Aix:       "ppc64_aix",
+                               ppc64leLinux:   "ppc64le_linux",
+                               s390xLinux:     "s390x_linux",
+                               aarch64Linux:   "aarch64_linux",
+                               aarch64Mac:     "aarch64_mac",
+                               arm32Linux:     "arm_linux",
+                               x32Windows:     "x86-32_windows",
+                               x64Solaris:     "x64_solaris",
                                sparcv9Solaris: "sparcv9_solaris"
                               ]
                                
@@ -148,13 +149,16 @@ def verifyReleaseContent(String version, String release, Map status) {
                 if (!foundAsset) {
                     echo "    $osarch : All artifacts missing"
                     missingAssets.add("$osarch : **All artifacts**")
-                } else if (missingForArch.length > 0) {
+                } else if (missingForArch.size() > 0) {
                     echo "    $osarch : Missing artifacts: ${missingForArch}"
                     missingAssets.addAll(missingForArch)
+                } else {
+                    echo "    $osarch : Complete"
                 }
             }
 
-            if (missingAssets.length > 0) {
+            // Set overall assets status for this release
+            if (missingAssets.size() > 0) {
                 status['assets'] = "Missing artifacts"
                 status['missingAssets'] = missingAssets
             } else {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -45,13 +45,10 @@ def verifyReleaseContent(String version, String release, Map status) {
     echo "Verifying ${version} asserts in release: ${release}"
     status['assets'] = "Good"
 
-def curl=sh(script:"curl --version", returnStdout: true)
-echo "CURL: $curl"
-
     def escRelease = release.replaceAll("\\+", "%2B")
     def releaseAssetsUrl = "https://api.github.com/repos/${params.BINARIES_REPO}/releases/tags/${escRelease}".replaceAll("_NN_", version.replaceAll("u","").replaceAll("jdk",""))
 
- releaseAssetsUrl = "https://api.github.com/repos/adoptium/temurin22-binaries/releases/tags/jdk-22+12-ea-beta"
+ //releaseAssetsUrl = "https://api.github.com/repos/adoptium/temurin22-binaries/releases/tags/jdk-22+12-ea-beta"
     // Get list of assets, concatenate into a single string
     def rc = sh(script: 'rm -f releaseAssets.json && curl -L -o releaseAssets.json '+releaseAssetsUrl, returnStatus: true)
     def releaseAssets = ""

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -200,7 +200,7 @@ node('worker') {
             def latestOpenjdkBuild = getLatestOpenjdkBuildTag("jdk")
             def tipVersion = tipRelease.replaceAll("u", "").replaceAll("jdk", "").toInteger()
             def releaseName = getLatestBinariesTag("${tipVersion}")
-            def escLatestOpenjdkBuild = latestOpenjdkBuild.replaceAll("\+", "%2B")
+            def escLatestOpenjdkBuild = latestOpenjdkBuild.replaceAll("\\+", "%2B")
             status = [releaseName: releaseName, expectedReleaseName: "${escLatestOpenjdkBuild}-ea-beta"]
             verifyReleaseContent(tipRelease, releaseName, status)
             healthStatus[tipVersion] = status

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -24,7 +24,7 @@ import java.time.temporal.ChronoUnit
 def getLatestOpenjdkBuildTag(String version) {
     def openjdkRepo = "https://github.com/openjdk/${version}.git"
 
-    def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v \"\\^{}\" | tr -s \"\\t \" \" \" | cut -d\" \" -f2 | sed \"s,refs/tags/,,\" | sort -V -r | head -1 | tr -d\"\\n\"")
+    def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | sort -V -r | head -1 | tr -d'\\n'")
     echo "latest ${version} tag = ${latestTag}A"
 
     return latestTag

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -416,9 +416,9 @@ node('worker') {
         echo "======> Latest pipeline build Success Rating for variant: ${variant}"
         echo "======> Total number of Build jobs    = ${totalBuildJobs}"
         echo "======> Total number of Test jobs     = ${totalTestJobs}"
-        echo "======> Nightly Build Success Rating  = ${nightlyBuildSuccessRating.intValue()} %"
-        echo "======> Nightly Test Success Rating   = ${nightlyTestSuccessRating.intValue()} %"
-        echo "======> Overall Nightly Build & Test Success Rating = ${overallNightlySuccessRating} %"
+        echo "======> Build Success Rating  = ${nightlyBuildSuccessRating.intValue()} %"
+        echo "======> Test Success Rating   = ${nightlyTestSuccessRating.intValue()} %"
+        echo "======> Overall Latest Build & Test Success Rating = ${overallNightlySuccessRating} %"
 
         def statusColor = 'good'
         if (nightlyBuildSuccessRating.intValue() < amberBuildAlertLevel || nightlyTestSuccessRating.intValue() < amberTestAlertLevel) {
@@ -433,8 +433,10 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
 
     stage('printPublishStats') {
         if (variant == 'temurin' || variant == 'hotspot') { //variant == "hotspot" should be enough for now. Keep temurin for later.
-            echo '-------------- Nightly pipeline health report ------------------'
-            featureReleases.each { featureRelease ->
+            echo '-------------- Latest pipeline health report ------------------'
+            def allReleases = featureReleases
+            allReleases.add(tipRelease)
+            allReleases.each { featureRelease ->
                 def featureReleaseInt = featureRelease.replaceAll("u", "").replaceAll("jdk", "").toInteger()
                 def status = healthStatus[featureReleaseInt]
 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -451,7 +451,6 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                     def maxDays = status['maxStaleDays'] as int
                     def releaseName = status['releaseName']
                     
-                    def fullMessage = "JDK ${featureRelease} latest pipeline publish status: healthy. Last published: ${msg}. Build: ${releaseName}"
                     def slackColor = 'good'
                     def health = "healthy"
                     def errorMsg = ""

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -49,7 +49,7 @@ def verifyReleaseContent(String version, String release, Map status) {
 echo "==>${releaseAssetsUrl}"
 
     // Get list of assets, concatenate into a single string
-    def releaseAssets = sh(script: "curl -L ${releaseAssetsUrl} | grep '\"name\"' | tr '\\n' '#'", returnStdout: true)
+    def releaseAssets = sh(script: "curl -L \"${releaseAssetsUrl}\" | grep '\"name\"' | tr '\\n' '#'", returnStdout: true)
     if (releaseAssets == "") {
         echo "Error loading release assets list for ${releaseAssetsUrl}"
         status['assets'] = "Error loading ${releaseAssetsUrl}"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -55,7 +55,6 @@ def verifyReleaseContent(String version, String release, Map status) {
     if (rc == 0) {
         releaseAssets = sh(script: "cat releaseAssets.json | grep '\"name\"' | tr '\\n' '#'", returnStdout: true)
     }
-echo "==> ${releaseAssets}"
     if (releaseAssets == "") {
         echo "Error loading release assets list for ${releaseAssetsUrl}"
         status['assets'] = "Error loading ${releaseAssetsUrl}"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -447,7 +447,7 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                     def latestTagBuilt = true
                     if (status['releaseName'] != status['expectedReleaseName']) {
                         latestTagBuilt = false
-                    )
+                    }
                     def maxDays = status['maxStaleDays'] as int
                     def releaseName = status['releaseName']
                     

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -89,6 +89,8 @@ def verifyReleaseContent(String version, String release, Map status) {
             def missingAssets = []
             targetConfigurations.keySet().each { osarch ->
                 echo "    Verifying : $osarch"
+                def foundAsset = false
+                def missingForArch = []
 
                 def imagetypes = ["debugimage", "jdk", "jre", "sbom"]
                 if (version != "jdk8u") {
@@ -138,11 +140,19 @@ def verifyReleaseContent(String version, String release, Map status) {
                         def findAsset = releaseAssets =~/.*${file_image}_${arch_fname}_[^\."]*${ftype}".*/
                         if (!findAsset) {
                             def missing="$osarch : $image : $ftype".replaceAll("\\\\", "")
-                            echo "    Missing asset: ${missing}"
-                            missingAssets.add(missing)
+                            missingForArch.add(missing)
                             status['assets'] = "Missing assets"
+                        } else {
+                            foundAsset = true
                         }
                     }
+                }
+                if (!foundAsset) {
+                    echo "    $osarch : All artifacts missing"
+                    missingAssets.addAll("$osarch : **All artifacts**")
+                } else {
+                    echo "    $osarch : Missing artifacts: ${missingForArch}"
+                    missingAssets.addAll(missingForArch)
                 }
             }
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -49,7 +49,7 @@ def verifyReleaseContent(String version, String release, Map status) {
     def releaseAssetsUrl = "https://api.github.com/repos/${params.BINARIES_REPO}/releases/tags/${escRelease}".replaceAll("_NN_", version.replaceAll("u","").replaceAll("jdk",""))
 
     // Get list of assets, concatenate into a single string
-    def rc = sh(script: "rm -f releaseAssets.json && curl -H \\\\\"Accept: application/json\\\\\" -L -o releaseAssets.json \\\\\"${releaseAssetsUrl}\\\\\"", returnStatus: true)
+    def rc = sh(script: 'rm -f releaseAssets.json && curl -H \\"Accept: application/json\\" -L -o releaseAssets.json \\"${releaseAssetsUrl}\\"', returnStatus: true)
     def releaseAssets = ""
     if (rc == 0) {
         releaseAssets = sh(script: "cat releaseAssets.json | grep '\"name\"' | tr '\\n' '#'", returnStdout: true)

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -48,7 +48,6 @@ def verifyReleaseContent(String version, String release, Map status) {
     def escRelease = release.replaceAll("\\+", "%2B")
     def releaseAssetsUrl = "https://api.github.com/repos/${params.BINARIES_REPO}/releases/tags/${escRelease}".replaceAll("_NN_", version.replaceAll("u","").replaceAll("jdk",""))
 
- //releaseAssetsUrl = "https://api.github.com/repos/adoptium/temurin22-binaries/releases/tags/jdk-22+12-ea-beta"
     // Get list of assets, concatenate into a single string
     def rc = sh(script: 'rm -f releaseAssets.json && curl -L -o releaseAssets.json '+releaseAssetsUrl, returnStatus: true)
     def releaseAssets = ""
@@ -436,7 +435,6 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
         if (variant == 'temurin' || variant == 'hotspot') { //variant == "hotspot" should be enough for now. Keep temurin for later.
             echo '-------------- Nightly pipeline health report ------------------'
             featureReleases.each { featureRelease ->
-echo featureRelease
                 def featureReleaseInt = featureRelease.replaceAll("u", "").replaceAll("jdk", "").toInteger()
                 def status = healthStatus[featureReleaseInt]
                 if (featureReleaseInt < 21) {
@@ -452,13 +450,12 @@ echo featureRelease
                     def health = "healthy"
                     def errorMsg = ""
                     def missingAssets = []
-echo "A"
                     if (status['assets'] != 'Complete') {
                         slackColor = 'danger'
                         health = "unhealthy"
 echo status['assets']
                         errorMsg = " Artifact status: "+status['assets']
-echo status['missingAssets']
+echo "$status['missingAssets']"
                         missingAssets = status['missingAssets']
                     } else if (maxDays <= days) {
                         slackColor = 'warning'

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -259,6 +259,8 @@ node('worker') {
         }
         allReleases.each { release ->
            def featureReleaseStr = release.replaceAll("u", "").replaceAll("jdk", "")
+
+           // Only interested in nightly/triggered openjdkNN-pipeline's
            pipelinesOfInterest += ",openjdk${featureReleaseStr}-pipeline"
         }
 
@@ -266,8 +268,8 @@ node('worker') {
         def trssBuildNames = sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getTopLevelBuildNames?type=Test")
         def buildNamesJson = new JsonSlurper().parseText(trssBuildNames)
         buildNamesJson.each { build ->
-            // Is it a build Pipeline? Excluding "evaluation-" pipelines
-            if (build._id.buildName.contains('-pipeline') && !build._id.buildName.startsWith('evaluation-')) {
+            // Is it a build Pipeline?
+            if (build._id.buildName.contains('-pipeline')) {
                 echo "Pipeline ${build._id.buildName}"
                 def pipelineName = build._id.buildName
 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -148,7 +148,7 @@ def verifyReleaseContent(String version, String release, Map status) {
                 }
                 if (!foundAsset) {
                     echo "    $osarch : All artifacts missing"
-                    missingAssets.addAll("$osarch : **All artifacts**")
+                    missingAssets.add("$osarch : **All artifacts**")
                 } else if (missingForArch.size > 0) {
                     echo "    $osarch : Missing artifacts: ${missingForArch}"
                     missingAssets.addAll(missingForArch)

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -139,8 +139,7 @@ def verifyReleaseContent(String version, String release, Map status) {
                         def arch_fname = archToAsset[osarch]
                         def findAsset = releaseAssets =~/.*${file_image}_${arch_fname}_[^\."]*${ftype}".*/
                         if (!findAsset) {
-                            def missing="$osarch : $image : $ftype".replaceAll("\\\\", "")
-                            missingForArch.add(missing)
+                            missingForArch.add("$osarch : $image : $ftype".replaceAll("\\\\", ""))
                         } else {
                             foundAsset = true
                         }
@@ -157,6 +156,7 @@ def verifyReleaseContent(String version, String release, Map status) {
 
             if (missingAssets.length > 0) {
                 status['assets'] = "Missing artifacts"
+                status['missingAssets'] = missingAssets
             } else {
                 status['assets'] = "Complete"
             }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -149,13 +149,13 @@ def verifyReleaseContent(String version, String release, Map status) {
                 if (!foundAsset) {
                     echo "    $osarch : All artifacts missing"
                     missingAssets.add("$osarch : **All artifacts**")
-                } else if (missingForArch.size > 0) {
+                } else if (missingForArch.length > 0) {
                     echo "    $osarch : Missing artifacts: ${missingForArch}"
                     missingAssets.addAll(missingForArch)
                 }
             }
 
-            if (missingAssets.size > 0) {
+            if (missingAssets.length > 0) {
                 status['assets'] = "Missing artifacts"
             } else {
                 status['assets'] = "Complete"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -130,7 +130,7 @@ echo "AA${releaseAssets}AA"
                     }
                     ftypes.each { ftype ->
                         def arch_fname = archToAsset[osarch]
-echo /.*{$file_image}_{$arch_fname}_[^\."]*{$ftype}".*/
+echo "/.*{$file_image}_{$arch_fname}_[^\.\"]*{$ftype}\".*/"
                         //def findAsset = releaseAssets =~/"(?s).*${file_image}_${arch_fname}_[^\"]*${ftype}\".*"/
                         def findAsset = releaseAssets =~/.*{$file_image}_{$arch_fname}_[^\."]*{$ftype}".*/
                         if (!findAsset) {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -476,7 +476,7 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                     missingAssets = status['missingAssets']
                 }
 
-                def fullMessage = "JDK ${featureRelease} latest pipeline publish status: ${health}. Build: ${releaseName}. Published: ${msg}.${errorMsg}"
+                def fullMessage = "JDK ${featureRelease} latest pipeline publish status: ${health}. Build: ${releaseName}.${lastPublishedMsg}.${errorMsg}"
                 echo "===> ${fullMessage}"
 
                 // Print out formatted missing artifacts if any missing

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -46,14 +46,14 @@ def verifyReleaseContent(String version, String release, Map status) {
     status['assets'] = "Good"
 
     def releaseAssetsUrl = "https://api.github.com/repos/${params.BINARIES_REPO}/releases/tags/${release}".replaceAll("_NN_", version.replaceAll("u","").replaceAll("jdk",""))
-echo "==>${releaseAssetsUrl}"
 
     // Get list of assets, concatenate into a single string
-def rrc = sh(script: "curl -L -o releaseAssets.json '${releaseAssetsUrl}'", returnStatus: true)
-echo "rc = $rrc"
-def out = sh(script: "cat releaseAssets.json", returnStdout: true)
-echo "out = ${out}"
-    def releaseAssets = sh(script: "curl -L \"${releaseAssetsUrl}\" | grep '\"name\"' | tr '\\n' '#'", returnStdout: true)
+    def rc = sh(script: "rm -f releaseAssets.json && curl -L -o releaseAssets.json '${releaseAssetsUrl}'", returnStatus: true)
+    def releaseAssets = ""
+    if (rc == 0) {
+        releaseAssets = sh(script: "cat releaseAssets.json | grep '\"name\"' | tr '\\n' '#'", returnStdout: true)
+    }
+echo "==> ${releaseAssets}"
     if (releaseAssets == "") {
         echo "Error loading release assets list for ${releaseAssetsUrl}"
         status['assets'] = "Error loading ${releaseAssetsUrl}"
@@ -61,7 +61,7 @@ echo "out = ${out}"
         def configFile = "${version}.groovy"   
         def targetConfigPath = "${params.BUILD_CONFIG_URL}/${configFile}"
         echo "    Loading pipeline config file: ${targetConfigPath}"
-        def rc = sh(script: "curl -LO ${targetConfigPath}", returnStatus: true)
+        rc = sh(script: "curl -LO ${targetConfigPath}", returnStatus: true)
         if (rc != 0) {
             echo "Error loading ${targetConfigPath}"
             status['assets'] = "Error loading ${targetConfigPath}"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -45,7 +45,8 @@ def verifyReleaseContent(String version, String release, Map status) {
     echo "Verifying ${version} asserts in release: ${release}"
     status['assets'] = "Good"
 
-    def releaseAssetsUrl = "https://api.github.com/repos/${params.BINARIES_REPO}/releases/tags/${release}".replaceAll("_NN_", version.replaceAll("u","").replaceAll("jdk",""))
+    def escRelease = release.replaceAll("\\+", "%2B")
+    def releaseAssetsUrl = "https://api.github.com/repos/${params.BINARIES_REPO}/releases/tags/${escRelease}".replaceAll("_NN_", version.replaceAll("u","").replaceAll("jdk",""))
 
     // Get list of assets, concatenate into a single string
     def rc = sh(script: "rm -f releaseAssets.json && curl -L -o releaseAssets.json '${releaseAssetsUrl}'", returnStatus: true)
@@ -200,8 +201,7 @@ node('worker') {
             def latestOpenjdkBuild = getLatestOpenjdkBuildTag("jdk")
             def tipVersion = tipRelease.replaceAll("u", "").replaceAll("jdk", "").toInteger()
             def releaseName = getLatestBinariesTag("${tipVersion}")
-            def escLatestOpenjdkBuild = latestOpenjdkBuild.replaceAll("\\+", "%2B")
-            status = [releaseName: releaseName, expectedReleaseName: "jdk-22%2B12-ea-beta"]
+            status = [releaseName: releaseName, expectedReleaseName: "${latestOpenjdkBuild}-ea-beta"]
             verifyReleaseContent(tipRelease, releaseName, status)
             healthStatus[tipVersion] = status
            

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -24,7 +24,7 @@ import java.time.temporal.ChronoUnit
 def getLatestOpenjdkBuildTag(String version) {
     def openjdkRepo = "https://github.com/openjdk/${version}.git"
 
-    def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | sort -V -r | head -1 | tr -d'\\n'")
+    def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | sort -V -r | head -1 | tr -d '\\n'")
     echo "latest ${version} tag = ${latestTag}A"
 
     return latestTag
@@ -34,7 +34,7 @@ def getLatestOpenjdkBuildTag(String version) {
 def getLatestBinariesTag(String version) {
     def binariesRepo = "https://github.com/${params.BINARIES_REPO}".replaceAll("_NN_", version)
 
-    def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${binariesRepo} | grep \"\\-ea\\-beta\" | grep -v \"\\^{}\" | tr -s \"\\t \" \" \" | cut -d\" \" -f2 | sed \"s,refs/tags/,,\" | sort -V -r | head -1")
+    def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${binariesRepo} | grep \"\\-ea\\-beta\" | grep -v \"\\^{}\" | tr -s \"\\t \" \" \" | cut -d\" \" -f2 | sed \"s,refs/tags/,,\" | sort -V -r | head -1 | tr -d '\\n'")
     echo "latest jdk${version} tag = ${latestTag}"
 
     return latestTag    

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -232,7 +232,7 @@ node('worker') {
                 verifyReleaseContent(featureRelease, releaseName, variant, status)
                 echo "  ${featureRelease} release binaries verification: "+status['assets']
                 if (status['assets'] == "Missing ALL artifacts") {
-                  echo " Published ${releaseName} binaries has no non-evaluation artifacts, it must be an 'evaluation' build, skip to next.."
+                  echo "Published ${releaseName} binaries has no non-evaluation artifacts, it must be an 'evaluation' build, skip to next.."
                   i += 1
                 } else {
                   foundNonEvaluationBinaries = true
@@ -493,7 +493,7 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                 if (featureReleaseInt < 21) {
                     // Check for stale published build
                     def days = status['actualDays'] as int
-                    lastPublishedMsg = "Published: ${days} day(s) ago." // might actually be days + N hours, where N < 24
+                    lastPublishedMsg = "\nPublished: ${days} day(s) ago." // might actually be days + N hours, where N < 24
                     if (status['actualDays'] == 0) {
                         lastPublishedMsg = "\nPublished: less than 24 hours ago."
                     }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -34,7 +34,7 @@ def getLatestOpenjdkBuildTag(String version) {
 def getLatestBinariesTag(String version) {
     def binariesRepo = "https://github.com/${params.BINARIES_REPO}".replaceAll("_NN_", version)
 
-    def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${binariesRepo} | grep \"\\-ea\\-beta\" | grep -v \"\\^{}\" | tr -s \"\\t \" \" \" | cut -d\" \" -f2 | sed \"s,refs/tags/,,\" | sort -V -r | head -1 | tr -d '\\n'")
+    def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${binariesRepo} | grep '\\-ea\\-beta' | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed 's,refs/tags/,,' | sort -V -r | head -1 | tr -d '\\n'")
     echo "latest jdk${version} tag = ${latestTag}"
 
     return latestTag    

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -130,7 +130,7 @@ echo "AA${releaseAssets}AA"
                     }
                     ftypes.each { ftype ->
                         def arch_fname = archToAsset[osarch]
-echo "/.*{$file_image}_{$arch_fname}_[^\.\"]*{$ftype}\".*/"
+echo "/.*{$file_image}_{$arch_fname}_[^\\.\"]*{$ftype}\".*/"
                         //def findAsset = releaseAssets =~/"(?s).*${file_image}_${arch_fname}_[^\"]*${ftype}\".*"/
                         def findAsset = releaseAssets =~/.*{$file_image}_{$arch_fname}_[^\."]*{$ftype}".*/
                         if (!findAsset) {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -426,7 +426,7 @@ node('worker') {
         }
 
         // Slack message:
-        //slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
 echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -201,7 +201,7 @@ node('worker') {
             def tipVersion = tipRelease.replaceAll("u", "").replaceAll("jdk", "").toInteger()
             def releaseName = getLatestBinariesTag("${tipVersion}")
             def escLatestOpenjdkBuild = latestOpenjdkBuild.replaceAll("\\+", "%2B")
-            status = [releaseName: releaseName, expectedReleaseName: "${escLatestOpenjdkBuild}-ea-beta"]
+            status = [releaseName: releaseName, expectedReleaseName: "jdk-22%2B12-ea-beta"]
             verifyReleaseContent(tipRelease, releaseName, status)
             healthStatus[tipVersion] = status
            

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -484,14 +484,14 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                     if (maxDays <= days) {
                         slackColor = 'warning'
                         health = "unhealthy"
-                        errorMsg = " Stale threshold: ${maxDays} days"
+                        errorMsg = " Stale threshold: ${maxDays} days."
                     }
                 } else {
                     // Check latest published binaries are for the latest openjdk build tag
                     if (status['releaseName'] != status['expectedReleaseName']) {
                         slackColor = 'danger'
                         health = "unhealthy"
-                        errorMsg = " Latest upstream build "+status['expectedReleaseName']+" != latest publish binaries "+status['releaseName']
+                        errorMsg = " Latest upstream build "+status['expectedReleaseName']+" != latest publish binaries "+status['releaseName']+"."
                     }
                 }
 
@@ -500,7 +500,7 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                 if (status['assets'] != 'Complete') {
                     slackColor = 'danger'
                     health = "unhealthy"
-                    errorMsg += " Artifact status: "+status['assets']
+                    errorMsg += " Artifact status: "+status['assets']+"."
                     missingAssets = status['missingAssets']
                 }
                  

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -508,7 +508,7 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                     if (status['releaseName'] != status['expectedReleaseName']) {
                         slackColor = 'danger'
                         health = "Unhealthy"
-                        errorMsg = "\nLatest upstream build "+status['expectedReleaseName']+" != latest publish binaries "+status['releaseName']+"."
+                        errorMsg = "\nLatest Adoptium publish binaries "+status['releaseName']+" !=  latest upstream openjdk build "+status['expectedReleaseName']+"."
                     }
                 }
 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -25,7 +25,7 @@ def getLatestOpenjdkBuildTag(String version) {
     def openjdkRepo = "https://github.com/openjdk/${version}.git"
 
     def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | sort -V -r | head -1 | tr -d '\\n'")
-    echo "latest ${version} tag = ${latestTag}A"
+    echo "latest upstream openjdk/${version} tag = ${latestTag}"
 
     return latestTag
 }
@@ -35,7 +35,7 @@ def getLatestBinariesTag(String version) {
     def binariesRepo = "https://github.com/${params.BINARIES_REPO}".replaceAll("_NN_", version)
 
     def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${binariesRepo} | grep '\\-ea\\-beta' | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed 's,refs/tags/,,' | sort -V -r | head -1 | tr -d '\\n'")
-    echo "latest jdk${version} tag = ${latestTag}"
+    echo "latest jdk${version} binaries repo tag = ${latestTag}"
 
     return latestTag    
 }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -49,6 +49,9 @@ def verifyReleaseContent(String version, String release, Map status) {
 echo "==>${releaseAssetsUrl}"
 
     // Get list of assets, concatenate into a single string
+def rc = sh(script: "curl -L -o releaseAssets.json '${releaseAssetsUrl}'", returnStatus)
+echo "rc = $rc"
+cat releaseAssets.json
     def releaseAssets = sh(script: "curl -L \"${releaseAssetsUrl}\" | grep '\"name\"' | tr '\\n' '#'", returnStdout: true)
     if (releaseAssets == "") {
         echo "Error loading release assets list for ${releaseAssetsUrl}"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -48,11 +48,8 @@ def verifyReleaseContent(String version, String release, Map status) {
     def escRelease = release.replaceAll("\\+", "%2B")
     def releaseAssetsUrl = "https://api.github.com/repos/${params.BINARIES_REPO}/releases/tags/${escRelease}".replaceAll("_NN_", version.replaceAll("u","").replaceAll("jdk",""))
 
-echo 'aa ${releaseAssetsUrl}'
-echo "aa2 ${releaseAssetsUrl}"
-echo 'aa3 '+releaseAssetsUrl
     // Get list of assets, concatenate into a single string
-    def rc = sh(script: 'rm -f releaseAssets.json && curl -H \\"Accept: application/json\\" -L -o releaseAssets.json \\"${releaseAssetsUrl}\\"', returnStatus: true)
+    def rc = sh(script: 'rm -f releaseAssets.json && curl -H \\"Accept: application/json\\" -L -o releaseAssets.json \\"'+releaseAssetsUrl+'\\"', returnStatus: true)
     def releaseAssets = ""
     if (rc == 0) {
         releaseAssets = sh(script: "cat releaseAssets.json | grep '\"name\"' | tr '\\n' '#'", returnStdout: true)

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -51,8 +51,9 @@ echo "CURL: $curl"
     def escRelease = release.replaceAll("\\+", "%2B")
     def releaseAssetsUrl = "https://api.github.com/repos/${params.BINARIES_REPO}/releases/tags/${escRelease}".replaceAll("_NN_", version.replaceAll("u","").replaceAll("jdk",""))
 
+ releaseAssetsUrl = "https://api.github.com/repos/adoptium/temurin22-binaries/releases/tags/jdk-22+12-ea-beta"
     // Get list of assets, concatenate into a single string
-    def rc = sh(script: 'rm -f releaseAssets.json && curl -L -o releaseAssets.json \\"'+releaseAssetsUrl+'\\"', returnStatus: true)
+    def rc = sh(script: 'rm -f releaseAssets.json && curl -L -o releaseAssets.json '+releaseAssetsUrl, returnStatus: true)
     def releaseAssets = ""
     if (rc == 0) {
         releaseAssets = sh(script: "cat releaseAssets.json | grep '\"name\"' | tr '\\n' '#'", returnStdout: true)

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -46,10 +46,10 @@ def verifyReleaseContent(String version, String release, Map status) {
     status['assets'] = "Good"
 
     def releaseAssetsUrl = "https://api.github.com/repos/${params.BINARIES_REPO}/releases/tags/${release}".replaceAll("_NN_", version.replaceAll("u","").replaceAll("jdk",""))
+echo "==>${releaseAssetsUrl}"
 
-    // Get list of assets, conctenate into a single string
-    def releaseAssets = sh(script: "curl -L '${releaseAssetsUrl}' | grep '\"name\"' | tr '\\n' '#'", returnStdout: true)
-echo "AA${releaseAssets}AA"
+    // Get list of assets, concatenate into a single string
+    def releaseAssets = sh(script: "curl -L ${releaseAssetsUrl} | grep '\"name\"' | tr '\\n' '#'", returnStdout: true)
     if (releaseAssets == "") {
         echo "Error loading release assets list for ${releaseAssetsUrl}"
         status['assets'] = "Error loading ${releaseAssetsUrl}"
@@ -130,8 +130,6 @@ echo "AA${releaseAssets}AA"
                     }
                     ftypes.each { ftype ->
                         def arch_fname = archToAsset[osarch]
-echo "/.*${file_image}_${arch_fname}_[^\\.\"]*${ftype}\".*/"
-                        //def findAsset = releaseAssets =~/"(?s).*${file_image}_${arch_fname}_[^\"]*${ftype}\".*"/
                         def findAsset = releaseAssets =~/.*${file_image}_${arch_fname}_[^\."]*${ftype}".*/
                         if (!findAsset) {
                             def missing="$osarch : $image : $ftype".replaceAll("\\\\", "")
@@ -151,8 +149,8 @@ node('worker') {
     def trssUrl    = "${params.TRSS_URL}"
     def apiUrl    = "${params.API_URL}"
     def slackChannel = "${params.SLACK_CHANNEL}"
-    def featureReleases = "${params.FEATURE_RELEASES}".split("[, ]+")   //[ "jdk8u", "jdk11u", "jdk17u", "jdk21" ] // Consider making those parameters
-    def tipRelease      = "${params.TIP_RELEASE}"  //"jdk22" // Current jdk(head) version
+    def featureReleases = "${params.FEATURE_RELEASES}".split("[, ]+") // feature versions 
+    def tipRelease      = "${params.TIP_RELEASE}"  // Current jdk(head) version, eg.jdk22
     def nightlyStaleDays = "${params.MAX_NIGHTLY_STALE_DAYS}"
     def amberBuildAlertLevel = params.AMBER_BUILD_ALERT_LEVEL ? params.AMBER_BUILD_ALERT_LEVEL as Integer : -99
     def amberTestAlertLevel  = params.AMBER_TEST_ALERT_LEVEL  ? params.AMBER_TEST_ALERT_LEVEL as Integer : -99

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -49,7 +49,7 @@ def verifyReleaseContent(String version, String release, Map status) {
     def releaseAssetsUrl = "https://api.github.com/repos/${params.BINARIES_REPO}/releases/tags/${escRelease}".replaceAll("_NN_", version.replaceAll("u","").replaceAll("jdk",""))
 
     // Get list of assets, concatenate into a single string
-    def rc = sh(script: "rm -f releaseAssets.json && curl -L -o releaseAssets.json '${releaseAssetsUrl}'", returnStatus: true)
+    def rc = sh(script: "rm -f releaseAssets.json && curl -H \"Accept: application/json\" -L -o releaseAssets.json '${releaseAssetsUrl}'", returnStatus: true)
     def releaseAssets = ""
     if (rc == 0) {
         releaseAssets = sh(script: "cat releaseAssets.json | grep '\"name\"' | tr '\\n' '#'", returnStdout: true)

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -444,10 +444,6 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                     if (status['actualDays'] == 0) {
                         msg = 'less than 24 hours ago'
                     }
-                    def latestTagBuilt = true
-                    if (status['releaseName'] != status['expectedReleaseName']) {
-                        latestTagBuilt = false
-                    }
                     def maxDays = status['maxStaleDays'] as int
                     def releaseName = status['releaseName']
                     
@@ -455,10 +451,13 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                     def health = "healthy"
                     def errorMsg = ""
                     def missingAssets = []
-                    if (status['assets'] != "Complete") {
+echo "A"
+                    if (status['assets'] != 'Complete') {
                         slackColor = 'danger'
                         health = "unhealthy"
+echo status['assets']
                         errorMsg = " Artifact status: "+status['assets']
+echo status['missingAssets']
                         missingAssets = status['missingAssets']
                     } else if (maxDays <= days) {
                         slackColor = 'warning'
@@ -473,6 +472,10 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                     // One slack message per JDK version:
                     //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
                 } else {
+                    def latestTagBuilt = true
+                    if (status['releaseName'] != status['expectedReleaseName']) {
+                        latestTagBuilt = false
+                    }
                 }
             }
             echo '----------------------------------------------------------------'

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -174,7 +174,7 @@ node('worker') {
     def apiUrl    = "${params.API_URL}"
     def slackChannel = "${params.SLACK_CHANNEL}"
     def featureReleases = "${params.FEATURE_RELEASES}".split("[, ]+") // feature versions 
-    def tipRelease      = "${params.TIP_RELEASE}"  // Current jdk(head) version, eg.jdk22
+    def tipRelease      = "${params.TIP_RELEASE}" as String  // Current jdk(head) version, eg.jdk22
     def nightlyStaleDays = "${params.MAX_NIGHTLY_STALE_DAYS}"
     def amberBuildAlertLevel = params.AMBER_BUILD_ALERT_LEVEL ? params.AMBER_BUILD_ALERT_LEVEL as Integer : -99
     def amberTestAlertLevel  = params.AMBER_TEST_ALERT_LEVEL  ? params.AMBER_TEST_ALERT_LEVEL as Integer : -99

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -48,6 +48,9 @@ def verifyReleaseContent(String version, String release, Map status) {
     def escRelease = release.replaceAll("\\+", "%2B")
     def releaseAssetsUrl = "https://api.github.com/repos/${params.BINARIES_REPO}/releases/tags/${escRelease}".replaceAll("_NN_", version.replaceAll("u","").replaceAll("jdk",""))
 
+echo 'aa ${releaseAssetsUrl}'
+echo "aa2 ${releaseAssetsUrl}"
+echo 'aa3 '+releaseAssetsUrl
     // Get list of assets, concatenate into a single string
     def rc = sh(script: 'rm -f releaseAssets.json && curl -H \\"Accept: application/json\\" -L -o releaseAssets.json \\"${releaseAssetsUrl}\\"', returnStatus: true)
     def releaseAssets = ""

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -463,7 +463,7 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                     if (status['releaseName'] != status['expectedReleaseName']) {
                         slackColor = 'danger'
                         health = "unhealthy"
-                        errorMsg = " Latest upstream build "+status['expectedReleaseName'] != latest publish binaries "+status['releaseName']
+                        errorMsg = " Latest upstream build "+status['expectedReleaseName']+" != latest publish binaries "+status['releaseName']
                     }
                 }
 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -47,6 +47,7 @@ def verifyReleaseContent(String version, String release, Map status) {
 
     def escRelease = release.replaceAll("\\+", "%2B")
     def releaseAssetsUrl = "https://api.github.com/repos/${params.BINARIES_REPO}/releases/tags/${escRelease}".replaceAll("_NN_", version.replaceAll("u","").replaceAll("jdk",""))
+    status['assetsUrl'] = releaseAssetsUrl
 
     // Get list of assets, concatenate into a single string
     def rc = sh(script: 'rm -f releaseAssets.json && curl -L -o releaseAssets.json '+releaseAssetsUrl, returnStatus: true)
@@ -494,8 +495,9 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                     errorMsg += " Artifact status: "+status['assets']
                     missingAssets = status['missingAssets']
                 }
-
-                def fullMessage = "${featureRelease} latest pipeline publish status: ${health}. Build: ${releaseName}.${lastPublishedMsg}${errorMsg}"
+                 
+                def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
+                def fullMessage = "${featureRelease} latest pipeline publish status: ${health}. Build: ${releaseLink}.${lastPublishedMsg}${errorMsg}"
                 echo "===> ${fullMessage}"
                 slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -136,6 +136,7 @@ def verifyReleaseContent(String version, String release, Map status) {
                             file_image="${file_image}-glibc"
                         }
                     }
+                    // Search for artifacts in the releaseAssets list
                     ftypes.each { ftype ->
                         def arch_fname = archToAsset[osarch]
                         def findAsset = releaseAssets =~/.*${file_image}_${arch_fname}_[^\."]*${ftype}".*/

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -339,8 +339,7 @@ node('worker') {
                                 def pipelineBuildJobs = sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getChildBuilds?parentId=${pipeline_id}")
                                 def pipelineBuildJobsJson = new JsonSlurper().parseText(pipelineBuildJobs)
                                 buildJobNumber = 0
-                                if (pipelineBuildJobsJson.size() > 0) {
-                                    pipelineBuildJobsJson.each { buildJob ->
+                                pipelineBuildJobsJson.each { buildJob ->
                                         if (buildJob.buildName.contains(buildVariant)) {
                                             buildJobNumber += 1
                                             if (buildJob.buildResult.equals('FAILURE')) {
@@ -349,7 +348,6 @@ node('worker') {
                                                 buildJobComplete += 1
                                             }
                                         }
-                                    }
                                 }
 
                                 def testResult = [name: pipelineName, url: pipelineUrl,

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -25,7 +25,7 @@ def getLatestOpenjdkBuildTag(String version) {
     def openjdkRepo = "https://github.com/openjdk/${version}.git"
 
     def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v \"\\^{}\" | tr -s \"\\t \" \" \" | cut -d\" \" -f2 | sed \"s,refs/tags/,,\" | sort -V -r | head -1")
-    echo "latest ${version} tag = ${latestTag}"
+    echo "latest ${version} tag = ${latestTag}A"
 
     return latestTag
 }
@@ -148,7 +148,7 @@ def verifyReleaseContent(String version, String release, Map status) {
                 }
                 if (!foundAsset) {
                     echo "    $osarch : All artifacts missing"
-                    missingAssets.add("$osarch : All : All")
+                    missingAssets.add("$osarch : All : .All")
                 } else if (missingForArch.size() > 0) {
                     echo "    $osarch : Missing artifacts: ${missingForArch}"
                     missingAssets.addAll(missingForArch)
@@ -476,7 +476,7 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                     missingAssets = status['missingAssets']
                 }
 
-                def fullMessage = "JDK ${featureRelease} latest pipeline publish status: ${health}. Build: ${releaseName}.${lastPublishedMsg}.${errorMsg}"
+                def fullMessage = "JDK ${featureRelease} latest pipeline publish status: ${health}. Build: ${releaseName}. ${lastPublishedMsg}.${errorMsg}"
                 echo "===> ${fullMessage}"
 
                 // Print out formatted missing artifacts if any missing

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -45,11 +45,14 @@ def verifyReleaseContent(String version, String release, Map status) {
     echo "Verifying ${version} asserts in release: ${release}"
     status['assets'] = "Good"
 
+def curl=sh(script:"curl --version", returnStdout: true)
+echo "CURL: $curl"
+
     def escRelease = release.replaceAll("\\+", "%2B")
     def releaseAssetsUrl = "https://api.github.com/repos/${params.BINARIES_REPO}/releases/tags/${escRelease}".replaceAll("_NN_", version.replaceAll("u","").replaceAll("jdk",""))
 
     // Get list of assets, concatenate into a single string
-    def rc = sh(script: 'rm -f releaseAssets.json && curl -H \\"Accept: application/json\\" -L -o releaseAssets.json \\"'+releaseAssetsUrl+'\\"', returnStatus: true)
+    def rc = sh(script: 'rm -f releaseAssets.json && curl -L -o releaseAssets.json \\"'+releaseAssetsUrl+'\\"', returnStatus: true)
     def releaseAssets = ""
     if (rc == 0) {
         releaseAssets = sh(script: "cat releaseAssets.json | grep '\"name\"' | tr '\\n' '#'", returnStdout: true)

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -24,7 +24,7 @@ import java.time.temporal.ChronoUnit
 def getLatestOpenjdkBuildTag(String version) {
     def openjdkRepo = "https://github.com/openjdk/${version}.git"
 
-    def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v \"\\^{}\" | tr -s \"\\t \" \" \" | cut -d\" \" -f2 | sed \"s,refs/tags/,,\" | sort -V -r | head -1")
+    def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v \"\\^{}\" | tr -s \"\\t \" \" \" | cut -d\" \" -f2 | sed \"s,refs/tags/,,\" | sort -V -r | head -1 | tr -d\"\\n\"")
     echo "latest ${version} tag = ${latestTag}A"
 
     return latestTag

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -436,6 +436,7 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
         if (variant == 'temurin' || variant == 'hotspot') { //variant == "hotspot" should be enough for now. Keep temurin for later.
             echo '-------------- Nightly pipeline health report ------------------'
             featureReleases.each { featureRelease ->
+echo featureRelease
                 def featureReleaseInt = featureRelease.replaceAll("u", "").replaceAll("jdk", "").toInteger()
                 def status = healthStatus[featureReleaseInt]
                 if (featureReleaseInt < 21) {


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/787
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/798

Update the daily Slack build pipeline health status:
- Handle build tag triggered builds that do not have a max stale days.
- For build tag triggered builds, confirm the latest published binary is the latest upstream openjdk build tag.
- For all versions, verify the latest published (according to API) binaries have all the required artifacts.
- Simplify the build&test success rating to simply find the last pipeline build from the trss API
- Parameterise the featureReleases and optional "tipRelease" versions

Added job Parameters:
FEATURE_RELEASES: List of jdkNNu releases to get status of
TIP_RELEASE: Optional jdk(head) release version (eg.jdk22)
BINARIES_REPO: github.com binaries repo template (eg.adoptium/temurin_NN_-binaries)
BUILD_CONFIG_URL: URL of raw ci-jenkins-piplines pipeline configuration for obtaining required Arch's for version

Test Slack status example: https://adoptium.slack.com/archives/C598A7EMQ/p1693580500301949

Missing Windows SBOM artifacts discovered with this work, raised as issue: https://github.com/adoptium/temurin-build/issues/3464
