### PR TITLE
Re-add wildcard lost from AQA branch regex

### DIFF
--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -32,7 +32,7 @@ node('worker') {
         if (params.jdkVersion == '8' && params.targetConfigurations.contains('arm32Linux')) {
             propertyFile = 'testenv_arm32.properties'
         }
-        if ( ! ( "${params.aqareference}" ==~ /^[A-Za-z0-9\/\.-_]$/ ) ) {
+        if ( ! ( "${params.aqareference}" ==~ /^[A-Za-z0-9\/\.-_]*$/ ) ) {
           throw new Exception("[ERROR] Dubious characters in aqa reference - aborting");
         }
         sh("curl -Os https://raw.githubusercontent.com/adoptium/aqa-tests/${params.aqaReference}/testenv/${propertyFile}")


### PR DESCRIPTION
Probably fix to https://github.com/adoptium/ci-jenkins-pipelines/pull/873#issuecomment-1881890894 - I think that got lost between my test and this going in. My bad if that's the case.