### PR TITLE
Ensure beta EA builds triggered during release periods do not enable Testing

### DIFF
--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -47,6 +47,7 @@ def isDuringReleasePeriod() {
     def releasePeriod = false
     def now = ZonedDateTime.now(ZoneId.of('UTC'))
     def month = now.getMonth()
+month = Month.MARCH
 
     // Is it a release month?
     if (month == Month.JANUARY || month == Month.MARCH || month == Month.APRIL || month == Month.JULY || month == Month.SEPTEMBER || month == Month.OCTOBER) {

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -89,7 +89,7 @@ node('worker') {
     def binariesRepoTag = publishJobTag + "-beta"
 
     if (isDuringReleasePeriod()) {
-        echo "We are within a release period (previous Saturday to the following Sunday around the release Tuesday), so Testing is disabled."
+        echo "We are within a release period (previous Saturday to the following Sunday around the release Tuesday), so testing is disabled."
         enableTesting = false
     }
 

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -35,7 +35,7 @@ def binariesRepo="https://github.com/${params.BINARIES_REPO}".replaceAll("_NN_",
 
 def triggerMainBuild = false
 def triggerEvaluationBuild = false
-def enableTesting = false
+def enableTesting = true
 def overrideMainTargetConfigurations = ""
 def overrideEvaluationTargetConfigurations = ""
 

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -14,6 +14,9 @@ limitations under the License.
 */
 
 import groovy.json.JsonOutput
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.Month
 
 /*
   Detect new upstream OpenJDK source build tag, and trigger a "beta" pipeline build
@@ -52,42 +55,60 @@ node('worker') {
     def binariesRepoTag = publishJobTag + "-beta"
 
     if (!params.FORCE_MAIN && !params.FORCE_EVALUATION) {
-        // Determine this versions potential GA tag, so as to not build and publish a GA version
-        def gaTag
-        def versionStr
-        if (version > 8) {
-            versionStr = latestAdoptTag.substring(0, latestAdoptTag.indexOf("+"))
+        def releasePeriod = false
+        def now = ZonedDateTime.now(ZoneId.of('UTC'))
+        def month = now.getMonth()
+
+        // Release period is between days 10 and 25 of each release month
+        if (month == Month.JANUARY || month == Month.MARCH || month == Month.APRIL || month == Month.JULY || month == Month.SEPTEMBER || month == Month.OCTOBER) {
+            def day = now.getDayOfMonth()
+            if (day >= 10 and day <= 25) {
+                releasePeriod = true
+            }
+        }
+
+        if (releasePeriod) {
+            echo "Not triggering as we are within a release period (days 10-25 of a release month)"
         } else {
-            versionStr = latestAdoptTag.substring(0, latestAdoptTag.indexOf("-"))
-        }
-        gaTag=versionStr+"-ga"
-        echo "Expected GA tag to check for = ${gaTag}"
+            echo "Not within a release period, so okay to trigger if required"
+
+            // Determine this versions potential GA tag, so as to not build and publish a GA version
+            def gaTag
+            def versionStr
+            if (version > 8) {
+                versionStr = latestAdoptTag.substring(0, latestAdoptTag.indexOf("+"))
+            } else {
+                versionStr = latestAdoptTag.substring(0, latestAdoptTag.indexOf("-"))
+            }
+            gaTag=versionStr+"-ga"
+            echo "Expected GA tag to check for = ${gaTag}"
    
-        // If "-ga" tag exists, then we don't want to trigger a MAIN build 
-        def gaTagCheck=sh(script:'git ls-remote --sort=-v:refname --tags "'+mirrorRepo+'" | grep -v "\\^{}" | grep "'+gaTag+'"', returnStatus:true)
-        if (gaTagCheck == 0) {
-            echo "Version "+versionStr+" already has a GA tag so not triggering a MAIN build"
-        }
-
-        // Check binaries repo for existance of the given release?
-        echo "Checking if ${binariesRepoTag} is already published?"
-        def desiredRepoTagURL="${binariesRepo}/releases/tag/${binariesRepoTag}"
-        def httpCode=sh(script:"curl -s -o /dev/null -w '%{http_code}' "+desiredRepoTagURL, returnStdout:true)
-
-        if (httpCode == "200") {
-            echo "Build tag ${binariesRepoTag} is already published - nothing to do"
-        } else if (httpCode == "404") {
-            echo "New unpublished build tag ${binariesRepoTag} - triggering builds"
+            // If "-ga" tag exists, then we don't want to trigger a MAIN build 
+            def gaTagCheck=sh(script:'git ls-remote --sort=-v:refname --tags "'+mirrorRepo+'" | grep -v "\\^{}" | grep "'+gaTag+'"', returnStatus:true)
             if (gaTagCheck == 0) {
                 echo "Version "+versionStr+" already has a GA tag so not triggering a MAIN build"
-            } else {
-                triggerMainBuild = true
             }
-            triggerEvaluationBuild = true
-        } else {
-            def error =  "Unexpected HTTP code ${httpCode} when querying for existing build tag at $desiredRepoTagURL"
-            echo "${error}"
-           throw new Exception("${error}")
+
+            // Check binaries repo for existance of the given release?
+            echo "Checking if ${binariesRepoTag} is already published?"
+            def desiredRepoTagURL="${binariesRepo}/releases/tag/${binariesRepoTag}"
+            def httpCode=sh(script:"curl -s -o /dev/null -w '%{http_code}' "+desiredRepoTagURL, returnStdout:true)
+
+            if (httpCode == "200") {
+                echo "Build tag ${binariesRepoTag} is already published - nothing to do"
+            } else if (httpCode == "404") {
+                echo "New unpublished build tag ${binariesRepoTag} - triggering builds"
+                if (gaTagCheck == 0) {
+                    echo "Version "+versionStr+" already has a GA tag so not triggering a MAIN build"
+                } else {
+                    triggerMainBuild = true
+                }
+                triggerEvaluationBuild = true
+            } else {
+                def error =  "Unexpected HTTP code ${httpCode} when querying for existing build tag at $desiredRepoTagURL"
+                echo "${error}"
+               throw new Exception("${error}")
+            }
         }
     } else {
         echo "FORCE triggering specified builds.."

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -60,7 +60,7 @@ node('worker') {
     if (!params.FORCE_MAIN && !params.FORCE_EVALUATION) {
         def releasePeriod = false
         def now = ZonedDateTime.now(ZoneId.of('UTC'))
-now = now.withMonth(4)
+now = now.withMonth(5)
         def month = now.getMonth()
 
         // Release period is between days 10 and 25 of each release month

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -102,14 +102,14 @@ node('worker') {
         }
         gaTag=versionStr+"-ga"
         echo "Expected GA tag to check for = ${gaTag}"
-
+    
         // If "-ga" tag exists, then we don't want to trigger a MAIN build 
         def gaTagCheck=sh(script:'git ls-remote --sort=-v:refname --tags "'+mirrorRepo+'" | grep -v "\\^{}" | grep "'+gaTag+'"', returnStatus:true)
         if (gaTagCheck == 0) {
             echo "Version "+versionStr+" already has a GA tag so not triggering a MAIN build"
         }
 
-        // Check binaries repo for existance of the given release
+        // Check binaries repo for existance of the given release?
         echo "Checking if ${binariesRepoTag} is already published?"
         def desiredRepoTagURL="${binariesRepo}/releases/tag/${binariesRepoTag}"
         def httpCode=sh(script:"curl -s -o /dev/null -w '%{http_code}' "+desiredRepoTagURL, returnStdout:true)

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -65,13 +65,13 @@ now = now.withMonth(3)
 
         // Release period is between days 10 and 25 of each release month
         if (month == Month.JANUARY || month == Month.MARCH || month == Month.APRIL || month == Month.JULY || month == Month.SEPTEMBER || month == Month.OCTOBER) {
-            def day = now.getDayOfMonth()
-            def dayOfWeek17th = now.withDayOfMonth(17).getDayOfWeek()
+            def day17th = now.withDayOfMonth(17)
+            def dayOfWeek17th = day17th.getDayOfWeek()
             def releaseDay
             if (dayOfWeek17th == DayOfWeek.SATURDAY || dayOfWeek17th == DayOfWeek.SUNDAY || dayOfWeek17th == DayOfWeek.MONDAY || dayOfWeek17th == DayOfWeek.TUESDAY) {
-                releaseDay = dayOfWeek17th.with(TemporalAdjusters.nextOrSame(DayOfWeek.TUESDAY))
+                releaseDay = day17th.with(TemporalAdjusters.nextOrSame(DayOfWeek.TUESDAY))
             } else {
-                releaseDay = dayOfWeek17th.with(TemporalAdjusters.previous(DayOfWeek.TUESDAY))
+                releaseDay = day17th.with(TemporalAdjusters.previous(DayOfWeek.TUESDAY))
             }
 echo "release day = " + releaseDay
             def days = ChronoUnit.DAYS.between(releaseDay, now)

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -49,7 +49,8 @@ def isDuringReleasePeriod() {
     def now = ZonedDateTime.now(ZoneId.of('UTC'))
     def month = now.getMonth()
 
-    // Is it a release month?
+    // Is it a release month? CPU updates in Jan, Apr, Jul, Oct
+    // New major versions are released in Mar and Sept
     if (month == Month.JANUARY || month == Month.MARCH || month == Month.APRIL || month == Month.JULY || month == Month.SEPTEMBER || month == Month.OCTOBER) {
         // Yes, calculate release Tuesday, which is the closest Tuesday to the 17th
         def day17th = now.withDayOfMonth(17)

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -60,7 +60,7 @@ node('worker') {
     if (!params.FORCE_MAIN && !params.FORCE_EVALUATION) {
         def releasePeriod = false
         def now = ZonedDateTime.now(ZoneId.of('UTC'))
-now = now.withMonth(Month.MARCH)
+now = now.withMonth(3)
         def month = now.getMonth()
 
         // Release period is between days 10 and 25 of each release month

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -60,7 +60,7 @@ node('worker') {
     if (!params.FORCE_MAIN && !params.FORCE_EVALUATION) {
         def releasePeriod = false
         def now = ZonedDateTime.now(ZoneId.of('UTC'))
-now = now.withMonth(3)
+now = now.withMonth(4)
         def month = now.getMonth()
 
         // Release period is between days 10 and 25 of each release month

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -47,7 +47,6 @@ def isDuringReleasePeriod() {
     def releasePeriod = false
     def now = ZonedDateTime.now(ZoneId.of('UTC'))
     def month = now.getMonth()
-month = Month.OCTOBER
 
     // Is it a release month?
     if (month == Month.JANUARY || month == Month.MARCH || month == Month.APRIL || month == Month.JULY || month == Month.SEPTEMBER || month == Month.OCTOBER) {

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -19,7 +19,7 @@ import java.time.ZonedDateTime
 import java.time.Month
 import java.time.DayOfWeek
 import java.time.temporal.ChronoUnit
-import java.time.temporal.TemporalAdjuster
+import java.time.temporal.TemporalAdjusters
 
 /*
   Detect new upstream OpenJDK source build tag, and trigger a "beta" pipeline build

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -47,7 +47,7 @@ def isDuringReleasePeriod() {
     def releasePeriod = false
     def now = ZonedDateTime.now(ZoneId.of('UTC'))
     def month = now.getMonth()
-month = Month.MARCH
+month = Month.OCTOBER
 
     // Is it a release month?
     if (month == Month.JANUARY || month == Month.MARCH || month == Month.APRIL || month == Month.JULY || month == Month.SEPTEMBER || month == Month.OCTOBER) {
@@ -89,7 +89,7 @@ node('worker') {
 
     if (!params.FORCE_MAIN && !params.FORCE_EVALUATION) {
         if (isDuringReleasePeriod()) {
-            echo "Not triggering as we are within a release period (previsous Sat to the following Sun around the release Tue)"
+            echo "Not triggering as we are within a release period (previous Saturday to the following Sunday around the release Tuesday)"
         } else {
             echo "Not within a release period, so okay to trigger if required"
 

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -102,7 +102,7 @@ node('worker') {
         }
         gaTag=versionStr+"-ga"
         echo "Expected GA tag to check for = ${gaTag}"
-    
+   
         // If "-ga" tag exists, then we don't want to trigger a MAIN build 
         def gaTagCheck=sh(script:'git ls-remote --sort=-v:refname --tags "'+mirrorRepo+'" | grep -v "\\^{}" | grep "'+gaTag+'"', returnStatus:true)
         if (gaTagCheck == 0) {

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -62,7 +62,7 @@ node('worker') {
         // Release period is between days 10 and 25 of each release month
         if (month == Month.JANUARY || month == Month.MARCH || month == Month.APRIL || month == Month.JULY || month == Month.SEPTEMBER || month == Month.OCTOBER) {
             def day = now.getDayOfMonth()
-            if (day >= 10 and day <= 25) {
+            if (day >= 10 && day <= 25) {
                 releasePeriod = true
             }
         }

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -60,7 +60,7 @@ node('worker') {
     if (!params.FORCE_MAIN && !params.FORCE_EVALUATION) {
         def releasePeriod = false
         def now = ZonedDateTime.now(ZoneId.of('UTC'))
-now = now.withMonth(5)
+now = now.withMonth(7)
         def month = now.getMonth()
 
         // Release period is between days 10 and 25 of each release month

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -35,7 +35,7 @@ def binariesRepo="https://github.com/${params.BINARIES_REPO}".replaceAll("_NN_",
 
 def triggerMainBuild = false
 def triggerEvaluationBuild = false
-def enableTesting = true
+def enableTesting = false
 def overrideMainTargetConfigurations = ""
 def overrideEvaluationTargetConfigurations = ""
 


### PR DESCRIPTION
During release periods:
**previous Saturday to the following Sunday around the release Tuesday of Jan, March, Apr, Jul, Sep, Oct**
do not enable Testing for triggered beta EA builds

Upstream release day is the closest Tuesday to the 17th of the month.

