### PR TITLE
Ensure reproduce_comparison Compare stage cleans WS of sbom and other prepare stage artifacts

### DIFF
--- a/tools/reproduce_comparison/Jenkinsfile
+++ b/tools/reproduce_comparison/Jenkinsfile
@@ -108,6 +108,7 @@ pipeline {
         stage('Compare') {
             agent { label NODE_LABEL }
             steps {
+                cleanWs() // Ensure Prepare stage contents cleaned
                 copyArtifacts filter: '**/OpenJDK*-jdk*.tar.gz,**/OpenJDK*-jdk*.zip',
                     fingerprintArtifacts: true, 
                     projectName: env.JOB_NAME,


### PR DESCRIPTION
Occasionally the reproduce_comparison fails the Compare stating:
```
Only in /home/jenkins/workspace/jdk21-linux-x64-temurin_reproduce_compare/original: OpenJDK21U-sbom_x64_linux_hotspot_2023-09-04-14-43.json
```
This is because the Prepare stage where it extracted the sbom, was not cleaned.

Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/805
