### PR TITLE
Ensure all Mac & Windows jdk.jpackage jmod executables are correctly signed

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1500,8 +1500,8 @@ class Build {
                                         includes: "${base_path}/hotspot/variant-server/**/*," +
                                             "${base_path}/support/modules_cmds/**/*," +
                                             "${base_path}/support/modules_libs/**/*," +
-                                            // JDK 16 + jpackage needs to be signed as well
-                                            "${base_path}/jdk/modules/jdk.jpackage/jdk/jpackage/internal/resources/jpackageapplauncher"
+                                            // JDK 16 + jpackage needs to be signed as well stash the resources folder containing the executables
+                                            "${base_path}/jdk/modules/jdk.jpackage/jdk/jpackage/internal/resources/*"
 
                                     context.node('eclipse-codesign') {
                                         context.sh "rm -rf ${base_path}/* || true"
@@ -1589,9 +1589,9 @@ class Build {
                                     context.sh "rm -rf ${base_path}/hotspot/variant-server || true"
                                     context.sh "rm -rf ${base_path}/support/modules_cmds || true"
                                     context.sh "rm -rf ${base_path}/support/modules_libs || true"
-                                    // JDK 16 + jpackage needs to be signed as well
+                                    // JDK 16 + jpackage executables need to be signed as well
                                     if (buildConfig.JAVA_TO_BUILD != 'jdk11u') {
-                                        context.sh "rm -rf ${base_path}/jdk/modules/jdk.jpackage/jdk/jpackage/internal/resources/jpackageapplauncher || true"
+                                        context.sh "rm -rf ${base_path}/jdk/modules/jdk.jpackage/jdk/jpackage/internal/resources/* || true"
                                     }
 
                                     // Restore signed JMODs


### PR DESCRIPTION
Ensure all the jdk.package JMOD executable resources are Signed
I think the stashing created a 0 length jpackagelauncher file, which then got .exe added and resulting empty file.

This PR ensures the whole jdk.jpackage resources folder is stashed for passing to the EF signing service.