### PR TITLE
[v2024.01.01] Change test to default in JDK11u x64 Linux build config

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -22,10 +22,7 @@ class Config11 {
                 dockerFile: [
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
-                test                : [
-                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional'],
-                        weekly : ['extended.openjdk', 'extended.perf', 'special.functional', 'sanity.external']
-                ],
+                test                : 'default',
                 configureArgs       : [
                         'openj9'      : '--enable-dtrace=auto',
                         'temurin'     : '--enable-dtrace=auto',


### PR DESCRIPTION
JDk11u x64 linux release build is failing. Testing to see if this fixes it

https://ci.adoptium.net/job/build-scripts/job/release-openjdk11-pipeline/31/console