### PR TITLE
Dont build jdk8u mac openj9 in our triggered builds as no macos10.14 nodes

### DIFF
--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -1,7 +1,6 @@
 targetConfigurations = [
         'x64Mac'        : [
-                'temurin',
-                'openj9'
+                'temurin'
         ],
         'x64Linux'      : [
                 'temurin',


### PR DESCRIPTION
The 10.14 MacStadium nodes will be disappearing soon thus we should not try and build openj9 jdk8u mac as that needs 10.14.
