### PR TITLE
Escape '-' literals in patterns

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -733,7 +733,7 @@ class Builder implements Serializable {
 
     /*
     Returns the jenkins folder of where we assume the downstream build jobs have been regenerated
-    e.g: 
+    e.g:
     nightly:    build-scripts/jobs/jdk11u/jdk11u-linux-aarch64-temurin
     evaluation:  build-scripts/jobs/evaluation/jobs/jdk17u/jdk17u-evaluation-mac-x64-openj9
     release:    build-scripts/jobs/release/jobs/jdk21/jdk21-release-aix-ppc64-temurin
@@ -906,9 +906,9 @@ class Builder implements Serializable {
                                         //Remove the previous artifacts
                                         try {
                                             context.timeout(time: pipelineTimeouts.REMOVE_ARTIFACTS_TIMEOUT, unit: 'HOURS') {
-                                                if ( ! ( "${config.TARGET_OS}"    ==~ /^[A-Za-z0-9\/\.-_]*$/ ) ||
-                                                     ! ( "${config.ARCHITECTURE}" ==~ /^[A-Za-z0-9\/\.-_]*$/ ) ||
-                                                     ! ( "${config.VARIANT}"      ==~ /^[A-Za-z0-9\/\.-_]*$/ ) ) {
+                                                if ( ! ( "${config.TARGET_OS}"    ==~ /^[A-Za-z0-9\/\.\-_]*$/ ) ||
+                                                     ! ( "${config.ARCHITECTURE}" ==~ /^[A-Za-z0-9\/\.\-_]*$/ ) ||
+                                                     ! ( "${config.VARIANT}"      ==~ /^[A-Za-z0-9\/\.\-_]*$/ ) ) {
                                                     throw new Exception("[ERROR] Dubious character in TARGET_OS, ARCHITECTURE or VARIANT - aborting");
                                                 }
                                                 context.sh "rm -rf target/${config.TARGET_OS}/${config.ARCHITECTURE}/${config.VARIANT}/"

--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -32,7 +32,7 @@ node('worker') {
         if (params.jdkVersion == '8' && params.targetConfigurations.contains('arm32Linux')) {
             propertyFile = 'testenv_arm32.properties'
         }
-        if ( ! ( "${params.aqareference}" ==~ /^[A-Za-z0-9\/\.-_]*$/ ) ) {
+        if ( ! ( "${params.aqareference}" ==~ /^[A-Za-z0-9\/\.\-_]*$/ ) ) {
           throw new Exception("[ERROR] Dubious characters in aqa reference - aborting");
         }
         sh("curl -Os https://raw.githubusercontent.com/adoptium/aqa-tests/${params.aqaReference}/testenv/${propertyFile}")
@@ -41,7 +41,7 @@ node('worker') {
         if (params.scmReference.contains('_adopt')) {
             buildTag = params.scmReference.substring(0, params.scmReference.length() - 6) // remove _adopt suffix
         }
-        
+
         def list = readFile("${propertyFile}").readLines()
         def jdkBranch = ""
         def jdkOpenj9Branch = ""
@@ -49,7 +49,6 @@ node('worker') {
             if (item.contains("JDK${params.jdkVersion}_BRANCH")) {
                 def branchInfo = item.split('=')
                 jdkBranch = branchInfo[1]
-                
             } else if (item.contains("JDK${params.jdkVersion}_OPENJ9_BRANCH")) {
                 def branchInfo = item.split('=')
                 jdkOpenj9Branch = branchInfo[1]


### PR DESCRIPTION
The pattern `[.-_]` matches characters `0x2e` through `0x5f` (which includes `[A-Z]`). I don't think that was the intent; `-` must be escaped (or appear first or last in `[]`).

See also #881 and #888.