### PR TITLE
Provide Windows SDK UCRT DLL paths for jdk17+ pipeline configuration

### DIFF
--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -74,7 +74,7 @@ class Config17 {
                 reproducibleCompare : [
                         'temurin'   : true
                 ],
-                configureArgs       : '--with-ucrt-dll-dir="C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64"',
+                configureArgs       : "--with-ucrt-dll-dir='C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64'",
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
@@ -85,7 +85,7 @@ class Config17 {
                 arch                : 'x86-32',
                 additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
-                configureArgs       : '--with-ucrt-dll-dir="C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64"',
+                configureArgs       : "--with-ucrt-dll-dir='C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64'",
                 buildArgs           : [
                         'temurin'   : '--jvm-variant client,server --create-jre-image --create-sbom'
                 ]
@@ -188,7 +188,7 @@ class Config17 {
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
-                configureArgs       : '--with-ucrt-dll-dir="C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64"',
+                configureArgs       : "--with-ucrt-dll-dir='C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64'",
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile'
                 ]

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -74,6 +74,7 @@ class Config17 {
                 reproducibleCompare : [
                         'temurin'   : true
                 ],
+                configureArgs       : '--with-ucrt-dll-dir="C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64"',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
@@ -84,6 +85,7 @@ class Config17 {
                 arch                : 'x86-32',
                 additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
+                configureArgs       : '--with-ucrt-dll-dir="C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64"',
                 buildArgs           : [
                         'temurin'   : '--jvm-variant client,server --create-jre-image --create-sbom'
                 ]
@@ -186,6 +188,7 @@ class Config17 {
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
+                configureArgs       : '--with-ucrt-dll-dir="C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64"',
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile'
                 ]

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -85,7 +85,7 @@ class Config17 {
                 arch                : 'x86-32',
                 additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
-                configureArgs       : "--with-ucrt-dll-dir='C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64'",
+                configureArgs       : "--with-ucrt-dll-dir='C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x86'",
                 buildArgs           : [
                         'temurin'   : '--jvm-variant client,server --create-jre-image --create-sbom'
                 ]
@@ -188,7 +188,6 @@ class Config17 {
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
-                configureArgs       : "--with-ucrt-dll-dir='C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64'",
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile'
                 ]

--- a/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
@@ -179,7 +179,6 @@ class Config21 {
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
-                configureArgs       : "--with-ucrt-dll-dir='C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64'",
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile'
                 ]

--- a/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
@@ -71,6 +71,7 @@ class Config21 {
                 reproducibleCompare : [
                         'temurin'   : true
                 ],
+                configureArgs       : '--with-ucrt-dll-dir="C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64"',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
@@ -178,6 +179,7 @@ class Config21 {
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
+                configureArgs       : '--with-ucrt-dll-dir="C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64"',
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile'
                 ]

--- a/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21_pipeline_config.groovy
@@ -71,7 +71,7 @@ class Config21 {
                 reproducibleCompare : [
                         'temurin'   : true
                 ],
-                configureArgs       : '--with-ucrt-dll-dir="C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64"',
+                configureArgs       : "--with-ucrt-dll-dir='C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64'",
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
@@ -179,7 +179,7 @@ class Config21 {
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
-                configureArgs       : '--with-ucrt-dll-dir="C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64"',
+                configureArgs       : "--with-ucrt-dll-dir='C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64'",
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile'
                 ]

--- a/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
@@ -62,6 +62,7 @@ class Config22 {
                 arch                : 'x64',
                 additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
+                configureArgs       : '--with-ucrt-dll-dir="C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64"',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
@@ -157,6 +158,7 @@ class Config22 {
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
+                configureArgs       : '--with-ucrt-dll-dir="C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64"',
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile'
                 ]

--- a/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
@@ -158,7 +158,6 @@ class Config22 {
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
-                configureArgs       : "--with-ucrt-dll-dir='C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64'",
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile'
                 ]

--- a/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
@@ -62,7 +62,7 @@ class Config22 {
                 arch                : 'x64',
                 additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
-                configureArgs       : '--with-ucrt-dll-dir="C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64"',
+                configureArgs       : "--with-ucrt-dll-dir='C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64'",
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
@@ -158,7 +158,7 @@ class Config22 {
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
-                configureArgs       : '--with-ucrt-dll-dir="C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64"',
+                configureArgs       : "--with-ucrt-dll-dir='C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64'",
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile'
                 ]


### PR DESCRIPTION
To ensure a managed and thus deterministic Windows SDK DLLs for jdk-17+ JDKs, specify --with-ucrt-dll-dir=<PATH to desired SDK version>.

The standard Windows SDK version 10.0.22000.0 UCRT DLLs used with VS2019 are located in:
```
'C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64'
```
Fixes https://github.com/adoptium/temurin-build/issues/3479
