### PR TITLE
postBuild plugin manager only available in postBuild groovy

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -824,6 +824,7 @@ class Builder implements Serializable {
                 releaseToolUrl += "&DRY_RUN=true"
             }
             URLEncoder.encode(releaseToolUrl.toString(), "UTF-8")
+            echo "dryrunReleasePublish: ${releaseComment} : ${releaseToolUrl}"
             return ["${releaseToolUrl}", "${releaseComment}"]
         }
     }
@@ -873,8 +874,10 @@ class Builder implements Serializable {
             context.echo "Force auto generate AQA test jobs: ${aqaAutoGen}"
             context.echo "Keep test reportdir: ${keepTestReportDir}"
             context.echo "Keep release logs: ${keepReleaseLogs}"
-            def releaseSummary = manager.createSummary('next.svg')
-            releaseSummary.appendText('<b>RELEASE PUBLISH BINARIES:</b><ul>', false)
+
+            // Disabling for the moment as "manager" only available in postBuild groovy script
+            //def releaseSummary = manager.createSummary('next.svg')
+            //releaseSummary.appendText('<b>RELEASE PUBLISH BINARIES:</b><ul>', false)
 
             jobConfigurations.each { configuration ->
                 jobs[configuration.key] = {
@@ -968,7 +971,7 @@ class Builder implements Serializable {
 
                                         copyArtifactSuccess = true
                                         def (String releaseToolUrl, String releaseComment) = dryrunReleasePublish(config)
-                                        releaseSummary.appendText("<li><a href=${releaseToolUrl}> ${releaseComment} ${config.VARIANT} ${publishName} ${config.TARGET_OS} ${config.ARCHITECTURE}</a></li>")
+                                        //releaseSummary.appendText("<li><a href=${releaseToolUrl}> ${releaseComment} ${config.VARIANT} ${publishName} ${config.TARGET_OS} ${config.ARCHITECTURE}</a></li>")
                                     }
                             }
                             context.println '[NODE SHIFT] OUT OF CONTROLLER NODE!'
@@ -992,7 +995,7 @@ class Builder implements Serializable {
                 }
             }
             context.parallel jobs
-            releaseSummary.appendText('</ul>', false)
+            //releaseSummary.appendText('</ul>', false)
             // publish to github if needed
             // Don't publish release automatically
             if (publish && !release) {

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -823,8 +823,7 @@ class Builder implements Serializable {
             } else {
                 releaseToolUrl += "&DRY_RUN=true"
             }
-            URLEncoder.encode(releaseToolUrl.toString(), "UTF-8")
-            echo "dryrunReleasePublish: ${releaseComment} : ${releaseToolUrl}"
+            releaseToolUrl = URLEncoder.encode(releaseToolUrl.toString(), "UTF-8")
             return ["${releaseToolUrl}", "${releaseComment}"]
         }
     }
@@ -971,6 +970,7 @@ class Builder implements Serializable {
 
                                         copyArtifactSuccess = true
                                         def (String releaseToolUrl, String releaseComment) = dryrunReleasePublish(config)
+                                        context.echo "dryrunReleasePublish result = ${releaseComment} : ${releaseToolUrl}"
                                         //releaseSummary.appendText("<li><a href=${releaseToolUrl}> ${releaseComment} ${config.VARIANT} ${publishName} ${config.TARGET_OS} ${config.ARCHITECTURE}</a></li>")
                                     }
                             }

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -12,6 +12,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/* groovylint-disable MethodCount */
+
 import common.IndividualBuildConfig
 import groovy.json.*
 


### PR DESCRIPTION
pipeline builds broken as postBuild plugin "manager" is only available in postBuild groovy scripts
https://ci.adoptium.net/job/build-scripts/job/openjdk17-pipeline/899/console
```
hudson.remoting.ProxyException: groovy.lang.MissingPropertyException: No such property: manager for class: Builder
```

I've commented out the build summary annotation for now
 