### PR TITLE
Allow for . in beta binaries status check of archive EA filename

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -150,7 +150,7 @@ def verifyReleaseContent(String version, String release, String variant, Map sta
                     // Search for artifacts in the releaseAssets list
                     ftypes.each { ftype ->
                         def arch_fname = archToAsset[osarch]
-                        def findAsset = releaseAssets =~/.*${file_image}_${arch_fname}_[^\."]*${ftype}".*/
+                        def findAsset = releaseAssets =~/.*${file_image}_${arch_fname}_[^"]*${ftype}".*/
                         if (!findAsset) {
                             missingForArch.add("$osarch : $image : $ftype".replaceAll("\\\\", ""))
                         } else {


### PR DESCRIPTION
New beta EA filename has "." in the version part of the filename, the nightly_build_and_test_stats.groovy regex needs updating to match it correctly.
 