### PR TITLE
Sign JMOD Windows exe/dll's using exploded/assemble method

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1500,7 +1500,6 @@ class Build {
                                         includes: "${base_path}/hotspot/variant-server/**/*," +
                                             "${base_path}/support/modules_cmds/**/*," +
                                             "${base_path}/support/modules_libs/**/*," +
-                                            // JDK 16 + jpackage needs to be signed as well
                                             "${base_path}/jdk/modules/jdk.jpackage/jdk/jpackage/internal/resources/jpackageapplauncher"
 
                                     context.node('eclipse-codesign') {
@@ -1529,26 +1528,47 @@ class Build {
                                                     echo "Signing $f using Eclipse Foundation codesign service"
                                                     dir=$(dirname "$f")
                                                     file=$(basename "$f")
-                                                    #mv "$f" "${dir}/unsigned_${file}"
-                                                    #if [ "${target_os}" == "mac" ]; then
-                                                    #    curl -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
-                                                    #else
-                                                    #    curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign
-                                                    #fi
-                                                    #chmod --reference="${dir}/unsigned_${file}" "$f"
-                                                    #rm -rf "${dir}/unsigned_${file}"
+                                                    mv "$f" "${dir}/unsigned_${file}"
+                                                    if [ "${target_os}" == "mac" ]; then
+                                                        curl -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
+                                                    else
+                                                        curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign
+                                                    fi
+                                                    chmod --reference="${dir}/unsigned_${file}" "$f"
+                                                    # Verify it was Signed..
+                                                    echo "Verify Signature for $f"
+                                                    if [ "${target_os}" == "mac" ]; then
+                                                        if ! codesign -v --verify $f; then
+                                                            echo "Warning: $f failed to be signed, attempting one more time..."
+                                                            rm -rf "$f"
+                                                            curl -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
+                                                            chmod --reference="${dir}/unsigned_${file}" "$f"
+                                                        fi
+                                                    else
+                                                        signToolPath=${signToolPath:-"/cygdrive/c/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x64/signtool.exe"}
+                                                        if ! $signToolPath verify /v $f; then
+                                                            echo "Warning: $f failed to be signed, attempting one more time..."
+                                                            rm -rf "$f"
+                                                            curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign
+                                                            chmod --reference="${dir}/unsigned_${file}" "$f"
+                                                        fi
+                                                    fi
+                                                    rm -rf "${dir}/unsigned_${file}"
                                                 done
+                                                # Finally verify all were signed
                                                 for f in $FILES
                                                 do
                                                     echo "Verify Signature for $f"
                                                     if [ "${target_os}" == "mac" ]; then
                                                         if ! codesign -v --verify $f; then
                                                             echo "ERROR: $f has not been signed"
+                                                            exit 1
                                                         fi
                                                     else
                                                         signToolPath=${signToolPath:-"/cygdrive/c/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x64/signtool.exe"}
                                                         if ! $signToolPath verify /v $f; then                                    
                                                             echo "ERROR: $f has not been signed"
+                                                            exit 1
                                                         fi
                                                     fi
                                                 done

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1483,7 +1483,7 @@ class Build {
                                 repoHandler.checkoutAdoptBuild(context)
                                 printGitRepoInfo()
                                 if ((buildConfig.TARGET_OS == 'mac' || buildConfig.TARGET_OS == 'windows') && buildConfig.JAVA_TO_BUILD != 'jdk8u') {
-                                    echo "Processing exploded build, sign JMODS, and assemble build, for platform ${buildConfig.TARGET_OS} version ${buildConfig.JAVA_TO_BUILD}"
+                                    context.println "Processing exploded build, sign JMODS, and assemble build, for platform ${buildConfig.TARGET_OS} version ${buildConfig.JAVA_TO_BUILD}"
                                     def signBuildArgs
                                     if (env.BUILD_ARGS != null && !env.BUILD_ARGS.isEmpty()) {
                                         signBuildArgs = env.BUILD_ARGS + ' --make-exploded-image'
@@ -1495,7 +1495,7 @@ class Build {
                                         context.sh(script: "./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
                                     }
                                     def base_path = '$(ls -d workspace/build/src/build/*)'
-                                    echo "base build path for jmod signing = ${base_path}"
+                                    context.println "base build path for jmod signing = ${base_path}"
                                     context.stash name: 'jmods',
                                         includes: "${base_path}/hotspot/variant-server/**/*," +
                                             "${base_path}/support/modules_cmds/**/*," +

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1494,7 +1494,7 @@ class Build {
                                         context.println 'Building an exploded image for signing'
                                         context.sh(script: "./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
                                     }
-                                    def base_path = '$(ls -d workspace/build/src/build/*)'
+                                    def base_path = $(ls -d workspace/build/src/build/*)
                                     context.println "base build path for jmod signing = ${base_path}"
                                     context.stash name: 'jmods',
                                         includes: "${base_path}/hotspot/variant-server/**/*," +

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1529,14 +1529,28 @@ class Build {
                                                     echo "Signing $f using Eclipse Foundation codesign service"
                                                     dir=$(dirname "$f")
                                                     file=$(basename "$f")
-                                                    mv "$f" "${dir}/unsigned_${file}"
+                                                    #mv "$f" "${dir}/unsigned_${file}"
+                                                    #if [ "${target_os}" == "mac" ]; then
+                                                    #    curl -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
+                                                    #else
+                                                    #    curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign
+                                                    #fi
+                                                    #chmod --reference="${dir}/unsigned_${file}" "$f"
+                                                    #rm -rf "${dir}/unsigned_${file}"
+                                                done
+                                                for f in $FILES
+                                                do
+                                                    echo "Verify Signature for $f"
                                                     if [ "${target_os}" == "mac" ]; then
-                                                        curl -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
+                                                        if ! codesign -v --verify $f; then
+                                                            echo "ERROR: $f has not been signed"
+                                                        fi
                                                     else
-                                                        curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign
+                                                        signToolPath=${signToolPath:-"/cygdrive/c/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x64/signtool.exe"}
+                                                        if ! $signToolPath verify /v $f; then                                    
+                                                            echo "ERROR: $f has not been signed"
+                                                        fi
                                                     fi
-                                                    chmod --reference="${dir}/unsigned_${file}" "$f"
-                                                    rm -rf "${dir}/unsigned_${file}"
                                                 done
                                             '''
                                             // groovylint-enable

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1513,15 +1513,15 @@ class Build {
                                         context.unstash 'jmods'
                                         def target_os = "${buildConfig.TARGET_OS}"
                                         context.println "OS = ${target_os}"
-                                        context.withEnv(['target_os='+target_os, 'base_path='+base_path]) {
+                                        context.withEnv(['base_os='+target_os, 'base_path='+base_path]) {
                                             // groovylint-disable
                                             context.sh '''
                                                 #!/bin/bash
                                                 set -eu
                                                 echo "base_path = ${base_path}"
-                                                echo "Signing JMOD files under build path ${base_path} for target_os ${target_os}"
+                                                echo "Signing JMOD files under build path ${base_path} for base_os ${base_os}"
                                                 TMP_DIR="${base_path}/"
-                                                if [ "${target_os}" == "mac" ]; then
+                                                if [ "${base_os}" == "mac" ]; then
                                                     ENTITLEMENTS="$WORKSPACE/entitlements.plist"
                                                     FILES=$(find "${TMP_DIR}" -perm +111 -type f -o -name '*.dylib' -type f || find "${TMP_DIR}" -perm /111 -type f -o -name '*.dylib'  -type f)
                                                 else
@@ -1533,7 +1533,7 @@ class Build {
                                                     dir=$(dirname "$f")
                                                     file=$(basename "$f")
                                                     mv "$f" "${dir}/unsigned_${file}"
-                                                    if [ "${target_os}" == "mac" ]; then
+                                                    if [ "${base_os}" == "mac" ]; then
                                                         curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
                                                     else
                                                         curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign
@@ -1541,7 +1541,7 @@ class Build {
                                                     chmod --reference="${dir}/unsigned_${file}" "$f"
                                                     # Verify it was Signed..
                                                     echo "Verify Signature for $f"
-                                                    if [ "${target_os}" == "mac" ]; then
+                                                    if [ "${base_os}" == "mac" ]; then
                                                         if ! codesign -v --verify $f; then
                                                             echo "Warning: $f failed to be signed, attempting one more time..."
                                                             rm -rf "$f"
@@ -1563,7 +1563,7 @@ class Build {
                                                 for f in $FILES
                                                 do
                                                     echo "Verify Signature for $f"
-                                                    if [ "${target_os}" == "mac" ]; then
+                                                    if [ "${base_os}" == "mac" ]; then
                                                         if ! codesign -v --verify $f; then
                                                             echo "ERROR: $f has not been signed"
                                                             exit 1

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1512,7 +1512,7 @@ class Build {
                                         // Copy pre assembled binary ready for JMODs to be codesigned
                                         context.unstash 'jmods'
                                         def target_os = "${buildConfig.TARGET_OS}"
-                                        echo "OS = ${target_os}"
+                                        context.println "OS = ${target_os}"
                                         context.withEnv(['target_os='+target_os, 'base_path='+base_path]) {
                                             // groovylint-disable
                                             context.sh '''

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1494,7 +1494,7 @@ class Build {
                                         context.println 'Building an exploded image for signing'
                                         context.sh(script: "./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
                                     }
-                                    def base_path = "$(ls -d workspace/build/src/build/*)"
+                                    def base_path = '$(ls -d workspace/build/src/build/*)'
                                     echo "base build path for jmod signing = ${base_path}"
                                     context.stash name: 'jmods',
                                         includes: "${base_path}/hotspot/variant-server/**/*," +

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1494,7 +1494,7 @@ class Build {
                                         context.println 'Building an exploded image for signing'
                                         context.sh(script: "./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
                                     }
-                                    def base_path = $(ls -d workspace/build/src/build/*)
+                                    def base_path = context.sh(script: "ls -d workspace/build/src/build/*", returnStdout:true)
                                     context.println "base build path for jmod signing = ${base_path}"
                                     context.stash name: 'jmods',
                                         includes: "${base_path}/hotspot/variant-server/**/*," +

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1511,11 +1511,14 @@ class Build {
 
                                         // Copy pre assembled binary ready for JMODs to be codesigned
                                         context.unstash 'jmods'
-                                        context.withEnv(['base_path=${base_path}','target_os=${buildConfig.TARGET_OS}']) {
+                                        def target_os = "${buildConfig.TARGET_OS}"
+                                        echo "OS = ${target_os}"
+                                        context.withEnv(['target_os='+target_os, 'base_path='+base_path]) {
                                             // groovylint-disable
                                             context.sh '''
                                                 #!/bin/bash
                                                 set -eu
+                                                echo "base_path = ${base_path}"
                                                 echo "Signing JMOD files under build path ${base_path} for target_os ${target_os}"
                                                 TMP_DIR="${base_path}/"
                                                 if [ "${target_os}" == "mac" ]; then


### PR DESCRIPTION
Add Windows to the exploded/assemble JDK build JMOD Signing method, currently only used for Mac.
Fixes: https://github.com/adoptium/ci-jenkins-pipelines/issues/814

Test build: https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-windows-x64-temurin/302/
sanity.openjdk test: https://ci.adoptium.net/view/Test_openjdk/job/Test_openjdk11_hs_sanity.openjdk_x86-64_windows/823/
sanity.system test: https://ci.adoptium.net/view/Test_system/job/Test_openjdk11_hs_sanity.system_x86-64_windows/810/
