### PR TITLE
Enable headless mode on RISC-V

### DIFF
--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -179,7 +179,7 @@ class Config17 {
                 dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                 dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',
-                configureArgs       : '--enable-dtrace',
+                configureArgs       : '--enable-headless-only=yes --enable-dtrace',
                 buildArgs           : [
                         'hotspot'   : '--create-jre-image --create-sbom'
                 ]

--- a/pipelines/jobs/configurations/jdk19u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk19u_pipeline_config.groovy
@@ -160,7 +160,7 @@ class Config19 {
                 crossCompile         : 'dockerhost-rise-ubuntu2204-aarch64-1',
                 dockerImage          : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                 dockerArgs           : '--platform linux/riscv64',
-                configureArgs        : '--enable-dtrace',
+                configureArgs        : '--enable-headless-only=yes --enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ],

--- a/pipelines/jobs/configurations/jdk20u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20u_pipeline_config.groovy
@@ -150,7 +150,7 @@ class Config20 {
                 dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                 dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',
-                configureArgs       : '--enable-dtrace',
+                configureArgs       : '--enable-headless-only=yes --enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -170,7 +170,7 @@ class Config21 {
                 // dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                 // dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',
-                configureArgs       : '--enable-dtrace',
+                configureArgs       : '--enable-headless-only=yes --enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]

--- a/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
@@ -149,7 +149,7 @@ class Config22 {
                 // dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                 // dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',
-                configureArgs       : '--enable-dtrace',
+                configureArgs       : '--enable-headless-only=yes --enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]

--- a/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
@@ -146,7 +146,7 @@ class Config23 {
                 os                  : 'linux',
                 arch                : 'riscv64',
                 test                : 'default',
-                configureArgs       : '--enable-dtrace',
+                configureArgs       : '--enable-headless-only=yes --enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]


### PR DESCRIPTION
We are simplifying the stack we want to build, test, and distribute, and we may disable headless mode later on when we have a stable release pipeline for RISC-V.

Related to https://github.com/adoptium/temurin-build/issues/3591