### PR TITLE
Sanitise parameters

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -906,6 +906,11 @@ class Builder implements Serializable {
                                         //Remove the previous artifacts
                                         try {
                                             context.timeout(time: pipelineTimeouts.REMOVE_ARTIFACTS_TIMEOUT, unit: 'HOURS') {
+                                                if ( ! ( "${config.TARGET_OS}"    ==~ /^[A-Za-z0-9\/\.-_]$/ ) ||
+                                                     ! ( "${config.ARCHITECTURE}" ==~ /^[A-Za-z0-9\/\.-_]$/ ) ||
+                                                     ! ( "${config.VARIANT}"      ==~ /^[A-Za-z0-9\/\.-_]$/ ) ) {
+                                                    throw new Exception("[ERROR] Dubious character in TARGET_OS, ARCHITECTURE or VARIANT - aborting");
+                                                }
                                                 context.sh "rm -rf target/${config.TARGET_OS}/${config.ARCHITECTURE}/${config.VARIANT}/"
                                             }
                                         } catch (FlowInterruptedException e) {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1883,7 +1883,12 @@ class Build {
                             label = 'codebuild'
                         }
 
+
                         context.println "[NODE SHIFT] MOVING INTO DOCKER NODE MATCHING LABELNAME ${label}..."
+                        if ( ! ( "${buildConfig.DOCKER_IMAGE}" ==~ /^[A-Za-z0-9\/\.-_]*$/ ) ||
+                             ! ( "${buildConfig.DOCKER_ARGS}"  ==~ /^[A-Za-z0-9\/\.-_]*$/ ) ) {
+                             throw new Exception("[ERROR] Dubious characters in DOCKER* parameters ${buildConfig.DOCKER_IMAGE}/${buildConfig.DOCKER_ARGS} - aborting");
+                        }
                         context.node(label) {
                             addNodeToBuildDescription()
                             // Cannot clean workspace from inside docker container
@@ -1911,6 +1916,7 @@ class Build {
                                         if (buildConfig.DOCKER_CREDENTIAL) {
                                             context.docker.withRegistry(buildConfig.DOCKER_REGISTRY, buildConfig.DOCKER_CREDENTIAL) {
                                                 if (buildConfig.DOCKER_ARGS) {
+                                                    
                                                     context.sh(script: "docker pull ${buildConfig.DOCKER_IMAGE} ${buildConfig.DOCKER_ARGS}")
                                                 } else {
                                                     context.docker.image(buildConfig.DOCKER_IMAGE).pull()

--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -32,6 +32,9 @@ node('worker') {
         if (params.jdkVersion == '8' && params.targetConfigurations.contains('arm32Linux')) {
             propertyFile = 'testenv_arm32.properties'
         }
+        if ( ! ( "${params.aqareference}" ==~ /^[A-Za-z0-9\/\.-_]$/ ) ) {
+          throw new Exception("[ERROR] Dubious characters in aqa reference - aborting");
+        }
         sh("curl -Os https://raw.githubusercontent.com/adoptium/aqa-tests/${params.aqaReference}/testenv/${propertyFile}")
 
         def buildTag = params.scmReference


### PR DESCRIPTION
This PR will trap potentially dangerous characters before passing them to a shell operation within the groovy pipelines. Noting that some dodgy characters are trapped elsewhere (but doing it here makes it explicit in case other places are missed):
```
15:45:46  Execution error: ERROR: Name must follow the pattern &#039;^[a-zA-Z0-9]+((\.|_|__|-+)[a-zA-Z0-9]+)*$&#039;
[Pipeline] echo
15:45:46  ERROR: Name must follow the pattern &#039;^[a-zA-Z0-9]+((\.|_|__|-+)[a-zA-Z0-9]+)*$&#039;
```
If the docker image parameter has nonsense in it.
Also VARIANT will get trapped and abort in make-adopt-build-farm.sh if it's not in a defined list: `16:29:19  + ./build-farm/make-adopt-build-farm.sh
16:29:19  [ERROR] hot$pot is not a recognised build variant. Valid Variants = hotspot temurin openj9 corretto SapMachine dragonwell fast_startup bisheng`

Ref TOB_TEMURIN_17

Preferred future solution would be to avoid using `sh` where possible to reduce the risk of shell escapes, but this should be good as an interim solution.