### PR TITLE
Add aarch64AlpineLinux to daily status tool asset mapping

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -82,6 +82,7 @@ def verifyReleaseContent(String version, String release, String variant, Map sta
                                ppc64leLinux:   "ppc64le_linux",
                                s390xLinux:     "s390x_linux",
                                aarch64Linux:   "aarch64_linux",
+                               aarch64AlpineLinux: "aarch64_alpine-linux",
                                aarch64Mac:     "aarch64_mac",
                                arm32Linux:     "arm_linux",
                                x32Windows:     "x86-32_windows",


### PR DESCRIPTION
aarch64 Alpine Linux asset to archive name mapping needs adding to daily status tool.
