### PR TITLE
Reformat tags for hotspot builds to ensure they match upstream tags

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -146,6 +146,12 @@ class Builder implements Serializable {
             cleanWsAfter = platformCleanWorkspaceAfterBuild
         }
 
+        // We need to ensure that _adopt is stripped from any tags used in hotspot variant builds, as *_adopt tags do not exist upstream.
+        def adjustedScmReference = scmReference
+        if (variant.equals("hotspot")) {
+            adjustedScmReference = scmReference - ('_adopt')
+        }
+
         return new IndividualBuildConfig(
             JAVA_TO_BUILD: javaToBuild,
             ARCHITECTURE: platformConfig.arch as String,
@@ -154,7 +160,7 @@ class Builder implements Serializable {
             TEST_LIST: testList,
             DYNAMIC_LIST: dynamicList,
             NUM_MACHINES: numMachines,
-            SCM_REF: scmReference,
+            SCM_REF: adjustedScmReference,
             BUILD_REF: buildReference,
             CI_REF: ciReference,
             HELPER_REF: helperReference,

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -206,6 +206,10 @@ class Build {
             } else {
                 jdkBranch = buildConfig.SCM_REF
             }
+            // We also need to ensure that _adopt is stripped from any tags used in hotspot builds, as *_adopt tags do not exist upstream.
+            if (buildConfig.VARIANT == 'temurin') {
+                jdkBranch = buildConfig.SCM_REF.replaceAll("_adopt", "")
+            }
         } else {
             if (buildConfig.VARIANT == 'corretto') {
                 jdkBranch = 'develop'

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -206,10 +206,6 @@ class Build {
             } else {
                 jdkBranch = buildConfig.SCM_REF
             }
-            // We also need to ensure that _adopt is stripped from any tags used in hotspot builds, as *_adopt tags do not exist upstream.
-            if (buildConfig.VARIANT == 'hotspot') {
-                jdkBranch = buildConfig.SCM_REF.replaceAll("_adopt", "")
-            }
         } else {
             if (buildConfig.VARIANT == 'corretto') {
                 jdkBranch = 'develop'

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -207,7 +207,7 @@ class Build {
                 jdkBranch = buildConfig.SCM_REF
             }
             // We also need to ensure that _adopt is stripped from any tags used in hotspot builds, as *_adopt tags do not exist upstream.
-            if (buildConfig.VARIANT == 'temurin') {
+            if (buildConfig.VARIANT == 'hotspot') {
                 jdkBranch = buildConfig.SCM_REF.replaceAll("_adopt", "")
             }
         } else {


### PR DESCRIPTION
*_adopt tags don't match anything upstream, so I'm removing the "_adopt" bit when we're running a hotspot build.

Testing here: https://ci.adoptium.net/job/build-scripts/job/openjdk21-pipeline/177/