### PR TITLE
Moving prepare stage to node 'worker' instead of 'Linux/x64'

### DIFF
--- a/tools/reproduce_comparison/Jenkinsfile
+++ b/tools/reproduce_comparison/Jenkinsfile
@@ -3,7 +3,7 @@ Jenkins job does reproducible build compare.
 */
 import groovy.json.JsonOutput
 
-env.NODE_LABEL = 'dockerBuild&&linux&&x64'
+env.NODE_LABEL = 'worker'
 pipeline {
     agent none
     parameters {


### PR DESCRIPTION
Moving prepare stage to node 'worker' instead of 'Linux/x64', which is has more abundant executors than 'linux/x64'.

Close #906 