### PR TITLE
Ensure release pipelines clean the build workspace before build

### DIFF
--- a/pipelines/jobs/release_pipeline_job_template.groovy
+++ b/pipelines/jobs/release_pipeline_job_template.groovy
@@ -86,7 +86,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
         booleanParam('enableSigner', runSigner, 'If set to true the signer pipeline will be executed')
         stringParam('additionalBuildArgs', '', 'Additional arguments to be passed to <code>makejdk-any-platform.sh</code>')
         stringParam('overrideFileNameVersion', '', "When forming the filename, ignore the part of the filename derived from the publishName or timestamp and override it.<br/>For instance if you set this to 'FOO' the final file name will be of the form: <code>OpenJDK8U-jre_ppc64le_linux_openj9_FOO.tar.gz</code>")
-        booleanParam('cleanWorkspaceBeforeBuild', false, 'Clean out the workspace before the build')
+        booleanParam('cleanWorkspaceBeforeBuild', true, 'Clean out the workspace before the build')
         booleanParam('cleanWorkspaceAfterBuild', false, 'Clean out the workspace after the build')
         booleanParam('cleanWorkspaceBuildOutputAfterBuild', cleanWsBuildOutput, 'Clean out the workspace/build/src/build and workspace/target output only, after the build')
         booleanParam('propagateFailures', propagateFailures, 'If true, a failure of <b>ANY</b> downstream build will cause the whole build to fail')


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/835

Currently the release pipeline calls the build jobs with CLEAN_WORKSPACE=false, we should always clean the workspace before a "release" build, to ensure its integrity.
