### PR TITLE
Enable docker image for RISC-V on 21, 22, 23

### DIFF
--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -166,9 +166,9 @@ class Config21 {
         riscv64Linux      :  [
                 os                  : 'linux',
                 arch                : 'riscv64',
-                // crossCompile        : 'dockerhost-rise-ubuntu2204-aarch64-1',
-                // dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
-                // dockerArgs          : '--platform linux/riscv64',
+                crossCompile        : 'dockerhost-rise-ubuntu2204-aarch64-1',
+                dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
+                dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [

--- a/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
@@ -145,9 +145,9 @@ class Config22 {
         riscv64Linux      :  [
                 os                  : 'linux',
                 arch                : 'riscv64',
-                // crossCompile        : 'dockerhost-rise-ubuntu2204-aarch64-1',
-                // dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
-                // dockerArgs          : '--platform linux/riscv64',
+                crossCompile        : 'dockerhost-rise-ubuntu2204-aarch64-1',
+                dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
+                dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [

--- a/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
@@ -145,6 +145,9 @@ class Config23 {
         riscv64Linux      :  [
                 os                  : 'linux',
                 arch                : 'riscv64',
+                crossCompile        : 'dockerhost-rise-ubuntu2204-aarch64-1',
+                dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
+                dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [


### PR DESCRIPTION
We verified it works on jdk21u with https://ci.adoptium.net/job/build-scripts/job/jobs/job/evaluation/job/jobs/job/jdk21u/job/jdk21u-evaluation-linux-riscv64-temurin/92

Relates to https://github.com/adoptium/temurin-build/issues/3591