### PR TITLE
Remove arm32Linux from jdk21+ pipeline configurations

### DIFF
--- a/pipelines/jobs/configurations/jdk21u.groovy
+++ b/pipelines/jobs/configurations/jdk21u.groovy
@@ -29,9 +29,6 @@ targetConfigurations = [
         ],
         'aarch64Mac': [
                 'temurin'
-        ],
-        'arm32Linux'  : [
-                'temurin'
         ]
 ]
 

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -150,19 +150,6 @@ class Config21 {
                 ]
         ],
 
-        arm32Linux    : [
-                os                  : 'linux',
-                arch                : 'arm',
-                crossCompile        : 'aarch64',
-                dockerImage         : 'adoptopenjdk/ubuntu1604_build_image',
-                dockerArgs          : '--platform linux/arm/v7',
-                test                : 'default',
-                configureArgs       : '--enable-dtrace',
-                buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom'
-                ]
-        ],
-
         riscv64Linux      :  [
                 os                  : 'linux',
                 arch                : 'riscv64',

--- a/pipelines/jobs/configurations/jdk21u_release.groovy
+++ b/pipelines/jobs/configurations/jdk21u_release.groovy
@@ -28,9 +28,6 @@ targetConfigurations = [
         ],
         'aarch64Mac': [
                 'temurin'
-        ],
-        'arm32Linux'  : [
-                'temurin'
         ]
 ]
 

--- a/pipelines/jobs/configurations/jdk22.groovy
+++ b/pipelines/jobs/configurations/jdk22.groovy
@@ -29,9 +29,6 @@ targetConfigurations = [
         ],
         'aarch64Mac': [
                 'temurin'
-        ],
-        'arm32Linux'  : [
-                'temurin'
         ]
 ]
 

--- a/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
@@ -129,19 +129,6 @@ class Config22 {
                 ]
         ],
 
-        arm32Linux    : [
-                os                  : 'linux',
-                arch                : 'arm',
-                crossCompile        : 'aarch64',
-                dockerImage         : 'adoptopenjdk/ubuntu1604_build_image',
-                dockerArgs          : '--platform linux/arm/v7',
-                test                : 'default',
-                configureArgs       : '--enable-dtrace',
-                buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom'
-                ]
-        ],
-
         riscv64Linux      :  [
                 os                  : 'linux',
                 arch                : 'riscv64',

--- a/pipelines/jobs/configurations/jdk23.groovy
+++ b/pipelines/jobs/configurations/jdk23.groovy
@@ -29,9 +29,6 @@ targetConfigurations = [
         ],
         'aarch64Mac': [
                 'temurin'
-        ],
-        'arm32Linux'  : [
-                'temurin'
         ]
 ]
 

--- a/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
@@ -129,19 +129,6 @@ class Config23 {
                 ]
         ],
 
-        arm32Linux    : [
-                os                  : 'linux',
-                arch                : 'arm',
-                crossCompile        : 'aarch64',
-                dockerImage         : 'adoptopenjdk/ubuntu1604_build_image',
-                dockerArgs          : '--platform linux/arm/v7',
-                test                : 'default',
-                configureArgs       : '--enable-dtrace',
-                buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom'
-                ]
-        ],
-
         riscv64Linux      :  [
                 os                  : 'linux',
                 arch                : 'riscv64',


### PR DESCRIPTION
Following PMC discussion, Temurin jdk21+ will no longer build arm32Linux
https://github.com/adoptium/adoptium-support/issues/962#issuecomment-1887219594
