### PR TITLE
Improves daily Slack build pipeline status when new upstream tags are published

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -56,7 +56,7 @@ def getLatestBinariesTag(String version) {
 }
 
 // Check if a given beta EA pipeline build is inprogress?
-def isBuildInProgress(String pipelineName, String publishName) {
+def isBuildInProgress(String trssUrl, String pipelineName, String publishName) {
     def inProgress = false
 
     def pipeline = sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getBuildHistory?buildName=${pipelineName}")
@@ -550,7 +550,7 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                     // Check latest published binaries are for the latest openjdk build tag
                     if (status['releaseName'] != status['expectedReleaseName']) {
                         def upstreamTagAge    = getOpenjdkBuildTagAge(featureRelease, status['expectedReleaseName'].replaceAll("-ea-beta", ""))
-                        def isBuildInProgress = isBuildInProgress("openjdk${featureReleaseInt}-pipeline", status['expectedReleaseName'].replaceAll("-beta", ""))
+                        def isBuildInProgress = isBuildInProgress(trssUrl, "openjdk${featureReleaseInt}-pipeline", status['expectedReleaseName'].replaceAll("-beta", ""))
                         if (upstreamTagAge > 3 && !isBuildInProgress) {
                             slackColor = 'danger'
                             health = "Unhealthy"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -555,7 +555,7 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                             slackColor = 'danger'
                             health = "Unhealthy"
                             errorMsg = "\nLatest Adoptium publish binaries "+status['releaseName']+" != latest upstream openjdk build "+status['expectedReleaseName']+" published ${upstreamTagAge} days ago. No build is in progress."
-                        else {
+                        } else {
                             errorMsg = "\nLatest upstream openjdk build "+status['expectedReleaseName']+" published ${upstreamTagAge} days ago. Build is in progress."
                         }
                     }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -12,6 +12,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/* groovylint-disable NestedBlockDepth */
+
 import groovy.json.JsonSlurper
 import java.time.LocalDateTime
 import java.time.Instant

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -37,7 +37,7 @@ def getLatestOpenjdkBuildTag(String version) {
 def getOpenjdkBuildTagAge(String version, String tag) {
     def openjdkRepo = "https://github.com/openjdk/${version}.git"
 
-    def date = sh(returnStdout: true, script:"(rm -rf tmpRepo; git clone --depth 1 --branch ${tag} ${openjdkRepo} tmpRepo; cd tmpRepo; git log --tags --simplify-by-decoration --pretty=\"format:PUBLISH_DATE=%cI\") | grep PUBLISH_DATE | cut -d\"=\" -f2" | tr -d '\\n')
+    def date = sh(returnStdout: true, script:"(rm -rf tmpRepo; git clone --depth 1 --branch ${tag} ${openjdkRepo} tmpRepo; cd tmpRepo; git log --tags --simplify-by-decoration --pretty=\"format:PUBLISH_DATE=%cI\") | grep PUBLISH_DATE | cut -d\"=\" -f2 | tr -d '\\n'")
     def tagTs = Instant.parse(date).atZone(ZoneId.of('UTC'))
     def now = ZonedDateTime.now(ZoneId.of('UTC'))
     def days = ChronoUnit.DAYS.between(tagTs, now) 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -549,7 +549,8 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                 } else {
                     // Check latest published binaries are for the latest openjdk build tag
                     if (status['releaseName'] != status['expectedReleaseName']) {
-                        def upstreamTagAge    = getOpenjdkBuildTagAge(featureRelease, status['expectedReleaseName'].replaceAll("-ea-beta", ""))
+                        def upstreamRepoVersion = (featureRelease == tipRelease) ? "jdk" : featureRelease
+                        def upstreamTagAge    = getOpenjdkBuildTagAge(upstreamRepoVersion, status['expectedReleaseName'].replaceAll("-ea-beta", ""))
                         def isBuildInProgress = isBuildInProgress(trssUrl, "openjdk${featureReleaseInt}-pipeline", status['expectedReleaseName'].replaceAll("-beta", ""))
                         if (upstreamTagAge > 3 && !isBuildInProgress) {
                             slackColor = 'danger'

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -551,7 +551,7 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                     if (status['releaseName'] != status['expectedReleaseName']) {
                         def upstreamTagAge    = getOpenjdkBuildTagAge(featureRelease, status['expectedReleaseName'].replaceAll("-ea-beta", ""))
                         def isBuildInProgress = isBuildInProgress("openjdk${featureReleaseInt}-pipeline", status['expectedReleaseName'].replaceAll("-beta", ""))
-                        if (upstreamTagAge > 3 && !isBuildInProgress)
+                        if (upstreamTagAge > 3 && !isBuildInProgress) {
                             slackColor = 'danger'
                             health = "Unhealthy"
                             errorMsg = "\nLatest Adoptium publish binaries "+status['releaseName']+" != latest upstream openjdk build "+status['expectedReleaseName']+" published ${upstreamTagAge} days ago. No build is in progress."

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -559,7 +559,11 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                             health = "Unhealthy"
                             errorMsg = "\nLatest Adoptium publish binaries "+status['releaseName']+" != latest upstream openjdk build "+status['expectedReleaseName']+" published ${upstreamTagAge} days ago. No build is in progress."
                         } else {
-                            errorMsg = "\nLatest upstream openjdk build "+status['expectedReleaseName']+" published ${upstreamTagAge} days ago. Build is in progress."
+                            if (isBuildInProgress) {
+                                errorMsg = "\nLatest upstream openjdk build "+status['expectedReleaseName']+" published ${upstreamTagAge} days ago. Build is in progress."
+                            } else {
+                                errorMsg = "\nLatest upstream openjdk build "+status['expectedReleaseName']+" published ${upstreamTagAge} days ago. Build is awaiting 'trigger'."
+                            }
                         }
                     }
                 }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -601,7 +601,7 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
                 def fullMessage = "${featureRelease} latest pipeline publish status: *${health}*. Build: ${releaseLink}.${lastPublishedMsg}${errorMsg}${missingMsg}"
                 echo "===> ${fullMessage}"
-                //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
+                slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }
             echo '----------------------------------------------------------------'
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -37,7 +37,7 @@ def getLatestOpenjdkBuildTag(String version) {
 def getOpenjdkBuildTagAge(String version, String tag) {
     def openjdkRepo = "https://github.com/openjdk/${version}.git"
 
-    def date = sh(returnStdout: true, script:"(rm -rf tmpRepo; git clone --depth 1 --branch ${tag} ${openjdkRepo} tmpRepo; cd tmpRepo; git log --tags --simplify-by-decoration --pretty=\"format:PUBLISH_DATE=%cI\") | grep PUBLISH_DATE | cut -d\"=\" -f2")
+    def date = sh(returnStdout: true, script:"(rm -rf tmpRepo; git clone --depth 1 --branch ${tag} ${openjdkRepo} tmpRepo; cd tmpRepo; git log --tags --simplify-by-decoration --pretty=\"format:PUBLISH_DATE=%cI\") | grep PUBLISH_DATE | cut -d\"=\" -f2" | tr -d '\\n')
     def tagTs = Instant.parse(date).atZone(ZoneId.of('UTC'))
     def now = ZonedDateTime.now(ZoneId.of('UTC'))
     def days = ChronoUnit.DAYS.between(tagTs, now) 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -74,7 +74,6 @@ def isInProgress(String pipelineName, String publishName) {
             // Is job for the required tag and currently inprogress?
             if (overridePublishName == publishName && job.status != null && job.status.equals('Streaming')) {
                 inProgress = true
-                break
             }
         }
     }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -557,12 +557,12 @@ echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlyS
                         if (upstreamTagAge > 3 && !isBuildInProgress) {
                             slackColor = 'danger'
                             health = "Unhealthy"
-                            errorMsg = "\nLatest Adoptium publish binaries "+status['releaseName']+" != latest upstream openjdk build "+status['expectedReleaseName']+" published ${upstreamTagAge} days ago. No build is in progress."
+                            errorMsg = "\nLatest Adoptium publish binaries "+status['releaseName']+" != latest upstream openjdk build "+status['expectedReleaseName'].replaceAll("-ea-beta", "")+" published ${upstreamTagAge} days ago. No build is in progress."
                         } else {
                             if (isBuildInProgress) {
-                                errorMsg = "\nLatest upstream openjdk build "+status['expectedReleaseName']+" published ${upstreamTagAge} days ago. Build is in progress."
+                                errorMsg = "\nLatest upstream openjdk build "+status['expectedReleaseName'].replaceAll("-ea-beta", "")+" published ${upstreamTagAge} days ago. Build is in progress."
                             } else {
-                                errorMsg = "\nLatest upstream openjdk build "+status['expectedReleaseName']+" published ${upstreamTagAge} days ago. Build is awaiting 'trigger'."
+                                errorMsg = "\nLatest upstream openjdk build "+status['expectedReleaseName'].replaceAll("-ea-beta", "")+" published ${upstreamTagAge} days ago. Build is awaiting 'trigger'."
                             }
                         }
                     }


### PR DESCRIPTION
 To better represent and display the daily Slack build status the following enhancements:

1. If upstream openjdk has published a new build tag then only report "Unhealthy" if:
    - Upstream tag published more than 3 days ago
    - AND there is no current build pipeline in progress
2. If a new upstream openjdk build tag has been published then highlight how long ago, and whether a build is "in progress"

See test output here: https://adoptium.slack.com/archives/C09NW3L2J/p1708101035777459

 