### PR TITLE
Enable arm32/win32 hotspot variant builds

### DIFF
--- a/pipelines/jobs/configurations/jdk23.groovy
+++ b/pipelines/jobs/configurations/jdk23.groovy
@@ -29,6 +29,12 @@ targetConfigurations = [
         ],
         'aarch64Mac': [
                 'temurin'
+        ],
+        'arm32Linux'  : [
+                'hotspot'
+        ],
+        'x32Windows'  : [
+                'hotspot'
         ]
 ]
 


### PR DESCRIPTION
While we no longer ship these at Temurin I believe it is worthwhile to continue to build these for a Hotspot variant in order to allow us to see if the platform is receiving any PRs that break the build that are potentially going to be backported. We've seen this recently for Win32. Since these are hotspot variant builds, they wil lnot be published as nightlies so are only for our own use and allow us to compare functionality between these and other architectures if required.

Another option would be to run these through the evaluation pipeline, but that doesn't feel right since that should be for platforms which we plan to make available.

Related: https://github.com/adoptium/ci-jenkins-pipelines/pull/525

