### PR TITLE
Revert "Disable nightly testing during Jan 2024 Release"

### DIFF
--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -38,7 +38,7 @@
     },
     "testDetails"            : {
         "enableReproducibleCompare" : false,
-        "enableTests"        : false,
+        "enableTests"        : true,
         "nightlyDefault"     : [
             "sanity.openjdk",
             "sanity.system",


### PR DESCRIPTION
Reverts adoptium/ci-jenkins-pipelines#892