### PR TITLE
Align linux-riscv64 evaluation pipelines on jdk17u, jdk21u and jdk{latest} only

### DIFF
--- a/pipelines/jobs/configurations/jdk17u_evaluation.groovy
+++ b/pipelines/jobs/configurations/jdk17u_evaluation.groovy
@@ -4,6 +4,9 @@ targetConfigurations = [
         ],
         'aarch64Windows': [
                 'temurin'
+        ],
+        'riscv64Linux': [
+                'temurin'
         ]
         // 'x64Mac'      : [
         //         'openj9'

--- a/pipelines/jobs/configurations/jdk17u_evaluation.groovy
+++ b/pipelines/jobs/configurations/jdk17u_evaluation.groovy
@@ -34,8 +34,10 @@ targetConfigurations = [
 ]
 
 // if set to empty string then it wont get triggered
+
+// 23:30 Tue, Thu
 triggerSchedule_evaluation = 'TZ=UTC\n30 23 * * 2,4'
-// if set to empty string then it wont get triggered
+// 12:05 Sun
 triggerSchedule_weekly_evaluation = 'TZ=UTC\n05 12 * * 7'
 
 // scmReferences to use for weekly evaluation build

--- a/pipelines/jobs/configurations/jdk20u_evaluation.groovy
+++ b/pipelines/jobs/configurations/jdk20u_evaluation.groovy
@@ -1,7 +1,4 @@
 targetConfigurations = [
-        'riscv64Linux': [
-                'temurin'
-        ],
         'aarch64AlpineLinux' : [
                 'temurin'
         ],

--- a/pipelines/jobs/configurations/jdk21u_evaluation.groovy
+++ b/pipelines/jobs/configurations/jdk21u_evaluation.groovy
@@ -10,7 +10,7 @@ targetConfigurations = [
 // if set to empty string then it wont get triggered
 
 // 23:40 Mon, Wed
-//Uses releaseTrigger_21ea: triggerSchedule_evaluation = 'TZ=UTC\n40 23 * * 1,3'
+triggerSchedule_evaluation = 'TZ=UTC\n40 23 * * 1,3'
 // 23:40 Sat
 triggerSchedule_weekly_evaluation = 'TZ=UTC\n40 23 * * 6'
 

--- a/pipelines/jobs/configurations/jdk22_evaluation.groovy
+++ b/pipelines/jobs/configurations/jdk22_evaluation.groovy
@@ -1,7 +1,4 @@
 targetConfigurations = [
-        'riscv64Linux': [
-                'temurin'
-        ],
         'aarch64Windows' : [
                 'temurin'
         ]


### PR DESCRIPTION
Given the constrained resources, we want to make sure we trigger the evaluation pipelines only on the LTS and latest releases.

Relates to https://github.com/adoptium/temurin-build/issues/3591