### PR TITLE
Move reproduce_compare job to the end of the build job

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1951,10 +1951,6 @@ class Build {
                     }
                 }
 
-                // Compare reproducible build if needed
-                if (enableReproducibleCompare) {
-                    compareReproducibleBuild(nonDockerNodeName)
-                }
                 // Run Smoke Tests and AQA Tests
                 if (enableTests) {
                     try {
@@ -2005,6 +2001,11 @@ class Build {
                     } catch (Exception e) {
                         context.println(e.message)
                     }
+                }
+
+                // Compare reproducible build if needed
+                if (enableReproducibleCompare) {
+                    compareReproducibleBuild(nonDockerNodeName)
                 }
 
             // Generic catch all. Will usually be the last message in the log.


### PR DESCRIPTION
Ensure the build jdk artifacts available for upstream pipeline to copy

 Fix #808 

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>