### PR TITLE
Update reproduce_comparison to return UNSTABLE for differences found

### DIFF
--- a/tools/reproduce_comparison/Jenkinsfile
+++ b/tools/reproduce_comparison/Jenkinsfile
@@ -161,7 +161,7 @@ pipeline {
                             }
                             if (rc != 0) {
                                 currentBuild.result = 'UNSTABLE'
-                                echo 'Failed: two builds are not the same! Please see the archived repro_diff.out.'
+                                echo 'Differences found: two builds are not the same! Please see the archived repro_diff.out.'
                             } else {
                                 echo 'Success: two builds are the same!'
                             }

--- a/tools/reproduce_comparison/Jenkinsfile
+++ b/tools/reproduce_comparison/Jenkinsfile
@@ -121,13 +121,13 @@ pipeline {
                         def reproducedJDKFile = findFiles(glob: "reproduced/*.zip")
                         def untarOriginalJDK = sh returnStatus: true, script: "cd original && temp=`mktemp -d` && unzip -d ${temp} ${originalJDKFile[0].name} && mv ${temp}/*/* ./ && rmdir ${temp}/* ${temp}"
                         if (untarOriginalJDK != 0 ) {
-                            currentBuild.result = 'UNSTABLE'
+                            currentBuild.result = 'FAILURE'
                             error " Unzip ${originalJDKFile[0].name} failed"
                             return
                         }
                         def untarReproducedJDK = sh returnStatus: true, script: "cd reproduced && temp=`mktemp -d` && unzip -d ${temp} ${reproducedJDKFile[0].name} && mv ${temp}/*/* ./ && rmdir ${temp}/* ${temp}"
                         if (untarReproducedJDK != 0 ) {
-                            currentBuild.result = 'UNSTABLE'
+                            currentBuild.result = 'FAILURE'
                             error " Unzip ${originalJDKFile[0].name} failed"
                             return
                         }
@@ -137,13 +137,13 @@ pipeline {
                         def reproducedJDKFile = findFiles(glob: "reproduced/*.tar.gz")
                         def untarOriginalJDK = sh returnStatus: true, script: "tar xzf ${originalJDKFile[0].path} --strip-components=1 -C original"
                         if (untarOriginalJDK != 0 ) {
-                            currentBuild.result = 'UNSTABLE'
+                            currentBuild.result = 'FAILURE'
                             error " Untar ${originalJDKFile[0].name} failed"
                             return
                         }
                         def untarReproducedJDK = sh returnStatus: true, script: "tar xzf ${reproducedJDKFile[0].path} --strip-components=1 -C reproduced"
                         if (untarReproducedJDK != 0 ) {
-                            currentBuild.result = 'UNSTABLE'
+                            currentBuild.result = 'FAILURE'
                             error " Untar ${reproducedJDKFile[0].name} failed"
                             return
                         }
@@ -160,7 +160,7 @@ pipeline {
                                 rc = sh returnStatus: true, script: "./repro_compare.sh temurin `pwd`/../../original temurin `pwd`/../../reproduced CYGWIN"
                             }
                             if (rc != 0) {
-                                currentBuild.result = 'FAILURE'
+                                currentBuild.result = 'UNSTABLE'
                                 echo 'Failed: two builds are not the same! Please see the archived repro_diff.out.'
                             } else {
                                 echo 'Success: two builds are the same!'


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/791

Updated results to UNSTABLE if repro_compare returns a difference.
Also changed failures to un-tar to be FAILUREs.

Test compare: https://ci.adoptium.net/view/ReproducibleBuild/job/jdk21-mac-aarch64-temurin_reproduce_compare/7/
