### PR TITLE
Daily build health stats exclude -ga from upstream tag search

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -24,7 +24,7 @@ import java.time.temporal.ChronoUnit
 def getLatestOpenjdkBuildTag(String version) {
     def openjdkRepo = "https://github.com/openjdk/${version}.git"
 
-    def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | sort -V -r | head -1 | tr -d '\\n'")
+    def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | grep -v '\-ga' | sort -V -r | head -1 | tr -d '\\n'")
     echo "latest upstream openjdk/${version} tag = ${latestTag}"
 
     return latestTag

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -24,7 +24,7 @@ import java.time.temporal.ChronoUnit
 def getLatestOpenjdkBuildTag(String version) {
     def openjdkRepo = "https://github.com/openjdk/${version}.git"
 
-    def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | grep -v '\-ga' | sort -V -r | head -1 | tr -d '\\n'")
+    def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | grep -v '\\-ga' | sort -V -r | head -1 | tr -d '\\n'")
     echo "latest upstream openjdk/${version} tag = ${latestTag}"
 
     return latestTag


### PR DESCRIPTION
Fix incorrect latest upstream openjdk tag check due to "-ga" tag:
```
Latest Adoptium publish binaries jdk-21+35-ea-beta !=  latest upstream openjdk build jdk-21-ga-ea-beta.
```
