### PR TITLE
Build jdk21u HEAD weekly

### DIFF
--- a/pipelines/jobs/configurations/jdk21u.groovy
+++ b/pipelines/jobs/configurations/jdk21u.groovy
@@ -35,7 +35,7 @@ targetConfigurations = [
 // 23:30 Mon, Wed, Fri
 //Uses releaseTrigger_21ea: triggerSchedule_nightly = 'TZ=UTC\n30 23 * * 1,3,5'
 // 23:30 Sat
-//Replaced by releaseTrigger_21ea: triggerSchedule_weekly = 'TZ=UTC\n30 23 * * 6'
+triggerSchedule_weekly = 'TZ=UTC\n30 23 * * 6'
 
 // scmReferences to use for weekly release build
 weekly_release_scmReferences = [

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -205,7 +205,7 @@ node('worker') {
             // In particular, look at first data set for latest published binaries.
             // If no published assets happened the last 4 days, the nightly pipeline
             // is considered unhealthy.
-            // For tag triggered versions (jdk-21+) check the binary is published
+            // For tag triggered versions (jdk-22+) check the binary is published
             // The release asset list is also verified
             featureReleases.each { featureRelease ->
               def featureReleaseInt = featureRelease.replaceAll("u", "").replaceAll("jdk", "").toInteger()
@@ -217,7 +217,7 @@ node('worker') {
               while(!foundNonEvaluationBinaries && i < assetsJson.size()) {
                 def releaseName = assetsJson[i].release_name
                 def status = []
-                if (featureReleaseInt < 21) {
+                if (featureReleaseInt < 22) {
                   def ts = assetsJson[i].timestamp // newest timestamp of a jdk asset
                   def assetTs = Instant.parse(ts).atZone(ZoneId.of('UTC'))
                   def now = ZonedDateTime.now(ZoneId.of('UTC'))
@@ -489,8 +489,8 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                 def releaseName = status['releaseName']
                 def lastPublishedMsg = ""
 
-                // jdk-21+ are latest tag triggered builds
-                if (featureReleaseInt < 21) {
+                // jdk-22+ are latest tag triggered builds
+                if (featureReleaseInt < 22) {
                     // Check for stale published build
                     def days = status['actualDays'] as int
                     lastPublishedMsg = "\nPublished: ${days} day(s) ago." // might actually be days + N hours, where N < 24


### PR DESCRIPTION
Schedule jdk21u HEAD build at weekend, since no builds are being published upstream until January '24 CPU.
