### PR TITLE
Allow : in build docker image name

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1885,9 +1885,9 @@ class Build {
 
 
                         context.println "[NODE SHIFT] MOVING INTO DOCKER NODE MATCHING LABELNAME ${label}..."
-                        if ( ! ( "${buildConfig.DOCKER_IMAGE}" ==~ /^[A-Za-z0-9\/\.-_]*$/ ) ||
-                             ! ( "${buildConfig.DOCKER_ARGS}"  ==~ /^[A-Za-z0-9\/\.-_]*$/ ) ) {
-                             throw new Exception("[ERROR] Dubious characters in DOCKER* parameters ${buildConfig.DOCKER_IMAGE}/${buildConfig.DOCKER_ARGS} - aborting");
+                        if ( ! ( "${buildConfig.DOCKER_IMAGE}" ==~ /^[A-Za-z0-9\/\.\-_:]*$/ ) ||
+                             ! ( "${buildConfig.DOCKER_ARGS}"  ==~ /^[A-Za-z0-9\/\.\-_\ ]*$/ ) ) {
+                             throw new Exception("[ERROR] Dubious characters in DOCKER* image or parameters: ${buildConfig.DOCKER_IMAGE} ${buildConfig.DOCKER_ARGS} - aborting");
                         }
                         context.node(label) {
                             addNodeToBuildDescription()


### PR DESCRIPTION
Also escapes the `-` character and adjusts the formatting of the error message. This was causing a problem for the riscv64 which use a slightly different format for these values and is causing a build job failure after the merging of https://github.com/adoptium/ci-jenkins-pipelines/pull/873