### PR TITLE
Add JMOD signing retry and check curl rc

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1531,10 +1531,50 @@ class Build {
                                                     dir=$(dirname "$f")
                                                     file=$(basename "$f")
                                                     mv "$f" "${dir}/unsigned_${file}"
+                                                    success=false
                                                     if [ "${base_os}" == "mac" ]; then
-                                                        curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
+                                                        if ! curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign; then
+                                                            echo "curl command failed, sign of $f failed"
+                                                        else
+                                                            success=true
+                                                        fi
                                                     else
-                                                        curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign
+                                                        if ! curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign; then
+                                                            echo "curl command failed, sign of $f failed"
+                                                        else
+                                                            success=true
+                                                        fi
+                                                    fi
+                                                    if [ $success == false ]; then
+                                                        # Retry up to 20 times
+                                                        max_iterations=20
+                                                        iteration=1
+                                                        echo "Code Not Signed For File $f"
+                                                        while [ $iteration -le $max_iterations ] && [ $success = false ]; do
+                                                            echo $iteration Of $max_iterations
+                                                            sleep 1
+                                                            if [ "${base_os}" == "mac" ]; then
+                                                                if curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign; then
+                                                                    success=true
+                                                                fi
+                                                            else
+                                                                if curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign; then
+                                                                    success=true
+                                                                fi
+                                                            fi
+
+                                                            if [ $success = false ]; then
+                                                                echo "curl command failed, $f Failed Signing On Attempt $iteration"
+                                                                iteration=$((iteration+1))
+                                                                if [ $iteration -gt $max_iterations ]
+                                                                then
+                                                                    echo "Errors Encountered During Signing"
+                                                                    exit 1
+                                                                fi
+                                                            else
+                                                                echo "$f Signed OK On Attempt $iteration"
+                                                            fi
+                                                        done
                                                     fi
                                                     chmod --reference="${dir}/unsigned_${file}" "$f"
                                                     rm -rf "${dir}/unsigned_${file}"


### PR DESCRIPTION
Add retry to the JMOD Windows&Mac signing, as a workaround until EF upstream issue is resolved: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3758
This is likely to fail during the release builds with the current failure rate.
