### PR TITLE
Add new testJobType for release

### DIFF
--- a/docs/UsingOurScripts.md
+++ b/docs/UsingOurScripts.md
@@ -84,7 +84,7 @@ This file contains the default constants and paths used in the build scripts for
         "enableTests"            : true,
         /*
         Test targets triggered in 'nightly' build pipelines running 6 days per week
-        nightly + weekly to be run during a 'release' pipeline
+        'weekly' to be run on the weekend and 'release' from a release pipeline
         */
         "nightlyDefault"     : [
             "sanity.openjdk",
@@ -96,15 +96,36 @@ This file contains the default constants and paths used in the build scripts for
         ],
         /*
         Test targets triggered in 'weekly' build pipelines running once per week
-        nightly + weekly + jck to be run during a 'release' pipeline
-        nightly + weekly to be run during 'evaluation weekly' pipeline
+        weekly + jck to be run during a 'weekly' pipeline
+        weekly to be run during 'evaluation weekly' pipeline
         */
         "weeklyDefault"     : [
+            "sanity.openjdk",
+            "sanity.system",
+            "extended.system",
+            "sanity.perf",
+            "sanity.functional",
+            "extended.functional"
             "extended.openjdk",
             "extended.perf",
             "special.functional",
             "dev.openjdk",
-            "dev.system"
+            "dev.functional"
+        ],
+        /*
+        Test targets triggered in 'release' build pipelines
+        release + jck to be run during a 'release' pipeline
+        */
+        "releaseDefault"     : [
+            "sanity.openjdk",
+            "sanity.system",
+            "extended.system",
+            "sanity.perf",
+            "sanity.functional",
+            "extended.functional"
+            "extended.openjdk",
+            "extended.perf",
+            "special.functional"
         ]
     },
     // Raw content URL of this (defaults.json) file. This is so the openjdk_build_pipeline.groovy script can set user default configs when checking out to the shell script repo

--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -50,7 +50,7 @@ class Regeneration implements Serializable {
     private final jobType
 
     private String javaToBuild
-    private final List<String> defaultTestList = ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external']
+    private final List<String> defaultTestList = ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
 
     private final String EXCLUDED_CONST = 'EXCLUDED'
 

--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -48,6 +48,27 @@
             "extended.functional"
         ],
         "weeklyDefault"     : [
+            "sanity.openjdk",
+            "sanity.system",
+            "extended.system",
+            "sanity.perf",
+            "sanity.functional",
+            "sanity.external",
+            "extended.functional",
+            "extended.openjdk",
+            "extended.perf",
+            "special.functional",
+            "special.openjdk",
+            "dev.openjdk",
+            "dev.functional"
+        ],
+        "releaseDefault"     : [
+            "sanity.openjdk",
+            "sanity.system",
+            "extended.system",
+            "sanity.perf",
+            "sanity.functional",
+            "extended.functional",
             "extended.openjdk",
             "extended.perf",
             "special.functional"

--- a/pipelines/src/test/groovy/RepoHandlerTest.groovy
+++ b/pipelines/src/test/groovy/RepoHandlerTest.groovy
@@ -67,6 +67,7 @@ class RepoHandlerTest {
         Assertions.assertTrue(adoptJson.testDetails.enableTests instanceof Boolean)
         Assertions.assertTrue(adoptJson.testDetails.nightlyDefault instanceof List)
         Assertions.assertTrue(adoptJson.testDetails.weeklyDefault instanceof List)
+        Assertions.assertTrue(adoptJson.testDetails.releaseDefault instanceof List)
     }
 
     @Test
@@ -125,6 +126,7 @@ class RepoHandlerTest {
         Assertions.assertTrue(userJson.testDetails.enableTests)
         Assertions.assertEquals(userJson.testDetails.nightlyDefault, [ 'test1', 'test2', 'test3' ])
         Assertions.assertEquals(userJson.testDetails.weeklyDefault, [ 'test4', 'test5', 'test6', "test7" ])
+        Assertions.assertEquals(userJson.testDetails.releaseDefault, [ 'test8', 'test9' ])
     }
 
     @Test

--- a/pipelines/src/test/groovy/fakeDefaults.json
+++ b/pipelines/src/test/groovy/fakeDefaults.json
@@ -36,7 +36,8 @@
         "enableReproducibleCompare" : false,
         "enableTests"        : true,
         "nightlyDefault"     : [ "test1", "test2", "test3" ],
-        "weeklyDefault"      : [ "test4", "test5", "test6", "test7"]
+        "weeklyDefault"      : [ "test4", "test5", "test6", "test7"],
+        "releaseDefault"     : [ "test8", "test9"]
     },
     "defaultsUrl"            : "23"
 }


### PR DESCRIPTION
Fixes #847 
Add an explicit testJobType for release pipeline, which allows us to add non-blocking testing to weekly runs