### PR TITLE
Add linux-riscv64 jdk11u temurin pipeline

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_evaluation.groovy
+++ b/pipelines/jobs/configurations/jdk11u_evaluation.groovy
@@ -2,6 +2,9 @@
 targetConfigurations = [
         'aarch64Windows': [
                 'temurin'
+        ],
+        'riscv64Linux': [
+                'temurin'
         ]
         // 'x64Mac'        : [
         //         'openj9'
@@ -33,10 +36,10 @@ targetConfigurations = [
         // ]
 ]
 
-// if set to empty string then it wont get triggered
-triggerSchedule_evaluation = ''
-// if set to empty string then it wont get triggered
-triggerSchedule_weekly_evaluation= ''
+// 11:30 Tue, Thu
+triggerSchedule_evaluation = 'TZ=UTC\n30 11 * * 2,4'
+// 23:05 Sun
+triggerSchedule_weekly_evaluation = 'TZ=UTC\n05 23 * * 7'
 
 // scmReferences to use for weekly evaluation build
 weekly_evaluation_scmReferences = [

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -180,27 +180,40 @@ class Config11 {
 
         riscv64Linux      :  [
                 os                   : 'linux',
+                arch                 : 'riscv64',
                 dockerImage          : [
+                        'temurin'    : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                         'openj9'     : 'adoptopenjdk/centos6_build_image',
                         'bisheng'    : 'adoptopenjdk/centos6_build_image'
                 ],
-                arch                 : 'riscv64',
+                dockerArgs           : [
+                        'temurin'    : '--platform linux/riscv64'
+                ],
                 crossCompile         : [
+                        'temurin'    : 'dockerhost-rise-ubuntu2204-aarch64-1'
                         'openj9'     : 'x64',
                         'bisheng'    : 'x64'
                 ],
                 buildArgs            : [
+                        'temurin'    : '--create-sbom',
                         'openj9'     : '--cross-compile',
-                        'bisheng'    : '--cross-compile --branch risc-v',
-                        'temurin'    : '--create-sbom'
+                        'bisheng'    : '--cross-compile --branch risc-v'
                 ],
                 configureArgs        : [
+                        'temurin'    : '--enable-headless-only=yes --enable-dtrace',
                         'openj9'     : '--disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root',
                         'bisheng'    : '--openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-jvm-features=shenandoahgc'
                 ],
                 test                : [
-                        nightly: ['sanity.openjdk'],
-                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                        'temurin'   : 'default',
+                        'openj9'    : [
+                                nightly: ['sanity.openjdk'],
+                                weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                        ],
+                        'bisheng'   : [
+                                nightly: ['sanity.openjdk'],
+                                weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                        ]
                 ],
         ],
 


### PR DESCRIPTION
We want to start testing the jdk11u backport, even if it's still in a PR at the moment.