### PR TITLE
Verify Windows and Mac Signing signatures in all executables and installers

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2088,12 +2088,14 @@ class Build {
                     }
                 }
 
-                // Verify Windows and Mac Signing for Temurin
-                if (buildConfig.VARIANT == 'temurin') {
-                    try {
-                        verifySigning()
-                    } catch (Exception e) {
-                        context.println(e.message)
+                if (!env.JOB_NAME.contains('pr-tester')) { // pr-tester does not sign the binaries
+                    // Verify Windows and Mac Signing for Temurin
+                    if (buildConfig.VARIANT == 'temurin') {
+                        try {
+                            verifySigning()
+                        } catch (Exception e) {
+                            context.println(e.message)
+                        }
                     }
                 }
 

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -925,7 +925,7 @@ class Build {
                 }
 
                 // Execute sign verification job
-                def signVerifyJob = context.build job: 'build-scripts/release/sign_verification',
+                context.build job: 'build-scripts/release/sign_verification',
                     propagate: true,
                     parameters: [
                             context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -908,31 +908,36 @@ class Build {
     // For Windows and Mac verify that all necessary executables are Signed and Notarized(mac)
     private void verifySigning() {
         if (buildConfig.TARGET_OS == "windows" || buildConfig.TARGET_OS == "mac") {
-            context.println "RUNNING sign_verification for ${buildConfig.TARGET_OS}/${buildConfig.ARCHITECTURE} ..."
+            try {
+                context.println "RUNNING sign_verification for ${buildConfig.TARGET_OS}/${buildConfig.ARCHITECTURE} ..."
 
-            // Determine suitable node to run on
-            def verifyNode
-            if (buildConfig.TARGET_OS == "windows") {
-                verifyNode = "ci.role.test&&sw.os.windows"
-            } else {
-                verifyNode = "ci.role.test&&(sw.os.osx||sw.os.mac)"
-            }
-            if (buildConfig.ARCHITECTURE == "aarch64") {
-                verifyNode = verifyNode + "&&hw.arch.aarch64"
-            } else {
-                verifyNode = verifyNode + "&&hw.arch.x86"
-            }
+                // Determine suitable node to run on
+                def verifyNode
+                if (buildConfig.TARGET_OS == "windows") {
+                    verifyNode = "ci.role.test&&sw.os.windows"
+                } else {
+                    verifyNode = "ci.role.test&&(sw.os.osx||sw.os.mac)"
+                }
+                if (buildConfig.ARCHITECTURE == "aarch64") {
+                    verifyNode = verifyNode + "&&hw.arch.aarch64"
+                } else {
+                    verifyNode = verifyNode + "&&hw.arch.x86"
+                }
 
-            // Execute sign verification job
-            def signVerifyJob = context.build job: 'build-scripts/release/sign_verification',
-                propagate: true,
-                parameters: [
-                        context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
-                        context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
-                        context.string(name: 'TARGET_OS', value: "${buildConfig.TARGET_OS}"),
-                        context.string(name: 'TARGET_ARCH', value: "${buildConfig.ARCHITECTURE}"),
-                        context.string(name: 'NODE_LABEL', value: "${verifyNode}")
-                ]
+                // Execute sign verification job
+                def signVerifyJob = context.build job: 'build-scripts/release/sign_verification',
+                    propagate: true,
+                    parameters: [
+                            context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
+                            context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
+                            context.string(name: 'TARGET_OS', value: "${buildConfig.TARGET_OS}"),
+                            context.string(name: 'TARGET_ARCH', value: "${buildConfig.ARCHITECTURE}"),
+                            context.string(name: 'NODE_LABEL', value: "${verifyNode}")
+                    ]
+            } catch (e) { 
+                context.println("Failed to sign_verification for ${buildConfig.TARGET_OS}/${buildConfig.ARCHITECTURE} ${e}")
+                currentBuild.result = 'FAILURE'
+            } 
         }
     }
 

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -48,7 +48,8 @@ String find_signtool() {
         println "ERROR: Unable to find signtool.exe in ${windowsKitPath}"
         exit 2
     } else {
-        def signtool = files[0].trim().replaceAll("\\(","\\\\(").replaceAll("\\)","\\\\)").replaceAll("\\ ","\\\\ ")
+        def signtool = files[0].trim().replaceAll("\\(","\\\\(").replaceAll("\\)","\\\\)")
+//.replaceAll("\\ ","\\\\ ")
         println "Found signtool: ${signtool}"
         return signtool 
     }

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -86,24 +86,28 @@ void unpackArchives(String unpack_dir, String[] archives) {
                 #!/bin/bash
                 set -eu
                 FILES=$(find "${dir}" -type f -name '*.jmod')
-                for f in $FILES
-                do
+                if [[ -n $FILES ]]; then
+                  for f in $FILES
+                  do
                     expand_dir=$(basename ${f})
                     expand_dir="${dir}/expanded_${expand_dir}"
                     mkdir "${expand_dir}"
                     echo "Expanding JMOD ${f}"
                     ${jdk_bin}/jmod extract --dir ${expand_dir} ${f}
-                done
+                  done
+                fi
 
                 FILES=$(find "${dir}" -type f -name 'modules')
-                for f in $FILES
-                do  
+                if [[ -n $FILES ]]; then
+                  for f in $FILES
+                  do  
                     expand_dir=$(basename ${f})
                     expand_dir="${dir}/expanded_${expand_dir}"
                     mkdir "${expand_dir}"
                     echo "Expanding compressed image file ${f}"
                     ${jdk_bin}/jimage extract --dir ${expand_dir} ${f}
-                done
+                  done
+                fi
             '''
         }
     }
@@ -124,8 +128,9 @@ void verifyExecutables(String unpack_dir) {
                 cc_signed=0
                 cc_unsigned=0
                 FILES=$(find "${unpack_dir}" -type f -not -name '*.*' -not -path '*/legal/*' -o -type f -name '*.dylib')
-                for f in $FILES
-                do
+                if [[ -n $FILES ]]; then
+                  for f in $FILES
+                  do
                     # Is file a Mac 64 bit executable or dylib ?
                     if file ${f} | grep "Mach-O 64-bit executable\\|Mach-O 64-bit dynamically linked shared library" >/dev/null; then
                         if ! codesign --verify --verbose ${f}; then
@@ -144,7 +149,8 @@ void verifyExecutables(String unpack_dir) {
                             fi
                         fi
                     fi
-                done
+                  done
+                fi
 
                 if [ "x${unsigned}" != "x" ]; then
                     echo "FAILURE: The following ${cc_unsigned} executables are not signed correctly:"
@@ -172,8 +178,9 @@ void verifyExecutables(String unpack_dir) {
                 cc_signed=0
                 cc_unsigned=0
                 FILES=$(find ${unpack_dir} -type f -name '*.exe' -o -name '*.dll')
-                for f in $FILES
-                do
+                if [[ -n $FILES ]]; then
+                  for f in $FILES
+                  do
                     if ! ${signtool} verify /pa /v ${f}; then
                         echo "Error: executable not Signed: ${f}"
                         unsigned="$unsigned $f"
@@ -182,7 +189,8 @@ void verifyExecutables(String unpack_dir) {
                         echo "Signed correctly: ${f}"
                         cc_signed=$((cc_signed+1))
                     fi
-                done
+                  done
+                fi
 
                 if [ "x${unsigned}" != "x" ]; then
                     echo "FAILURE: The following ${cc_unsigned} executables are not signed correctly:"
@@ -211,9 +219,10 @@ void verifyInstallers() {
             unsigned=""
             cc_signed=0
             cc_unsigned=0
-            FILES="$(find . -type f -name '*.pkg')"
-            for f in $FILES
-            do
+            FILES=$(find . -type f -name '*.pkg')
+            if [[ -n $FILES ]]; then
+              for f in $FILES
+              do
                 if ! pkgutil --check-signature ${f}; then
                     echo "Error: pkg not Signed: ${f}"
                     unsigned="$unsigned $f"
@@ -230,7 +239,8 @@ void verifyInstallers() {
                         cc_signed=$((cc_signed+1))
                     fi
                 fi
-            done 
+              done
+            fi
 
             if [ "x${unsigned}" != "x" ]; then
                 echo "FAILURE: The following ${cc_unsigned} installers are not signed and notarized correctly:"
@@ -256,8 +266,9 @@ void verifyInstallers() {
                 cc_signed=0
                 cc_unsigned=0
                 FILES=$(find . -type f -name '*.msi')
-                for f in $FILES
-                do
+                if [[ -n $FILES ]]; then
+                  for f in $FILES
+                  do
                     if ! ${signtool} verify /pa /v ${f}; then
                         echo "Error: installer not Signed: ${f}"
                         unsigned="$unsigned $f"
@@ -266,7 +277,8 @@ void verifyInstallers() {
                         echo "Signed correctly: ${f}"
                         cc_signed=$((cc_signed+1))
                     fi
-                done
+                  done
+                fi
 
                 if [ "x${unsigned}" != "x" ]; then
                     echo "FAILURE: The following ${cc_unsigned} installers are not signed correctly:"

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -219,7 +219,7 @@ void verifyInstallers() {
             unsigned=""
             cc_signed=0
             cc_unsigned=0
-            if [[ -n `find . -type f -name '*.pkg'` ]]; then
+ #           if [[ -n `find . -type f -name '*.pkg'` ]]; then
               FILES=$(find . -type f -name '*.pkg')
               for f in $FILES
               do
@@ -230,7 +230,7 @@ void verifyInstallers() {
                 else
                     echo "Signed correctly: ${f}"
 
-                    if ! spctl -a -vvv -t install ${f}"; then
+                    if ! spctl -a -vvv -t install ${f}; then
                         echo "Error: pkg not Notarized: ${f}"
                         unsigned="$unsigned $f"
                         cc_unsigned=$((cc_unsigned+1))
@@ -240,7 +240,7 @@ void verifyInstallers() {
                     fi
                 fi
               done
-            fi
+  #          fi
 
             if [ "x${unsigned}" != "x" ]; then
                 echo "FAILURE: The following ${cc_unsigned} installers are not signed and notarized correctly:"

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -40,7 +40,7 @@ String find_signtool() {
 
     def windowsKitPath = "/cygdrive/c/'Program Files (x86)'/'Windows Kits'"
 
-    def files = sh(script:"find ${windowsKitPath} -type f -path */${arch}/signtool.exe", \
+    def files = sh(script:"cd ${windowsKitPath} && find . -type f -path */${arch}/signtool.exe", \
                    returnStdout:true).split("\\r?\\n|\\r")
 
     // Return the first one we find
@@ -48,7 +48,8 @@ String find_signtool() {
         println "ERROR: Unable to find signtool.exe in ${windowsKitPath}"
         exit 2
     } else {
-        def signtool = files[0].trim().replaceAll("\\(","\\\\(").replaceAll("\\)","\\\\)")
+        def signtool = "${windowsKitPath}/files[0].trim()"
+//.replaceAll("\\(","\\\\(").replaceAll("\\)","\\\\)")
 //.replaceAll("\\ ","\\\\ ")
         println "Found signtool: ${signtool}"
         return signtool 

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -48,7 +48,7 @@ String find_signtool() {
         println "ERROR: Unable to find signtool.exe in ${windowsKitPath}"
         exit 2
     } else {
-        def signtool = "${windowsKitPath}/files[0].trim()"
+        def signtool = "${windowsKitPath}/"+files[0].trim()
 //.replaceAll("\\(","\\\\(").replaceAll("\\)","\\\\)")
 //.replaceAll("\\ ","\\\\ ")
         println "Found signtool: ${signtool}"

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -48,7 +48,7 @@ String find_signtool() {
         println "ERROR: Unable to find signtool.exe in ${windowsKitPath}"
         exit 2
     } else {
-        def signtool = files[0].trim().replaceAll("\\(","\\\\(").replaceAll(" ","\\ ")
+        def signtool = files[0].trim().replaceAll("\\(","\\\\(").replaceAll("\\)","\\\\)").replaceAll(" ","\\ ")
         println "Found signtool: ${signtool}"
         return signtool 
     }

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -38,7 +38,8 @@ String find_signtool() {
             exit 1
     }
 
-    def windowsKitPath = "/cygdrive/c/Program\\ Files\\ \\(x86\\)/Windows\\ Kits"
+//    def windowsKitPath = "/cygdrive/c/Program\\ Files\\ \\(x86\\)/Windows\\ Kits"
+    def windowsKitPath = "/cygdrive/c/progra~2/wi3cf2~1"
 
     def files = sh(script:"cd ${windowsKitPath} && find . -type f -path */${arch}/signtool.exe", \
                    returnStdout:true).split("\\r?\\n|\\r")
@@ -183,7 +184,7 @@ void verifyExecutables(String unpack_dir) {
                   FILES=$(find ${unpack_dir} -type f -name '*.exe' -o -name '*.dll')
                   for f in $FILES
                   do
-                    if ! "${signtool}" verify /pa /v ${f}; then
+                    if ! ${signtool} verify /pa /v ${f}; then
                         echo "Error: executable not Signed: ${f}"
                         unsigned="$unsigned $f"
                         cc_unsigned=$((cc_unsigned+1))
@@ -271,7 +272,7 @@ void verifyInstallers() {
                   FILES=$(find . -type f -name '*.msi')
                   for f in $FILES
                   do
-                    if ! "${signtool}" verify /pa /v ${f}; then
+                    if ! ${signtool} verify /pa /v ${f}; then
                         echo "Error: installer not Signed: ${f}"
                         unsigned="$unsigned $f"
                         cc_unsigned=$((cc_unsigned+1))

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -38,7 +38,7 @@ String find_signtool() {
             exit 1
     }
 
-    def windowsKitPath = "/cygdrive/c/'Program Files (x86)'/'Windows Kits'"
+    def windowsKitPath = "/cygdrive/c/Program Files\ \(x86\)/Windows\ Kits"
 
     def files = sh(script:"find ${windowsKitPath} -type f -path */${arch}/signtool.exe", \
                    returnStdout:true).split("\\r?\\n|\\r")

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -185,7 +185,7 @@ signtool = "'/cygdrive/c/Program Files (x86)/Windows Kits/./10/bin/10.0.15063.0/
                   FILES=$(find ${unpack_dir} -type f -name '*.exe' -o -name '*.dll')
                   for f in $FILES
                   do
-                    if ! ${signtool} verify /pa /v ${f}; then
+                    if ! "${signtool}" verify /pa /v ${f}; then
                         echo "Error: executable not Signed: ${f}"
                         unsigned="$unsigned $f"
                         cc_unsigned=$((cc_unsigned+1))

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -85,7 +85,6 @@ void unpackArchives(String unpack_dir, String[] archives) {
             sh '''
                 #!/bin/bash
                 set -eu
-                pwd
                 FILES=$(find "${dir}" -type f -name '*.jmod')
                 for f in $FILES
                 do
@@ -93,17 +92,17 @@ void unpackArchives(String unpack_dir, String[] archives) {
                     expand_dir="${dir}/expanded_${expand_dir}"
                     mkdir "${expand_dir}"
                     echo "Expanding JMOD ${f}"
-                    "${jdk_bin}/jmod extract --dir ${expand_dir} ${f}"
+                    ${jdk_bin}/jmod extract --dir ${expand_dir} ${f}
                 done
 
                 FILES=$(find "${dir}" -type f -name 'modules')
                 for f in $FILES
                 do  
                     expand_dir=$(basename ${f})
-                    expand_dir="${dir}/${expand_dir}"
+                    expand_dir="${dir}/expanded_${expand_dir}"
                     mkdir "${expand_dir}"
                     echo "Expanding compressed image file ${f}"
-                    "${jdk_bin}/jimage extract --dir ${expand_dir} ${f}"
+                    ${jdk_bin}/jimage extract --dir ${expand_dir} ${f}
                 done
             '''
         }

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -48,7 +48,9 @@ String find_signtool() {
         println "ERROR: Unable to find signtool.exe in ${windowsKitPath}"
         exit 2
     } else {
-        return files[0].trim()
+        def signtool = files[0].trim()
+        println "Found signtool: ${signtool}"
+        return signtool 
     }
 }
 

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -38,7 +38,7 @@ String find_signtool() {
             exit 1
     }
 
-    def windowsKitPath = "/cygdrive/c/'Program Files (x86)'/'Windows Kits'"
+    def windowsKitPath = "/cygdrive/c/Program\\ Files\\ \\(x86\\)/Windows\\ Kits"
 
     def files = sh(script:"cd ${windowsKitPath} && find . -type f -path */${arch}/signtool.exe", \
                    returnStdout:true).split("\\r?\\n|\\r")

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -186,7 +186,7 @@ if (params.TARGET_OS != "mac" && params.TARGET_OS != "windows") {
                                   returnStdout:true).split("\\r?\\n|\\r")
                     bins.each { bin ->
                         if (bin.trim() != "") {
-                            def rc = sh(script:"${signtool} verify /v ${bin}", returnStatus:true)
+                            def rc = sh(script:"${signtool} verify /pa /v ${bin}", returnStatus:true)
                             if (rc != 0) {
                                 println "Error: binary not signed: ${bin}"
                                 currentBuild.result = 'FAILURE'

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -38,7 +38,7 @@ String find_signtool() {
             exit 1
     }
 
-    def windowsKitPath = "/cygdrive/c/progra~2/wi3cf2~1"
+    def windowsKitPath = "/cygdrive/c/'Program Files (x86)'/'Windows Kits'"
 
     def files = sh(script:"find ${windowsKitPath} -type f -path */${arch}/signtool.exe", \
                    returnStdout:true).split("\\r?\\n|\\r")
@@ -49,6 +49,141 @@ String find_signtool() {
         exit 2
     } else {
         return files[0].trim()
+    }
+}
+
+// Unpack the archives so the signartures can be checked
+void unpackArchives(String unpack_dir, String[] archives) {
+    archives.each { archive ->
+        def dir = "${unpack_dir}/${archive}"
+        if (params.TARGET_OS == "mac") {
+            sh("mkdir -p ${dir} && tar -C ${dir} -xf *-${archive}*.tar.gz")
+        } else { // Windows
+            sh("mkdir -p ${dir} && unzip *-${archive}*.zip -d ${dir}")
+        }
+    }
+
+    // Copy JDK so it can be used for unpacking using jmod/jimage
+    sh("mkdir jdk_cp && cp -r ${unpack_dir}/jdk/*/* jdk_cp")
+
+    def jdk_bin = "jdk_cp/bin"
+    if (params.TARGET_OS == "mac") {
+        jdk_bin = "jdk_cp/Contents/Home/bin"
+    }
+
+    // Expand the JMODs and modules image to test binaries within
+    archives.each { archive ->
+        def dir = "${unpack_dir}/${archive}"
+        // Expand JMODs
+        println "Expanding JMODS under ${dir}"
+        def jmods = sh(script:"find ${dir} -type f -name '*.jmod'", \
+                       returnStdout:true).split("\\r?\\n|\\r")
+        jmods.each { jmod ->
+            if (jmod.trim() != "") {
+                def expand_dir = "expanded_" + sh(script:"basename ${jmod}", returnStdout:true)
+                expand_dir = "${dir}/${expand_dir}".trim()
+                sh("mkdir ${expand_dir}")
+                sh("${jdk_bin}/jmod extract --dir ${expand_dir} ${jmod}")
+            }
+        }
+
+        // Expand "modules" compress image containing jmods
+        println "Expanding 'modules' compressed image file under ${dir}"
+        def modules = sh(script:"find ${dir} -type f -name 'modules'", \
+                         returnStdout:true).split("\\r?\\n|\\r")
+        modules.each { module ->
+            if (module.trim() != "") {
+                def expand_dir = "expanded_" + sh(script:"basename ${module}", returnStdout:true)
+                expand_dir = "${dir}/${expand_dir}".trim()
+                sh("mkdir ${expand_dir}")
+                sh("${jdk_bin}/jimage extract --dir ${expand_dir} ${module}")
+            }
+        }
+    }
+}
+
+// Verify executables for Signatures
+void verifyExecutables(String unpack_dir) {
+    if (params.TARGET_OS == "mac") {
+        // On Mac find all dylib's and binaries marked as "executable",
+        // also add "jpackageapplauncher" specific case which is not marked as "executable"
+        // as it is within the jdk.jpackage resources used by jpackage util to generate user app launchers
+        def bins = sh(script:"find ${unpack_dir} -perm +111 -type f -not -name '.*' -o -name '*.dylib' -o -name 'jpackageapplauncher' || \
+                              find ${unpack_dir} -perm /111 -type f -not -name '.*' -o -name '*.dylib' -o -name 'jpackageapplauncher'",  \
+                      returnStdout:true).split("\\r?\\n|\\r")
+        bins.each { bin ->
+            if (bin.trim() != "") {
+                def rc = sh(script:"codesign --verify --verbose ${bin}", returnStatus:true)
+                if (rc != 0) {
+                    println "Error: executable not Signed: ${bin}"
+                    currentBuild.result = 'FAILURE'
+                } else {
+                    println "Signed correctly: ${bin}"
+                }
+            }
+        }
+    } else { // Windows
+        def signtool = find_signtool()
+
+        // Find all exe/dll's that must be Signed
+        def bins = sh(script:"find ${unpack_dir} -type f -name '*.exe' -o -name '*.dll'", \
+                      returnStdout:true).split("\\r?\\n|\\r")
+        bins.each { bin ->
+            if (bin.trim() != "") {
+                def rc = sh(script:"${signtool} verify /pa /v ${bin}", returnStatus:true)
+                if (rc != 0) {
+                    println "Error: executable not Signed: ${bin}"
+                    currentBuild.result = 'FAILURE'
+                } else {
+                    println "Signed correctly: ${bin}"
+                }
+            }
+        }
+    }
+}
+
+// Verify installers for Signatures and Notarization(mac only)
+void verifyInstallers() {
+    if (params.TARGET_OS == "mac") {
+        // Find all pkg's that need to be Signed and Notarized
+        def pkgs = sh(script:"find . -type f -name '*.pkg'", \
+                      returnStdout:true).split("\\r?\\n|\\r")
+        pkgs.each { pkg ->
+            if (pkg.trim() != "") {
+                def rc = sh(script:"pkgutil --check-signature ${pkg}", returnStatus:true)
+                if (rc != 0) {
+                    println "Error: pkg not Signed: ${pkg}"
+                    currentBuild.result = 'FAILURE'
+                } else {
+                    println "Signed correctly: ${pkg}"
+                }
+
+                rc = sh(script:"spctl -a -vvv -t install ${pkg}", returnStatus:true)
+                if (rc != 0) {
+                    println "Error: pkg not Notarized: ${pkg}"
+                    currentBuild.result = 'FAILURE'
+                } else {
+                    println "Notarized correctly: ${pkg}"
+                }
+            }
+        }
+    } else { // Windows
+        // Find all msi's that need to be Signed
+        def signtool = find_signtool()
+
+        def msis = sh(script:"find . -type f -name '*.msi'", \
+                      returnStdout:true).split("\\r?\\n|\\r")
+        msis.each { msi ->
+            if (msi.trim() != "") {
+                def rc = sh(script:"${signtool} verify /pa /v ${msi}", returnStatus:true)
+                if (rc != 0) {
+                    println "Error: installer not Signed: ${msi}"
+                    currentBuild.result = 'FAILURE'
+                } else {
+                    println "Signed correctly: ${msi}"
+                }
+            }
+        }
     }
 }
 
@@ -111,109 +246,13 @@ if (params.TARGET_OS != "mac" && params.TARGET_OS != "windows") {
                 // Unpack archives
                 def unpack_dir = "unpacked"
                 def archives = ["jdk", "jre"]
+                unpackArchives(unpack_dir, archives)
 
-                archives.each { archive ->
-                    def dir = "${unpack_dir}/${archive}"
-                    if (params.TARGET_OS == "mac") {
-                        sh("mkdir -p ${dir} && tar -C ${dir} -xf *-${archive}*.tar.gz")
-                    } else { // Windows
-                        sh("mkdir -p ${dir} && unzip *-${archive}*.zip -d ${dir}")
-                    }
-                }
+                // Verify all executables for Signatures
+                verifyExecutables(unpack_dir)
 
-                // Copy JDK so it can be used for unpacking using jmod/jimage
-                sh("mkdir jdk_cp && cp -r ${unpack_dir}/jdk/*/* jdk_cp")
-
-                def jdk_bin = "jdk_cp/bin"
-                if (params.TARGET_OS == "mac") {
-                    jdk_bin = "jdk_cp/Contents/Home/bin"
-                }
-
-                // Expand the JMODs and modules image to test binaries within
-                archives.each { archive ->
-                    def dir = "${unpack_dir}/${archive}"
-                    // Expand JMODs
-                    println "Expanding JMODS under ${dir}"
-                    def jmods = sh(script:"find ${dir} -type f -name '*.jmod'", \
-                                   returnStdout:true).split("\\r?\\n|\\r")
-                    jmods.each { jmod ->
-                        if (jmod.trim() != "") {
-                            def expand_dir = "expanded_" + sh(script:"basename ${jmod}", returnStdout:true)
-                            expand_dir = "${dir}/${expand_dir}".trim()
-                            sh("mkdir ${expand_dir}")
-                            sh("${jdk_bin}/jmod extract --dir ${expand_dir} ${jmod}")
-                        }
-                    }
-
-                    // Expand "modules" compress image containing jmods
-                    println "Expanding 'modules' compressed image file under ${dir}"
-                    def modules = sh(script:"find ${dir} -type f -name 'modules'", \
-                                     returnStdout:true).split("\\r?\\n|\\r")
-                    modules.each { module ->
-                        if (module.trim() != "") {
-                            def expand_dir = "expanded_" + sh(script:"basename ${module}", returnStdout:true)
-                            expand_dir = "${dir}/${expand_dir}".trim()
-                            sh("mkdir ${expand_dir}")
-                            sh("${jdk_bin}/jimage extract --dir ${expand_dir} ${module}")
-                        }
-                    }
-                }
-
-                // Verify all executables and installers for Signatures
-                if (params.TARGET_OS == "mac") {
-                    // On Mac find all dylib's and binaries marked as "executable" and .pkg's,
-                    // also add "jpackageapplauncher" specific case which is not marked as "executable"
-                    // as it is within the jdk.jpackage resources used by jpackage util to generate user app launchers
-                    def bins = sh(script:"find . -perm +111 -type f -not -name '.*' -o -name '*.dylib' -o -name 'jpackageapplauncher' -o -name '*.pkg' || \
-                                          find . -perm /111 -type f -not -name '.*' -o -name '*.dylib' -o -name 'jpackageapplauncher' -o -name '*.pkg'",  \
-                                  returnStdout:true).split("\\r?\\n|\\r")
-                    bins.each { bin ->
-                        if (bin.trim() != "") {
-                            def rc = sh(script:"codesign --verify --verbose ${bin}", returnStatus:true)
-                            if (rc != 0) {
-                                println "Error: dylib not signed: ${bin}"
-                                currentBuild.result = 'FAILURE'
-                            } else {
-                                println "Signed correctly: ${bin}"
-                            }
-                        }
-                    }
-                } else { // Windows
-                    def signtool = find_signtool()
-
-                    // Find all exe/dll's and msi's that must be Signed
-                    def bins = sh(script:"find ${unpack_dir} -type f -name '*.exe' -o -name '*.dll' -o -name '*.msi'", \
-                                  returnStdout:true).split("\\r?\\n|\\r")
-                    bins.each { bin ->
-                        if (bin.trim() != "") {
-                            def rc = sh(script:"${signtool} verify /pa /v ${bin}", returnStatus:true)
-                            if (rc != 0) {
-                                println "Error: binary not signed: ${bin}"
-                                currentBuild.result = 'FAILURE'
-                            } else { 
-                                println "Signed correctly: ${bin}"
-                            }
-                        }
-                    }
-                }
-
-                // For Mac also verify installer (if built) is Notarized
-                if (params.TARGET_OS == "mac") {
-                    // Find all pkg's that need to be Notarized
-                    def pkgs = sh(script:"find . -type f -name '*.pkg'", \
-                                  returnStdout:true).split("\\r?\\n|\\r") 
-                    pkgs.each { pkg ->
-                        if (pkg.trim() != "") {
-                            def rc = sh(script:"spctl -a -vvv -t install ${pkg}", returnStatus:true)
-                            if (rc != 0) {
-                                println "Error: pkg not Notarized: ${pkg}"
-                                currentBuild.result = 'FAILURE'
-                            } else {
-                                println "Notarized correctly: ${pkg}"
-                            }
-                        }
-                    }
-                }
+                // Verify installers (if built) are Signed and Notarized(mac only)
+                verifyInstallers()
             } finally {
                 // Clean workspace afterwards
                 cleanWs notFailBuild: true, disableDeferredWipeout: true, deleteDirs: true

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -118,7 +118,8 @@ if (verify) {
                     def dir = "${unpack_dir}/${archive}"
                     // Expand JMODs
                     println "Expanding JMODS under ${dir}"
-                    def jmods = findFiles(glob: "${dir}/**/*.jmod")
+                    def jmods = sh(script:"find ${dir} -type f -name '*.jmod'", \
+                                   returnStdout:true).split("\\r?\\n|\\r")
                     jmods.each { jmod ->
                         def expand_dir = "expanded_" + sh(script:"basename ${jmod}", returnStdout:true)
                         expand_dir = "${dir}/${expand_dir}".trim()
@@ -128,7 +129,8 @@ if (verify) {
 
                     // Expand "modules" compress image containing jmods
                     println "Expanding 'modules' compressed image file under ${dir}"
-                    def modules = findFiles(glob: "${dir}/**/modules")
+                    def modules = sh(script:"find ${dir} -type f -name 'modules'", \
+                                     returnStdout:true).split("\\r?\\n|\\r")
                     modules.each { module ->
                         def expand_dir = "expanded_" + sh(script:"basename ${module}", returnStdout:true)
                         expand_dir = "${dir}/${expand_dir}".trim()
@@ -172,7 +174,8 @@ if (verify) {
                 // For Mac also verify installer (if built) is Notarized
                 if (params.TARGET_OS == "mac") {
                     // Find all pkg's that need to be Notarized
-                    def pkgs = findFiles(glob: "*.pkg")
+                    def pkgs = sh(script:"find . -type f -name '*.pkg'", \
+                                  returnStdout:true).split("\\r?\\n|\\r") 
                     pkgs.each { pkg ->
                        def rc = sh(script:"spctl -a -vvv -t install ${pkg}", returnStatus:true)
                        if (rc != 0) {

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -38,7 +38,7 @@ String find_signtool() {
             exit 1
     }
 
-    def windowsKitPath = "/cygdrive/c/progra~2/wi3cf2~1"
+    def windowsKitPath = "/cygdrive/c/'Program Files (x86)'/'Windows Kits'"
 
     def files = sh(script:"find ${windowsKitPath} -type f -path */${arch}/signtool.exe", \
                    returnStdout:true).split("\\r?\\n|\\r")
@@ -48,7 +48,7 @@ String find_signtool() {
         println "ERROR: Unable to find signtool.exe in ${windowsKitPath}"
         exit 2
     } else {
-        def signtool = files[0].trim()
+        def signtool = files[0].trim().replaceAll("(","\\(").replaceAll(" ","\\ ")
         println "Found signtool: ${signtool}"
         return signtool 
     }

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -38,8 +38,7 @@ String find_signtool() {
             exit 1
     }
 
-//    def windowsKitPath = "/cygdrive/c/Program\\ Files\\ \\(x86\\)/Windows\\ Kits"
-    def windowsKitPath = "/cygdrive/c/progra~2/wi3cf2~1"
+    def windowsKitPath = "/cygdrive/c/'Program Files (x86)'/'Windows Kits'"
 
     def files = sh(script:"cd ${windowsKitPath} && find . -type f -path */${arch}/signtool.exe", \
                    returnStdout:true).split("\\r?\\n|\\r")

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -48,7 +48,7 @@ String find_signtool() {
         println "ERROR: Unable to find signtool.exe in ${windowsKitPath}"
         exit 2
     } else {
-        def signtool = files[0].trim().replaceAll("\\(","\\\\(").replaceAll("\\)","\\\\)").replaceAll(" ","\\ ")
+        def signtool = files[0].trim().replaceAll("\\(","\\\\(").replaceAll("\\)","\\\\)").replaceAll("\\ ","\\\\ ")
         println "Found signtool: ${signtool}"
         return signtool 
     }

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -85,9 +85,8 @@ void unpackArchives(String unpack_dir, String[] archives) {
             sh '''
                 #!/bin/bash
                 set -eu
-                if [[ -n `find "${dir}" -type f -name '*.jmod'` ]]; then
-                  FILES=$(find "${dir}" -type f -name '*.jmod')
-                  for f in $FILES
+                FILES=$(find "${dir}" -type f -name '*.jmod')
+                for f in $FILES
                   do
                     expand_dir=$(basename ${f})
                     expand_dir="${dir}/expanded_${expand_dir}"
@@ -95,11 +94,9 @@ void unpackArchives(String unpack_dir, String[] archives) {
                     echo "Expanding JMOD ${f}"
                     ${jdk_bin}/jmod extract --dir ${expand_dir} ${f}
                   done
-                fi
 
-                if [[ -n `find "${dir}" -type f -name 'modules'` ]]; then
-                  FILES=$(find "${dir}" -type f -name 'modules')
-                  for f in $FILES
+                FILES=$(find "${dir}" -type f -name 'modules')
+                for f in $FILES
                   do  
                     expand_dir=$(basename ${f})
                     expand_dir="${dir}/expanded_${expand_dir}"
@@ -107,7 +104,6 @@ void unpackArchives(String unpack_dir, String[] archives) {
                     echo "Expanding compressed image file ${f}"
                     ${jdk_bin}/jimage extract --dir ${expand_dir} ${f}
                   done
-                fi
             '''
         }
     }
@@ -127,9 +123,8 @@ void verifyExecutables(String unpack_dir) {
                 unsigned=""
                 cc_signed=0
                 cc_unsigned=0
-                if [[ -n `find "${unpack_dir}" -type f -not -name '*.*' -not -path '*/legal/*' -o -type f -name '*.dylib'` ]]; then
-                  FILES=$(find "${unpack_dir}" -type f -not -name '*.*' -not -path '*/legal/*' -o -type f -name '*.dylib')
-                  for f in $FILES
+                FILES=$(find "${unpack_dir}" -type f -not -name '*.*' -not -path '*/legal/*' -o -type f -name '*.dylib')
+                for f in $FILES
                   do
                     # Is file a Mac 64 bit executable or dylib ?
                     if file ${f} | grep "Mach-O 64-bit executable\\|Mach-O 64-bit dynamically linked shared library" >/dev/null; then
@@ -150,7 +145,6 @@ void verifyExecutables(String unpack_dir) {
                         fi
                     fi
                   done
-                fi
 
                 if [ "x${unsigned}" != "x" ]; then
                     echo "FAILURE: The following ${cc_unsigned} executables are not signed correctly:"
@@ -177,9 +171,8 @@ void verifyExecutables(String unpack_dir) {
                 unsigned=""
                 cc_signed=0
                 cc_unsigned=0
-                if [[ -n `find ${unpack_dir} -type f -name '*.exe' -o -name '*.dll'` ]]; then
-                  FILES=$(find ${unpack_dir} -type f -name '*.exe' -o -name '*.dll')
-                  for f in $FILES
+                FILES=$(find ${unpack_dir} -type f -name '*.exe' -o -name '*.dll')
+                for f in $FILES
                   do
                     if ! "${signtool}" verify /pa /v ${f}; then
                         echo "Error: executable not Signed: ${f}"
@@ -190,7 +183,6 @@ void verifyExecutables(String unpack_dir) {
                         cc_signed=$((cc_signed+1))
                     fi
                   done
-                fi
 
                 if [ "x${unsigned}" != "x" ]; then
                     echo "FAILURE: The following ${cc_unsigned} executables are not signed correctly:"
@@ -219,9 +211,8 @@ void verifyInstallers() {
             unsigned=""
             cc_signed=0
             cc_unsigned=0
- #           if [[ -n `find . -type f -name '*.pkg'` ]]; then
-              FILES=$(find . -type f -name '*.pkg')
-              for f in $FILES
+            FILES=$(find . -type f -name '*.pkg')
+            for f in $FILES
               do
                 if ! pkgutil --check-signature ${f}; then
                     echo "Error: pkg not Signed: ${f}"
@@ -240,7 +231,6 @@ void verifyInstallers() {
                     fi
                 fi
               done
-  #          fi
 
             if [ "x${unsigned}" != "x" ]; then
                 echo "FAILURE: The following ${cc_unsigned} installers are not signed and notarized correctly:"
@@ -265,9 +255,8 @@ void verifyInstallers() {
                 unsigned=""
                 cc_signed=0
                 cc_unsigned=0
-                if [[ -n `find . -type f -name '*.msi'` ]]; then
-                  FILES=$(find . -type f -name '*.msi')
-                  for f in $FILES
+                FILES=$(find . -type f -name '*.msi')
+                for f in $FILES
                   do
                     if ! "${signtool}" verify /pa /v ${f}; then
                         echo "Error: installer not Signed: ${f}"
@@ -278,7 +267,6 @@ void verifyInstallers() {
                         cc_signed=$((cc_signed+1))
                     fi
                   done
-                fi
 
                 if [ "x${unsigned}" != "x" ]; then
                     echo "FAILURE: The following ${cc_unsigned} installers are not signed correctly:"

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -44,7 +44,7 @@ String find_signtool() {
                    returnStdout:true).split("\\r?\\n|\\r")
 
     // Return the first one we find
-    if (files.size == 0 || files[0].trim() == "") {
+    if (files.size() == 0 || files[0].trim() == "") {
         println "ERROR: Unable to find signtool.exe in ${windowsKitPath}"
         exit 2
     } else {

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -53,7 +53,7 @@ String find_signtool() {
 }
 
 // Unpack the archives so the signartures can be checked
-void unpackArchives(String unpack_dir, String[] archives) {
+def unpackArchives(String unpack_dir, String[] archives) {
     archives.each { archive ->
         def dir = "${unpack_dir}/${archive}"
         if (params.TARGET_OS == "mac") {
@@ -103,7 +103,7 @@ void unpackArchives(String unpack_dir, String[] archives) {
 }
 
 // Verify executables for Signatures
-void verifyExecutables(String unpack_dir) {
+def verifyExecutables(String unpack_dir) {
     if (params.TARGET_OS == "mac") {
         // On Mac find all dylib's and binaries marked as "executable",
         // also add "jpackageapplauncher" specific case which is not marked as "executable"
@@ -143,7 +143,7 @@ void verifyExecutables(String unpack_dir) {
 }
 
 // Verify installers for Signatures and Notarization(mac only)
-void verifyInstallers() {
+def verifyInstallers() {
     if (params.TARGET_OS == "mac") {
         // Find all pkg's that need to be Signed and Notarized
         def pkgs = sh(script:"find . -type f -name '*.pkg'", \

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -40,7 +40,7 @@ String find_signtool() {
 
     def windowsKitPath = "/cygdrive/c/'Program Files (x86)'/'Windows Kits'"
 
-    def files = sh(script:"cd ${windowsKitPath} && find . -type f -path */${arch}/signtool.exe", \
+    def files = sh(script:"find ${windowsKitPath} -type f -path */${arch}/signtool.exe", \
                    returnStdout:true).split("\\r?\\n|\\r")
 
     // Return the first one we find
@@ -48,7 +48,7 @@ String find_signtool() {
         println "ERROR: Unable to find signtool.exe in ${windowsKitPath}"
         exit 2
     } else {
-        def signtool = "${windowsKitPath}/"+files[0].trim()
+        def signtool = files[0].trim()
 //.replaceAll("\\(","\\\\(").replaceAll("\\)","\\\\)")
 //.replaceAll("\\ ","\\\\ ")
         println "Found signtool: ${signtool}"

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -49,8 +49,6 @@ String find_signtool() {
         exit 2
     } else {
         def signtool = files[0].trim()
-//.replaceAll("\\(","\\\\(").replaceAll("\\)","\\\\)")
-//.replaceAll("\\ ","\\\\ ")
         println "Found signtool: ${signtool}"
         return signtool 
     }
@@ -168,7 +166,6 @@ void verifyExecutables(String unpack_dir) {
         }
     } else { // Windows
         def signtool = find_signtool()
-signtool = "/cygdrive/c/Program Files (x86)/Windows Kits/10/bin/10.0.15063.0/x64/signtool.exe"
 
         // Find all exe/dll's that must be Signed
 
@@ -272,7 +269,7 @@ void verifyInstallers() {
                   FILES=$(find . -type f -name '*.msi')
                   for f in $FILES
                   do
-                    if ! ${signtool} verify /pa /v ${f}; then
+                    if ! "${signtool}" verify /pa /v ${f}; then
                         echo "Error: installer not Signed: ${f}"
                         unsigned="$unsigned $f"
                         cc_unsigned=$((cc_unsigned+1))

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -116,7 +116,7 @@ def verifyExecutables(String unpack_dir) {
         bins.each { bin ->
             if (bin.trim() != "") {
                 // Is file a Mac 64 bit executable or dylib ?
-                def rc = sh(script:"file ${bin} | grep \"Mach-O 64-bit executable\|Mach-O 64-bit dynamically linked shared library\" >/dev/null", returnStatus:true)
+                def rc = sh(script:"file ${bin} | grep \"Mach-O 64-bit executable\\|Mach-O 64-bit dynamically linked shared library\" >/dev/null", returnStatus:true)
                 if (rc == 0) {
                     rc = sh(script:"codesign --verify --verbose ${bin}", returnStatus:true)
                     if (rc != 0) {

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -110,7 +110,8 @@ List<String> verifyExecutables(String unpack_dir) {
 
     if (params.TARGET_OS == "mac") {
         // On Mac find all dylib's and "executable" binaries
-        def bins = sh(script:"find ${unpack_dir} -type f -not -name '*.*' -o -type f -name '*.dylib'",  \
+        // Ignore "legal" text folder to reduce the number of non-extension files it finds...
+        def bins = sh(script:"find ${unpack_dir} -type f -not -name '*.*' -not -path '*/legal/*' -o -type f -name '*.dylib'",  \
                       returnStdout:true).split("\\r?\\n|\\r")
         bins.each { bin ->
             if (bin.trim() != "") {

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -121,10 +121,12 @@ if (verify) {
                     def jmods = sh(script:"find ${dir} -type f -name '*.jmod'", \
                                    returnStdout:true).split("\\r?\\n|\\r")
                     jmods.each { jmod ->
-                        def expand_dir = "expanded_" + sh(script:"basename ${jmod}", returnStdout:true)
-                        expand_dir = "${dir}/${expand_dir}".trim()
-                        sh("mkdir ${expand_dir}")
-                        sh("${jdk_bin}/jmod extract --dir ${expand_dir} ${jmod}")
+                        if (jmod.trim() != "") {
+                            def expand_dir = "expanded_" + sh(script:"basename ${jmod}", returnStdout:true)
+                            expand_dir = "${dir}/${expand_dir}".trim()
+                            sh("mkdir ${expand_dir}")
+                            sh("${jdk_bin}/jmod extract --dir ${expand_dir} ${jmod}")
+                        }
                     }
 
                     // Expand "modules" compress image containing jmods
@@ -132,10 +134,12 @@ if (verify) {
                     def modules = sh(script:"find ${dir} -type f -name 'modules'", \
                                      returnStdout:true).split("\\r?\\n|\\r")
                     modules.each { module ->
-                        def expand_dir = "expanded_" + sh(script:"basename ${module}", returnStdout:true)
-                        expand_dir = "${dir}/${expand_dir}".trim()
-                        sh("mkdir ${expand_dir}")
-                        sh("${jdk_bin}/jimage extract --dir ${expand_dir} ${module}")
+                        if (module.trim() != "") {
+                            def expand_dir = "expanded_" + sh(script:"basename ${module}", returnStdout:true)
+                            expand_dir = "${dir}/${expand_dir}".trim()
+                            sh("mkdir ${expand_dir}")
+                            sh("${jdk_bin}/jimage extract --dir ${expand_dir} ${module}")
+                        }
                     }
                 }
 
@@ -148,26 +152,30 @@ if (verify) {
                                           find ${unpack_dir} -perm /111 -type f -not -name '.*' -o -name '*.dylib' -o -name 'jpackageapplauncher'",  \
                                   returnStdout:true).split("\\r?\\n|\\r")
                     bins.each { bin ->
-                       def rc = sh(script:"codesign --verify --verbose ${bin}", returnStatus:true)
-                       if (rc != 0) {
-                           println "Error: dylib not signed: ${bin}"
-                           currentBuild.result = 'FAILURE'
-                       } else {
-                           println "Signed correctly: ${bin}"
-                       }
+                        if (bin.trim() != "") {
+                            def rc = sh(script:"codesign --verify --verbose ${bin}", returnStatus:true)
+                            if (rc != 0) {
+                                println "Error: dylib not signed: ${bin}"
+                                currentBuild.result = 'FAILURE'
+                            } else {
+                                println "Signed correctly: ${bin}"
+                            }
+                        }
                     }
                 } else { // Windows
                     // Find all exe/dll's that must be Signed
                     def bins = sh(script:"find ${unpack_dir} -type f -name '*.exe' -o -name '*.dll'", \
                                   returnStdout:true).split("\\r?\\n|\\r")
                     bins.each { bin ->
-                       def rc = sh(script:"signtool verify /v ${bin}", returnStatus:true)
-                       if (rc != 0) {
-                           println "Error: binary not signed: ${bin}"
-                           currentBuild.result = 'FAILURE'
-                       } else { 
-                           println "Signed correctly: ${bin}"
-                       } 
+                        if (bin.trim() != "") {
+                            def rc = sh(script:"signtool verify /v ${bin}", returnStatus:true)
+                            if (rc != 0) {
+                                println "Error: binary not signed: ${bin}"
+                                currentBuild.result = 'FAILURE'
+                            } else { 
+                                println "Signed correctly: ${bin}"
+                            }
+                        }
                     }
                 }
 
@@ -177,13 +185,15 @@ if (verify) {
                     def pkgs = sh(script:"find . -type f -name '*.pkg'", \
                                   returnStdout:true).split("\\r?\\n|\\r") 
                     pkgs.each { pkg ->
-                       def rc = sh(script:"spctl -a -vvv -t install ${pkg}", returnStatus:true)
-                       if (rc != 0) {
-                           println "Error: pkg not Notarized: ${pkg}"
-                           currentBuild.result = 'FAILURE'
-                       } else {
-                           println "Notarized correctly: ${pkg}"
-                       }
+                        if (pkg.trim() != "") {
+                            def rc = sh(script:"spctl -a -vvv -t install ${pkg}", returnStatus:true)
+                            if (rc != 0) {
+                                println "Error: pkg not Notarized: ${pkg}"
+                                currentBuild.result = 'FAILURE'
+                            } else {
+                                println "Notarized correctly: ${pkg}"
+                            }
+                        }
                     }
                 }
             } finally {

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -196,7 +196,7 @@ if (params.TARGET_OS != "mac" && params.TARGET_OS != "windows") {
     println "Verifying signing for platform ${params.TARGET_OS}, ${params.UPSTREAM_JOB_NAME} #${params.UPSTREAM_JOB_NUMBER}"
 
     // Switch to appropriate node
-    stage("verify_signing") {
+    stage("verify signatures") {
         node(params.NODE_LABEL) {
             try {
                 // Clean workspace to ensure no old artifacts

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -38,7 +38,7 @@ String find_signtool() {
             exit 1
     }
 
-    def windowsKitPath = "/cygdrive/c/'Program Files \(x86\)'/'Windows Kits'"
+    def windowsKitPath = "/cygdrive/c/'Program Files (x86)'/'Windows Kits'"
 
     def files = sh(script:"find ${windowsKitPath} -type f -path */${arch}/signtool.exe", \
                    returnStdout:true).split("\\r?\\n|\\r")
@@ -48,7 +48,7 @@ String find_signtool() {
         println "ERROR: Unable to find signtool.exe in ${windowsKitPath}"
         exit 2
     } else {
-        def signtool = files[0].trim().replaceAll("(","\\(").replaceAll(" ","\\ ")
+        def signtool = files[0].trim().replaceAll("\(","\\\(").replaceAll(" ","\\ ")
         println "Found signtool: ${signtool}"
         return signtool 
     }

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -48,7 +48,7 @@ String find_signtool() {
         println "ERROR: Unable to find signtool.exe in ${windowsKitPath}"
         exit 2
     } else {
-        def signtool = files[0].trim().replaceAll("\(","\\\(").replaceAll(" ","\\ ")
+        def signtool = files[0].trim().replaceAll("\\(","\\\\(").replaceAll(" ","\\ ")
         println "Found signtool: ${signtool}"
         return signtool 
     }

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -32,7 +32,7 @@ String find_signtool() {
     switch (params.TARGET_ARCH) {
         case "aarch64": arch = "arm64"; break
         case "x64":     arch = "x64"; break
-        case "x86-32":  arch = "x86-32"; break
+        case "x86-32":  arch = "x86"; break
         default:
             println "ERROR: Unknown architecture: ${params.TARGET_ARCH}"
             exit 1

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -111,7 +111,7 @@ def verifyExecutables(String unpack_dir) {
         //def bins = sh(script:"find ${unpack_dir} -perm +111 -type f -not -name '.*' -o -name '*.dylib' -o -name 'jpackageapplauncher' || \
         //#                      find ${unpack_dir} -perm /111 -type f -not -name '.*' -o -name '*.dylib' -o -name 'jpackageapplauncher'",  \
         //#              returnStdout:true).split("\\r?\\n|\\r")
-        def bins = sh(script:"find ${unpack_dir} -type f -not -name \".*\" -o -name \"*.dylib\"",  \
+        def bins = sh(script:"find ${unpack_dir} -type f -not -name '*.*' -o -type f -name '*.dylib'",  \
                       returnStdout:true).split("\\r?\\n|\\r")
         bins.each { bin ->
             if (bin.trim() != "") {

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -169,6 +169,7 @@ void verifyExecutables(String unpack_dir) {
         }
     } else { // Windows
         def signtool = find_signtool()
+signtool = "'/cygdrive/c/Program Files (x86)/Windows Kits/./10/bin/10.0.15063.0/x64/signtool.exe'"
 
         // Find all exe/dll's that must be Signed
 

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -111,7 +111,7 @@ def verifyExecutables(String unpack_dir) {
         //def bins = sh(script:"find ${unpack_dir} -perm +111 -type f -not -name '.*' -o -name '*.dylib' -o -name 'jpackageapplauncher' || \
         //#                      find ${unpack_dir} -perm /111 -type f -not -name '.*' -o -name '*.dylib' -o -name 'jpackageapplauncher'",  \
         //#              returnStdout:true).split("\\r?\\n|\\r")
-        def bins = sh(script:"find ${unpack_dir} -type f -not -name '.*' -o -name '*.dylib'",  \
+        def bins = sh(script:"find ${unpack_dir} -type f -not -name \".*\" -o -name \"*.dylib\"",  \
                       returnStdout:true).split("\\r?\\n|\\r")
         bins.each { bin ->
             if (bin.trim() != "") {

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -38,7 +38,7 @@ String find_signtool() {
             exit 1
     }
 
-    def windowsKitPath = "/cygdrive/c/'Program Files (x86)'/'Windows Kits'"
+    def windowsKitPath = "/cygdrive/c/progra~2/wi3cf2~1"
 
     def files = sh(script:"find ${windowsKitPath} -type f -path */${arch}/signtool.exe", \
                    returnStdout:true).split("\\r?\\n|\\r")

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -127,7 +127,7 @@ List<String> verifyExecutables(String unpack_dir) {
                 for f in $FILES
                 do
                     # Is file a Mac 64 bit executable or dylib ?
-                    if file ${f} | grep "Mach-O 64-bit executable\|Mach-O 64-bit dynamically linked shared library" >/dev/null; then
+                    if file ${f} | grep "Mach-O 64-bit executable\\|Mach-O 64-bit dynamically linked shared library" >/dev/null; then
                         if ! codesign --verify --verbose ${f}; then
                             echo "Error: executable not Signed: ${bin}"
                             unsigned="$unsigned $f"

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -168,7 +168,7 @@ void verifyExecutables(String unpack_dir) {
         }
     } else { // Windows
         def signtool = find_signtool()
-signtool = "'/cygdrive/c/Program Files (x86)/Windows Kits/./10/bin/10.0.15063.0/x64/signtool.exe'"
+signtool = "/cygdrive/c/Program Files (x86)/Windows Kits/10/bin/10.0.15063.0/x64/signtool.exe"
 
         // Find all exe/dll's that must be Signed
 

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -129,12 +129,12 @@ List<String> verifyExecutables(String unpack_dir) {
                     # Is file a Mac 64 bit executable or dylib ?
                     if file ${f} | grep "Mach-O 64-bit executable\\|Mach-O 64-bit dynamically linked shared library" >/dev/null; then
                         if ! codesign --verify --verbose ${f}; then
-                            echo "Error: executable not Signed: ${bin}"
+                            echo "Error: executable not Signed: ${f}"
                             unsigned="$unsigned $f"
                         else
                             # Verify it is not "adhoc" signed
                             if ! codesign --display --verbose ${f} 2>&1 | grep Signature=adhoc; then
-                                echo "Signed correctly: ${bin}"
+                                echo "Signed correctly: ${f}"
                             else
                                 echo "Error: executable is 'adhoc' Signed: ${f}"
                                 unsigned="$unsigned $f"

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -211,7 +211,7 @@ void verifyInstallers() {
             unsigned=""
             cc_signed=0
             cc_unsigned=0
-            FILES=$(find . -type f -name '*.pkg')
+            FILES="$(find . -type f -name '*.pkg')"
             for f in $FILES
             do
                 if ! pkgutil --check-signature ${f}; then

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -132,7 +132,7 @@ void verifyExecutables(String unpack_dir) {
                   do
                     # Is file a Mac 64 bit executable or dylib ?
                     if file ${f} | grep "Mach-O 64-bit executable\\|Mach-O 64-bit dynamically linked shared library" >/dev/null; then
-                        if ! codesign --verify --verbose ${f}; then
+                        if ! codesign --verify ${f}; then
                             echo "Error: executable not Signed: ${f}"
                             unsigned="$unsigned $f"
                             cc_unsigned=$((cc_unsigned+1))
@@ -180,7 +180,7 @@ void verifyExecutables(String unpack_dir) {
                 FILES=$(find ${unpack_dir} -type f -name '*.exe' -o -name '*.dll')
                 for f in $FILES
                   do
-                    if ! "${signtool}" verify /pa /v ${f}; then
+                    if ! "${signtool}" verify /pa ${f}; then
                         echo "Error: executable not Signed: ${f}"
                         unsigned="$unsigned $f"
                         cc_unsigned=$((cc_unsigned+1))
@@ -229,7 +229,7 @@ void verifyInstallers() {
                 else
                     echo "Signed correctly: ${f}"
 
-                    if ! spctl -a -vvv -t install ${f}; then
+                    if ! spctl -a -t install ${f}; then
                         echo "Error: pkg not Notarized: ${f}"
                         unsigned="$unsigned $f"
                         cc_unsigned=$((cc_unsigned+1))
@@ -268,7 +268,7 @@ void verifyInstallers() {
                 FILES=$(find . -type f -name '*.msi')
                 for f in $FILES
                   do
-                    if ! "${signtool}" verify /pa /v ${f}; then
+                    if ! "${signtool}" verify /pa ${f}; then
                         echo "Error: installer not Signed: ${f}"
                         unsigned="$unsigned $f"
                         cc_unsigned=$((cc_unsigned+1))

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -116,8 +116,9 @@ def verifyExecutables(String unpack_dir) {
         bins.each { bin ->
             if (bin.trim() != "") {
                 // Is file a Mac 64 bit executable or dylib ?
-                if file ${bin} | grep "Mach-O 64-bit executable\|Mach-O 64-bit dynamically linked shared library" >/dev/null; then
-                    def rc = sh(script:"codesign --verify --verbose ${bin}", returnStatus:true)
+                def rc = sh(script:"file ${bin} | grep \"Mach-O 64-bit executable\|Mach-O 64-bit dynamically linked shared library\" >/dev/null", returnStatus:true)
+                if (rc == 0) {
+                    rc = sh(script:"codesign --verify --verbose ${bin}", returnStatus:true)
                     if (rc != 0) {
                         println "Error: executable not Signed: ${bin}"
                         currentBuild.result = 'FAILURE'

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -108,9 +108,9 @@ if (verify) {
                 // Copy JDK so it can be used for unpacking using jmod/jimage
                 sh("mkdir jdk_cp && cp -r ${unpack_dir}/jdk/*/* jdk_cp")
 
-                def jdk_bin = "${WORKSPACE}/jdk_cp/bin"
+                def jdk_bin = "jdk_cp/bin"
                 if (params.TARGET_OS == "mac") {
-                    jdk_bin = "${WORKSPACE}/jdk_cp/Contents/Home/bin"
+                    jdk_bin = "jdk_cp/Contents/Home/bin"
                 }
 
                 // Expand the JMODs and modules image to test binaries within

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -80,9 +80,9 @@ void unpackArchives(String unpack_dir, String[] archives) {
         // Expand JMODs
         println "Expanding JMODS and 'modules' under ${dir}"
 
-        context.withEnv(['dir='+dir, 'jdk_bin='+jdk_bin]) {
+        withEnv(['dir='+dir, 'jdk_bin='+jdk_bin]) {
             // groovylint-disable
-            context.sh '''
+            sh '''
                 #!/bin/bash
                 set -eu
                 FILES=$(find "${dir}" -type f -name '*.jmod')

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -55,7 +55,7 @@ String find_signtool() {
 //
 // Main code
 //
-if (params.TARGET_OS != "mac" && params.TARGET_OS != "windows")
+if (params.TARGET_OS != "mac" && params.TARGET_OS != "windows") {
     println "No signing verification for platform: ${params.TARGET_OS}"
 } else {
     println "Verifying signing for platform ${params.TARGET_OS}, ${params.UPSTREAM_JOB_NAME} #${params.UPSTREAM_JOB_NUMBER}"

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -53,7 +53,7 @@ String find_signtool() {
 }
 
 // Unpack the archives so the signartures can be checked
-def unpackArchives(String unpack_dir, String[] archives) {
+private void unpackArchives(String unpack_dir, String[] archives) {
     archives.each { archive ->
         def dir = "${unpack_dir}/${archive}"
         if (params.TARGET_OS == "mac") {

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -85,6 +85,8 @@ void unpackArchives(String unpack_dir, String[] archives) {
             sh '''
                 #!/bin/bash
                 set -eu
+                set +x
+
                 FILES=$(find "${dir}" -type f -name '*.jmod')
                 for f in $FILES
                   do
@@ -120,6 +122,8 @@ void verifyExecutables(String unpack_dir) {
             sh '''
                 #!/bin/bash
                 set -eu
+                set +x
+
                 unsigned=""
                 cc_signed=0
                 cc_unsigned=0
@@ -168,6 +172,8 @@ void verifyExecutables(String unpack_dir) {
             sh '''
                 #!/bin/bash
                 set -eu
+                set +x
+
                 unsigned=""
                 cc_signed=0
                 cc_unsigned=0
@@ -208,6 +214,8 @@ void verifyInstallers() {
         sh '''
             #!/bin/bash
             set -eu
+            set +x
+
             unsigned=""
             cc_signed=0
             cc_unsigned=0
@@ -252,6 +260,8 @@ void verifyInstallers() {
             sh '''
                 #!/bin/bash
                 set -eu
+                set +x
+
                 unsigned=""
                 cc_signed=0
                 cc_unsigned=0

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -85,11 +85,12 @@ void unpackArchives(String unpack_dir, String[] archives) {
             sh '''
                 #!/bin/bash
                 set -eu
+                pwd
                 FILES=$(find "${dir}" -type f -name '*.jmod')
                 for f in $FILES
                 do
                     expand_dir=$(basename ${f})
-                    expand_dir="${dir}/${expand_dir}"
+                    expand_dir="${dir}/expanded_${expand_dir}"
                     mkdir "${expand_dir}"
                     echo "Expanding JMOD ${f}"
                     "${jdk_bin}/jmod extract --dir ${expand_dir} ${f}"

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -53,7 +53,7 @@ String find_signtool() {
 }
 
 // Unpack the archives so the signartures can be checked
-private void unpackArchives(String unpack_dir, String[] archives) {
+void unpackArchives(String unpack_dir, String[] archives) {
     archives.each { archive ->
         def dir = "${unpack_dir}/${archive}"
         if (params.TARGET_OS == "mac") {
@@ -244,8 +244,8 @@ if (params.TARGET_OS != "mac" && params.TARGET_OS != "windows") {
                 )
 
                 // Unpack archives
-                def unpack_dir = "unpacked"
-                def archives = ["jdk", "jre"]
+                String unpack_dir = "unpacked"
+                String[] archives = ["jdk", "jre"]
                 unpackArchives(unpack_dir, archives)
 
                 // Verify all executables for Signatures

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -183,7 +183,7 @@ void verifyExecutables(String unpack_dir) {
                   FILES=$(find ${unpack_dir} -type f -name '*.exe' -o -name '*.dll')
                   for f in $FILES
                   do
-                    if ! ${signtool} verify /pa /v ${f}; then
+                    if ! "${signtool}" verify /pa /v ${f}; then
                         echo "Error: executable not Signed: ${f}"
                         unsigned="$unsigned $f"
                         cc_unsigned=$((cc_unsigned+1))
@@ -271,7 +271,7 @@ void verifyInstallers() {
                   FILES=$(find . -type f -name '*.msi')
                   for f in $FILES
                   do
-                    if ! ${signtool} verify /pa /v ${f}; then
+                    if ! "${signtool}" verify /pa /v ${f}; then
                         echo "Error: installer not Signed: ${f}"
                         unsigned="$unsigned $f"
                         cc_unsigned=$((cc_unsigned+1))

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -85,8 +85,8 @@ void unpackArchives(String unpack_dir, String[] archives) {
             sh '''
                 #!/bin/bash
                 set -eu
-                FILES=$(find "${dir}" -type f -name '*.jmod')
-                if [[ -n $FILES ]]; then
+                if [[ -n `find "${dir}" -type f -name '*.jmod'` ]]; then
+                  FILES=$(find "${dir}" -type f -name '*.jmod')
                   for f in $FILES
                   do
                     expand_dir=$(basename ${f})
@@ -97,8 +97,8 @@ void unpackArchives(String unpack_dir, String[] archives) {
                   done
                 fi
 
-                FILES=$(find "${dir}" -type f -name 'modules')
-                if [[ -n $FILES ]]; then
+                if [[ -n `find "${dir}" -type f -name 'modules'` ]]; then
+                  FILES=$(find "${dir}" -type f -name 'modules')
                   for f in $FILES
                   do  
                     expand_dir=$(basename ${f})
@@ -127,8 +127,8 @@ void verifyExecutables(String unpack_dir) {
                 unsigned=""
                 cc_signed=0
                 cc_unsigned=0
-                FILES=$(find "${unpack_dir}" -type f -not -name '*.*' -not -path '*/legal/*' -o -type f -name '*.dylib')
-                if [[ -n $FILES ]]; then
+                if [[ -n `find "${unpack_dir}" -type f -not -name '*.*' -not -path '*/legal/*' -o -type f -name '*.dylib'` ]]; then
+                  FILES=$(find "${unpack_dir}" -type f -not -name '*.*' -not -path '*/legal/*' -o -type f -name '*.dylib')
                   for f in $FILES
                   do
                     # Is file a Mac 64 bit executable or dylib ?
@@ -177,8 +177,8 @@ void verifyExecutables(String unpack_dir) {
                 unsigned=""
                 cc_signed=0
                 cc_unsigned=0
-                FILES=$(find ${unpack_dir} -type f -name '*.exe' -o -name '*.dll')
-                if [[ -n $FILES ]]; then
+                if [[ -n `find ${unpack_dir} -type f -name '*.exe' -o -name '*.dll'` ]]; then
+                  FILES=$(find ${unpack_dir} -type f -name '*.exe' -o -name '*.dll')
                   for f in $FILES
                   do
                     if ! ${signtool} verify /pa /v ${f}; then
@@ -219,8 +219,8 @@ void verifyInstallers() {
             unsigned=""
             cc_signed=0
             cc_unsigned=0
-            FILES=$(find . -type f -name '*.pkg')
-            if [[ -n $FILES ]]; then
+            if [[ -n `find . -type f -name '*.pkg'` ]]; then
+              FILES=$(find . -type f -name '*.pkg')
               for f in $FILES
               do
                 if ! pkgutil --check-signature ${f}; then
@@ -265,8 +265,8 @@ void verifyInstallers() {
                 unsigned=""
                 cc_signed=0
                 cc_unsigned=0
-                FILES=$(find . -type f -name '*.msi')
-                if [[ -n $FILES ]]; then
+                if [[ -n `find . -type f -name '*.msi'` ]]; then
+                  FILES=$(find . -type f -name '*.msi')
                   for f in $FILES
                   do
                     if ! ${signtool} verify /pa /v ${f}; then

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -111,7 +111,7 @@ def verifyExecutables(String unpack_dir) {
         //def bins = sh(script:"find ${unpack_dir} -perm +111 -type f -not -name '.*' -o -name '*.dylib' -o -name 'jpackageapplauncher' || \
         //#                      find ${unpack_dir} -perm /111 -type f -not -name '.*' -o -name '*.dylib' -o -name 'jpackageapplauncher'",  \
         //#              returnStdout:true).split("\\r?\\n|\\r")
-        def bins = sh(script:"find ${unpack_dir}",  \
+        def bins = sh(script:"find ${unpack_dir} -type f -not -name '.*' -o -name '*.dylib'",  \
                       returnStdout:true).split("\\r?\\n|\\r")
         bins.each { bin ->
             if (bin.trim() != "") {

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -38,7 +38,7 @@ String find_signtool() {
             exit 1
     }
 
-    def windowsKitPath = "/cygdrive/c/Program Files\ \(x86\)/Windows\ Kits"
+    def windowsKitPath = "/cygdrive/c/'Program Files \(x86\)'/'Windows Kits'"
 
     def files = sh(script:"find ${windowsKitPath} -type f -path */${arch}/signtool.exe", \
                    returnStdout:true).split("\\r?\\n|\\r")


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3494

For Temurin builds, verify that for Windows and Mac platforms all the following are correctly signed with a non-adhoc Signature:
- Mac:
  - Within JMODs executable format files
  - jdk|jre/bin executable format files
  - *.pkg installers (also verify Notarized)
- Windows:
  - Within JMODs all *.exe/*.dll executable files
  -  jdk|jre/bin all *.exe/*.dll executable files
  - *.msi installers