### PR TITLE
Make sure betaTrigger job does not lock worker node

### DIFF
--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -101,7 +101,7 @@ node('worker') {
             overrideEvaluationTargetConfigurations = params.OVERRIDE_EVALUATION_TARGET_CONFIGURATIONS
         }
     }
-}
+} // End: node('worker')
 
 if (triggerMainBuild || triggerEvaluationBuild) {
     // Set version suffix, jdk8 has different mechanism to jdk11+

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -23,8 +23,6 @@ import groovy.json.JsonOutput
   The "Force" option can be used to re-build and re-publish the existing latest build.
 */
 
-node('worker') {
-
     def mirrorRepo="${params.MIRROR_REPO}"
     def version="${params.JDK_VERSION}".toInteger()
     def binariesRepo="https://github.com/${params.BINARIES_REPO}".replaceAll("_NN_", "${version}")
@@ -147,5 +145,4 @@ node('worker') {
 
         parallel jobs
     }
-}
 


### PR DESCRIPTION
betaTrigger job locks the worker node while the build is running, which it should not do
Moved parallel jobs out of worker node context

Test: https://ci.adoptium.net/job/build-scripts/job/utils/job/betaTrigger_8ea/26/console
