### PR TITLE
revert mac signing fix in pipeline

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -301,7 +301,7 @@ class Build {
 
         // Use BUILD_REF override if specified
         vendorTestBranches = buildConfig.BUILD_REF ?: vendorTestBranches
-
+        
         try {
             context.println 'Running smoke test'
             context.stage('smoke test') {
@@ -332,10 +332,10 @@ class Build {
                             context.string(name: 'VENDOR_TEST_REPOS', value: vendorTestRepos),
                             context.string(name: 'VENDOR_TEST_BRANCHES', value: vendorTestBranches),
                             context.string(name: 'TIME_LIMIT', value: '1')
-                    ]
+                    ]  
                 currentBuild.result = testJob.getResult()
                 return testJob.getResult()
-
+                     
             }
         } catch (Exception e) {
             context.println "Failed to execute test: ${e.message}"
@@ -351,7 +351,7 @@ class Build {
         def jdkBranch = getJDKBranch()
         def jdkRepo = getJDKRepo()
         def openj9Branch = (buildConfig.SCM_REF && buildConfig.VARIANT == 'openj9') ? buildConfig.SCM_REF : 'master'
-
+ 
         List testList = buildConfig.TEST_LIST
         List dynamicList = buildConfig.DYNAMIC_LIST
         List numMachines = buildConfig.NUM_MACHINES
@@ -463,7 +463,7 @@ class Build {
                                         wait: true
                         currentBuild.result = testJob.getResult()
                         context.node('worker') {
-                            //Copy Taps files from downstream test jobs if files available.
+                            //Copy Taps files from downstream test jobs if files available. 
                             context.sh 'rm -f workspace/target/AQAvitTaps/*.tap'
                             try {
                                 context.timeout(time: 2, unit: 'HOURS') {
@@ -543,7 +543,7 @@ class Build {
             }
         }
 
-        targets.each { targetMode, targetTests ->
+        targets.each { targetMode, targetTests -> 
             try {
                 context.println "Remote trigger: ${targetTests}"
                 remoteTargets["${targetTests}"] = {
@@ -1524,7 +1524,6 @@ class Build {
                                                 echo "Signing JMOD files"
                                                 TMP_DIR="${macos_base_path}/"
                                                 ENTITLEMENTS="$WORKSPACE/entitlements.plist"
-                                                MACSIGNSTRING="Apple Certification Authority"
                                                 FILES=$(find "${TMP_DIR}" -perm +111 -type f -o -name '*.dylib'  -type f || find "${TMP_DIR}" -perm /111 -type f -o -name '*.dylib'  -type f)
                                                 for f in $FILES
                                                 do
@@ -1532,44 +1531,9 @@ class Build {
                                                     dir=$(dirname "$f")
                                                     file=$(basename "$f")
                                                     mv "$f" "${dir}/unsigned_${file}"
-                                                    curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
-                                                    echo File = "$f"
-                                                    TESTMACSIGN=$(grep -ic "$MACSIGNSTRING" "$f")
-                                                    echo Sign Result = "$TESTMACSIGN"
-                                                    if [ "$TESTMACSIGN" -gt 0 ]
-                                                    then
-                                                      echo "Code Signed For File $f"
-                                                      chmod --reference="${dir}/unsigned_${file}" "$f"
-                                                      rm -rf "${dir}/unsigned_${file}"
-                                                    else
-                                                      max_iterations=20
-                                                      iteration=1
-                                                      success=false
-                                                      echo "Code Not Signed For File $f"
-                                                      while [ $iteration -le $max_iterations ] && [ $success = false ]; do
-                                                        echo $iteration Of $max_iterations
-                                                        sleep 1
-                                                          curl --fail -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
-                                                          TESTMACSIGN2=$(grep -ic "$MACSIGNSTRING" "$f")
-                                                          echo TESTMACSIGN2 = "$TESTMACSIGN2"
-                                                          if [ "$TESTMACSIGN2" -gt 0 ]
-                                                          then
-                                                            echo "$f Signed OK On Attempt $iteration"
-                                                            chmod --reference="${dir}/unsigned_${file}" "$f"
-                                                            rm -rf "${dir}/unsigned_${file}"
-                                                            success=true
-                                                          else
-                                                            echo "$f Failed Signing On Attempt $iteration"
-                                                            success=false
-                                                            iteration=$((iteration+1))
-                                                            if [ $iteration -gt $max_iterations ]
-                                                            then
-                                                              echo "Errors Encountered During Signing"
-                                                              exit 1
-                                                            fi
-                                                          fi
-                                                      done
-                                                    fi
+                                                    curl -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
+                                                    chmod --reference="${dir}/unsigned_${file}" "$f"
+                                                    rm -rf "${dir}/unsigned_${file}"
                                                 done
                                             '''
                                             // groovylint-enable
@@ -1746,7 +1710,7 @@ class Build {
         }
     }
 
-    /*
+    /* 
         this function should only be used in pr-tester
     */
     def updateGithubCommitStatus(STATE, MESSAGE) {
@@ -1798,7 +1762,7 @@ class Build {
                 context.println "Executing tests: ${buildConfig.TEST_LIST}"
                 context.println "Build num: ${env.BUILD_NUMBER}"
                 context.println "File name: ${filename}"
-
+                
                 def enableReproducibleCompare = Boolean.valueOf(buildConfig.ENABLE_REPRODUCIBLE_COMPARE)
                 def enableTests = Boolean.valueOf(buildConfig.ENABLE_TESTS)
                 def enableInstallers = Boolean.valueOf(buildConfig.ENABLE_INSTALLERS)
@@ -1999,7 +1963,7 @@ class Build {
                                     platform = 'x86-64_' + buildConfig.TARGET_OS
                                 } else {
                                     platform = buildConfig.ARCHITECTURE + '_' + buildConfig.TARGET_OS
-                                }
+                                }           
                                 if ( !(platform  == 'riscv64_linux' || platform =='aarch64_windows') ) {
                                     if ( !(buildConfig.JAVA_TO_BUILD == 'jdk8u' && platform == 's390x_linux') ) {
                                         context.echo "Remote trigger Eclipse Temurin AQA_Test_Pipeline job with ${platform} ${buildConfig.JAVA_TO_BUILD}"


### PR DESCRIPTION
revert mac signing fix in pipeline

Aligning the code in the pipeline does not exhibit the same behaviour as the sign.sh script in the later build process, an alternate solution will need to be investigated.