### PR TITLE
2nd attempt to fix v5 labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,35 +10,28 @@
 
 ghActions:
 - changed-files:
-  - .github/workflows/**/*
+    - any-glob-to-any-file: [.github/workflows/**/*]
 documentation:
 - changed-files:
-  - docs/**/*
-  - docs/*
-  - '**/*.md'
+    - any-glob-to-any-file: [docs/**/*, docs/*, '**/*.md']
 jenkins-pipeline:
-- changed-files:
-  - pipelines/**/*
-  - pipelines/*
+    - changed-files:
+        - any-glob-to-any-file: [pipelines/**/*, pipelines/*]
 generation:
-- changed-files:
-  - pipelines/build/regeneration/*
-  - pipelines/build/common/config_regeneration.groovy
+    - changed-files:
+        - any-glob-to-any-file: [pipelines/build/regeneration/*, pipelines/build/common/config_regeneration.groovy]
 docker:
-- changed-files:
-  - pipelines/build/dockerFiles/*
+    - changed-files:
+        - any-glob-to-any-file: [pipelines/build/dockerFiles/*]
 testing:
-- changed-files:
-  - pipelines/build/prTester/*
-  - pipelines/src/test/*
+    - changed-files:
+        - any-glob-to-any-file: [pipelines/build/prTester/*, pipelines/src/test/*]
 code-tools:
-- changed-files:
-  - tools/*
+    - changed-files:
+        - any-glob-to-any-file: [tools/*]
 gradle:
-- changed-files:
-  - pipelines/gradle/*
-  - pipelines/build.gradle
-  - pipelines/gradlew
+    - changed-files:
+        - any-glob-to-any-file: [pipelines/gradle/*, pipelines/build.gradle, pipelines/gradlew]
 cross-compile:
-- changed-files:
-  - pipelines/build/common/cross_compiled_version_out.groovy
+    - changed-files:
+        - any-glob-to-any-file: [pipelines/build/common/cross_compiled_version_out.groovy]

--- a/.github/regex_labeler.yml
+++ b/.github/regex_labeler.yml
@@ -80,7 +80,6 @@ labels:
     matcher:
       title: "sparc"
       body: "sparc"
-
   - label: "hotspot"
     matcher:
       title: "hotspot"
@@ -117,7 +116,6 @@ labels:
     matcher:
       title: "cross"
       body: "risc"
-
   - label: "hacktoberfest"
     matcher:
       body: "hacktober"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Assign Labels
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
       if: ${{ github.event.pull_request }}
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
 
-    - uses: fuxingloh/multi-labeler@v2
+    - uses: fuxingloh/multi-labeler@6704db0bcba106d07482efabbc79d3092af74fa2 # v2.0.3
       with:
         github-token: "${{secrets.GITHUB_TOKEN}}"
         config-path: .github/regex_labeler.yml

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pipelines/gradle-cache
 pipelines/target
 **/.DS_Store
 jenkins-helper/
+**/*/.java-version


### PR DESCRIPTION
WARN: Because of https://github.com/actions/labeler?tab=readme-ov-file#notes-regarding-pull_request_target-event this PR will appear to have failed the GH Action check.  We won't know its worked until a subsequent PR is created.  This is why we can't have nice things :-)