### PR TITLE
Update x64 Mac build jobs to use macos11 label

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -4,7 +4,7 @@ class Config11 {
         x64Mac    : [
                 os                  : 'mac',
                 arch                : 'x64',
-                additionalNodeLabels : 'macos10.14',
+                additionalNodeLabels : 'macos11',
                 test                : 'default',
                 configureArgs       : [
                         'openj9'      : '--enable-dtrace=auto --with-cmake',

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -4,7 +4,7 @@ class Config17 {
         x64Mac    : [
                 os                  : 'mac',
                 arch                : 'x64',
-                additionalNodeLabels: 'macos10.14',
+                additionalNodeLabels: 'macos11',
                 additionalTestLabels: [
                         openj9      : '!sw.os.osx.10_11'
                 ],

--- a/pipelines/jobs/configurations/jdk20u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20u_pipeline_config.groovy
@@ -4,7 +4,7 @@ class Config20 {
         x64Mac    : [
                 os                  : 'mac',
                 arch                : 'x64',
-                additionalNodeLabels: 'macos10.14',
+                additionalNodeLabels: 'macos',
                 additionalTestLabels: [
                         openj9      : '!sw.os.osx.10_11'
                 ],

--- a/pipelines/jobs/configurations/jdk20u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20u_pipeline_config.groovy
@@ -4,7 +4,7 @@ class Config20 {
         x64Mac    : [
                 os                  : 'mac',
                 arch                : 'x64',
-                additionalNodeLabels: 'macos',
+                additionalNodeLabels: 'macos11',
                 additionalTestLabels: [
                         openj9      : '!sw.os.osx.10_11'
                 ],

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -4,7 +4,7 @@ class Config21 {
         x64Mac    : [
                 os                  : 'mac',
                 arch                : 'x64',
-                additionalNodeLabels: 'macos10.14',
+                additionalNodeLabels: 'macos11',
                 additionalTestLabels: [
                         openj9      : '!sw.os.osx.10_11'
                 ],

--- a/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
@@ -4,7 +4,7 @@ class Config22 {
         x64Mac    : [
                 os                  : 'mac',
                 arch                : 'x64',
-                additionalNodeLabels: 'macos10.14',
+                additionalNodeLabels: 'macos11',
                 additionalTestLabels: [
                         openj9      : '!sw.os.osx.10_11'
                 ],

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -5,7 +5,7 @@ class Config8 {
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels: [
-                        temurin : 'macos10.14',
+                        temurin : 'macos11',
                         corretto: 'build-macstadium-macos1010-1',
                         openj9  : 'macos10.14'
                 ],


### PR DESCRIPTION
In light of https://github.com/adoptium/infrastructure/issues/2536#issuecomment-1697270848 and https://github.com/adoptium/temurin-build/issues/3354, and now that https://github.com/adoptium/temurin-build/pull/3492 is in we can force the builds to run on Macos11 machines only. 

I am positive I have updated the correct files, but feel free to correct me if I have not.

There is one problem. This line, https://github.com/adoptium/ci-jenkins-pipelines/blob/5fcae13f466c8063ca572eaa8365c13548fede46/pipelines/build/common/config_regeneration.groovy#L465, will insist that the `NODE_LABEL` contains the architecture of the binary to build, in this case `x64`. So the final label will be `"NODE_LABEL": "macos11&&build&&mac&&x64"` which will prevent it from running on our arm mac build machines. 

An easy solution is to add `x64` labels to our build arm mac machines. A harder solution is to modify https://github.com/adoptium/ci-jenkins-pipelines/blob/5fcae13f466c8063ca572eaa8365c13548fede46/pipelines/build/common/config_regeneration.groovy#L465 to something more versatile which will not break the other build jobs, but at the moment I do not know this repo well enough for this to be a quick fix before the next release. 

@sxa @andrew-m-leonard thoughts?

>An easy solution is to add `x64` labels to our build arm mac machines.

I'm in favour of this 