### PR TITLE
Do not exclude jck tests for Headless platform as no auto-manuals

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -527,6 +527,11 @@ class Build {
 
         def appOptions="customJtx=${excludeRoot}/jenkins/jck_run/jdk${jdkVersion}/${excludePlat}/temurin.jtx"
 
+        if (configureArguments.contains('--enable-headless-only=yes')) {
+            // Headless platforms have no auto-manuals, so do not exclude any tests
+            appOptions=""
+        }
+
         def targets = ['serial': 'sanity.jck,extended.jck,special.jck']
 
         if ("${platform}" == 'x86-64_linux' || "${platform}" == 'x86-64_windows' || "${platform}" == 'x86-64_mac') {


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/919

For headless platforms do not provide a JCK auto-manuals exclude list.

This is checked by checking for the presence of "--enable-headless-only=yes" in the configure args.
