### PR TITLE
Enable betaTrigger_8u(arm32Linux & x64AlpineLinux) job triggering from the fork mirrors and enable Slack status

### DIFF
--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -205,7 +205,7 @@ if (triggerMainBuild || triggerEvaluationBuild) {
         if (!mainTargetConfigurations) {
             def error =  "Empty mainTargetConfigurations"
             echo "${error}"
-            throw new Exception("${error}
+            throw new Exception("${error}")
         }
     }
     if (triggerEvaluationBuild) {
@@ -213,7 +213,7 @@ if (triggerMainBuild || triggerEvaluationBuild) {
         if (!evaluationTargetConfigurations) {
             def error =  "Empty evaluationTargetConfigurations"
             echo "${error}"
-            throw new Exception("${error}
+            throw new Exception("${error}")
         }
     }
 

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -195,11 +195,23 @@ node('worker') {
         // Load the targetConfigurations
         if (triggerMainBuild && mainTargetConfigurations == "") {
             // Load "main" targetConfigurations from pipeline config
-            mainTargetConfigurations = loadTargetConfigurations((String)version, variant, "", ignore_platforms)
+            def config = loadTargetConfigurations((String)version, variant, "", ignore_platforms)
+            if (!config) {
+                def error =  "Empty mainTargetConfigurations"
+                echo "${error}"
+                throw new Exception("${error}")
+            }       
+            mainTargetConfigurations = JsonOutput.toJson(config)
         }
         if (triggerEvaluationBuild && evaluationTargetConfigurations == "") {
             // Load "evaluation" targetConfigurations from pipeline config
-            evaluationTargetConfigurations = loadTargetConfigurations((String)version, variant, "_evaluation", ignore_platforms)
+            def config = loadTargetConfigurations((String)version, variant, "_evaluation", ignore_platforms)
+            if (!config) {
+                def error =  "Empty evaluationTargetConfigurations"
+                echo "${error}"
+                throw new Exception("${error}")
+            }
+            evaluationTargetConfigurations = JsonOutput.toJson(config) 
         }
     }
 } // End: node('worker')
@@ -214,19 +226,9 @@ if (triggerMainBuild || triggerEvaluationBuild) {
 
     if (triggerMainBuild) {
         pipelines["main"] = "build-scripts/openjdk${version}-pipeline"
-        if (!mainTargetConfigurations) {
-            def error =  "Empty mainTargetConfigurations"
-            echo "${error}"
-            throw new Exception("${error}")
-        }
     }
     if (triggerEvaluationBuild) {
         pipelines["evaluation"] = "build-scripts/evaluation-openjdk${version}-pipeline"
-        if (!evaluationTargetConfigurations) {
-            def error =  "Empty evaluationTargetConfigurations"
-            echo "${error}"
-            throw new Exception("${error}")
-        }
     }
 
     pipelines.keySet().each { pipeline_type ->

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -40,7 +40,7 @@ def triggerEvaluationBuild = false
 def enableTesting = true
 def overrideMainTargetConfigurations = params.OVERRIDE_MAIN_TARGET_CONFIGURATIONS
 def overrideEvaluationTargetConfigurations = params.OVERRIDE_EVALUATION_TARGET_CONFIGURATIONS
-def ignore_platforms = "${params.IGNORE_PLATFORMS}".split("[, ]+") // platforms not to build
+def ignore_platforms = "${params.IGNORE_PLATFORMS}" // platforms not to build
 
 def latestAdoptTag
 def publishJobTag
@@ -76,7 +76,8 @@ def isDuringReleasePeriod() {
 }
 
 // Load the given targetConfigurations from the pipeline config
-def loadTargetConfigurations(String javaVersion, String variant, String configSet, List ignore_platforms) {
+def loadTargetConfigurations(String javaVersion, String variant, String configSet, String ignore_platforms) {
+    def to_be_ignored = ignore_platforms.split("[, ]+")
     def target
     targetConfigurations = null
     try {
@@ -95,7 +96,7 @@ def loadTargetConfigurations(String javaVersion, String variant, String configSe
     def targetConfigurationsForVariant = [:]
     if (targetConfigurations != null) {
         targetConfigurations.each { platform ->
-            if (platform.contains(variant) && !ignore_platforms.contains(platform.key)) {
+            if (platform.contains(variant) && !to_be_ignored.contains(platform.key)) {
                 targetConfigurationsForVariant[platform.key] = [variant]
             }
         }

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -112,7 +112,7 @@ def loadTargetConfigurations(String javaVersion, String variant, String configSe
 
     println "targetConfigurations for variant ${variant} = " + JsonOutput.prettyPrint(JsonOutput.toJson(targetConfigurationsForVariant))
 
-    return JsonOutput.toJson(targetConfigurationsForVariant)
+    return targetConfigurationsForVariant
 }
 
 node('worker') {
@@ -247,10 +247,10 @@ if (triggerMainBuild || triggerEvaluationBuild) {
 
                     // Specify the required targetConfigurations
                     if (pipeline_type == "main") {
-                        jobParams.add(text(name: 'targetConfigurations',     JsonOutput.prettyPrint(mainTargetConfigurations)))
+                        jobParams.add(text(name: 'targetConfigurations',   value: JsonOutput.prettyPrint(mainTargetConfigurations)))
                     }
                     if (pipeline_type == "evaluation") {
-                        jobParams.add(text(name: 'targetConfigurations',     JsonOutput.prettyPrint(evaluationTargetConfigurations)))
+                        jobParams.add(text(name: 'targetConfigurations',   value: JsonOutput.prettyPrint(evaluationTargetConfigurations)))
                     }
 
                     def job = build job: "${pipeline}", propagate: true, parameters: jobParams

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -194,7 +194,7 @@ node('worker') {
         }
         if (triggerEvaluationBuild && evaluationTargetConfigurations == "") {
             // Load "evaluation" targetConfigurations from pipeline config
-            evaluationTargetConfigurations = loadTargetConfigurations(version, variant, "_evaluation", ignore_platforms)
+            evaluationTargetConfigurations = loadTargetConfigurations(version, variant, "_evaluation", (String)ignore_platforms)
         }
     }
 } // End: node('worker')

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -104,7 +104,7 @@ def loadTargetConfigurations(String javaVersion, String variant, String configSe
     def targetConfigurationsForVariant = [:]
     if (targetConfigurations != null) {
         targetConfigurations.each { platform ->
-            if (platform.contains(variant) && !to_be_ignored.contains(platform.key)) {
+            if (platform.value.contains(variant) && !to_be_ignored.contains(platform.key)) {
                 targetConfigurationsForVariant[platform.key] = [variant]
             }
         }

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -99,6 +99,7 @@ def loadTargetConfigurations(String javaVersion, String variant, String configSe
     if (rc == 0) {
         // We successfully downloaded the pipeline config file, now load it into groovy to set targetConfigurations..
         load configFile
+        echo "Successfully loaded ${targetConfigPath}/${configFile}"
     }
 
     def targetConfigurationsForVariant = [:]
@@ -109,8 +110,6 @@ def loadTargetConfigurations(String javaVersion, String variant, String configSe
             }
         }
     }
-
-    println "targetConfigurations for variant ${variant} = " + JsonOutput.prettyPrint(JsonOutput.toJson(targetConfigurationsForVariant))
 
     return targetConfigurationsForVariant
 }
@@ -226,9 +225,13 @@ if (triggerMainBuild || triggerEvaluationBuild) {
 
     if (triggerMainBuild) {
         pipelines["main"] = "build-scripts/openjdk${version}-pipeline"
+        echo "main build targetConfigurations:"
+        echo JsonOutput.prettyPrint(mainTargetConfigurations)
     }
     if (triggerEvaluationBuild) {
         pipelines["evaluation"] = "build-scripts/evaluation-openjdk${version}-pipeline"
+        echo "evaluation build targetConfigurations:"
+        echo JsonOutput.prettyPrint(evaluationTargetConfigurations)
     }
 
     pipelines.keySet().each { pipeline_type ->

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -242,10 +242,10 @@ if (triggerMainBuild || triggerEvaluationBuild) {
 
                     // Specify the required targetConfigurations
                     if (pipeline_type == "main") {
-                        jobParams.add(text(name: 'targetConfigurations',     value: JsonOutput.prettyPrint(mainTargetConfigurations)))
+                        jobParams.add(text(name: 'targetConfigurations',     value: JsonOutput.prettyPrint(JsonOutput.toJson(mainTargetConfigurations))))
                     }
                     if (pipeline_type == "evaluation") {
-                        jobParams.add(text(name: 'targetConfigurations',     value: JsonOutput.prettyPrint(evaluationTargetConfigurations)))
+                        jobParams.add(text(name: 'targetConfigurations',     value: JsonOutput.prettyPrint(JsonOutput.toJson(evaluationTargetConfigurations))))
                     }
 
                     def job = build job: "${pipeline}", propagate: true, parameters: jobParams

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import java.nio.file.NoSuchFileException
 import groovy.json.JsonOutput
 import java.time.ZoneId
 import java.time.ZonedDateTime

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -80,19 +80,21 @@ def isDuringReleasePeriod() {
 
 // Load the given targetConfigurations from the pipeline config
 def loadTargetConfigurations(String javaVersion, String variant, String configSet, String ignore_platforms) {
+    def targetConfigPath = "${params.BUILD_CONFIG_URL}"
+
     def to_be_ignored = ignore_platforms.split("[, ]+")
     def target
     targetConfigurations = null
     try {
-        target = load "${WORKSPACE}/pipelines/jobs/configurations/jdk${javaVersion}${configSet}.groovy"
+        target = load "${targetConfigPath}/jdk${javaVersion}${configSet}.groovy"
         targetConfigurations = target.targetConfigurations
     } catch (NoSuchFileException e) {
         try {
-            println "[WARNING] ${WORKSPACE}/pipelines/jobs/configurations/jdk${javaVersion}${configSet}.groovy does not exist. Trying jdk${javaVersion}u${configSet}.groovy"
-            target = load "${WORKSPACE}/pipelines/jobs/configurations/jdk${javaVersion}u${configSet}.groovy"
+            println "[WARNING] ${targetConfigPath}/jdk${javaVersion}${configSet}.groovy does not exist. Trying jdk${javaVersion}u${configSet}.groovy"
+            target = load "${params.BUILD_CONFIG_URL}/jdk${javaVersion}u${configSet}.groovy"
             targetConfigurations = target.targetConfigurations
         } catch (NoSuchFileException e2) {
-            println "[ERROR] ${WORKSPACE}/pipelines/jobs/configurations/jdk${javaVersion}u${configSet}.groovy does not exist, unable to load targetConfigurations"
+            println "[ERROR] ${params.BUILD_CONFIG_URL}/jdk${javaVersion}u${configSet}.groovy does not exist, unable to load targetConfigurations"
         }
     }
 

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -247,10 +247,10 @@ if (triggerMainBuild || triggerEvaluationBuild) {
 
                     // Specify the required targetConfigurations
                     if (pipeline_type == "main") {
-                        jobParams.add(text(name: 'targetConfigurations',     value: JsonOutput.prettyPrint(JsonOutput.toJson(mainTargetConfigurations))))
+                        jobParams.add(text(name: 'targetConfigurations',     value: mainTargetConfigurations))
                     }
                     if (pipeline_type == "evaluation") {
-                        jobParams.add(text(name: 'targetConfigurations',     value: JsonOutput.prettyPrint(JsonOutput.toJson(evaluationTargetConfigurations))))
+                        jobParams.add(text(name: 'targetConfigurations',     value: evaluationTargetConfigurations))
                     }
 
                     def job = build job: "${pipeline}", propagate: true, parameters: jobParams

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -88,11 +88,11 @@ def loadTargetConfigurations(String javaVersion, String variant, String configSe
         targetConfigurations = target.targetConfigurations
     } catch (NoSuchFileException e) {
         try {
-            println "[WARNING] jdk${javaVersion}${configSet}.groovy does not exist. Trying jdk${javaVersion}u${configSet}.groovy"
+            println "[WARNING] ${WORKSPACE}/pipelines/jobs/configurations/jdk${javaVersion}${configSet}.groovy does not exist. Trying jdk${javaVersion}u${configSet}.groovy"
             target = load "${WORKSPACE}/pipelines/jobs/configurations/jdk${javaVersion}u${configSet}.groovy"
             targetConfigurations = target.targetConfigurations
         } catch (NoSuchFileException e2) {
-            println "[ERROR] jdk${javaVersion}u${configSet}.groovy does not exist, unable to load targetConfigurations"
+            println "[ERROR] ${WORKSPACE}/pipelines/jobs/configurations/jdk${javaVersion}u${configSet}.groovy does not exist, unable to load targetConfigurations"
         }
     }
 

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -112,7 +112,7 @@ def loadTargetConfigurations(String javaVersion, String variant, String configSe
 
     println "targetConfigurations for variant ${variant} = " + JsonOutput.prettyPrint(JsonOutput.toJson(targetConfigurationsForVariant))
 
-    return targetConfigurationsForVariant
+    return JsonOutput.toJson(targetConfigurationsForVariant)
 }
 
 node('worker') {
@@ -247,10 +247,10 @@ if (triggerMainBuild || triggerEvaluationBuild) {
 
                     // Specify the required targetConfigurations
                     if (pipeline_type == "main") {
-                        jobParams.add(text(name: 'targetConfigurations',     JsonOutput.prettyPrint(JsonOutput.toJson(mainTargetConfigurations))))
+                        jobParams.add(text(name: 'targetConfigurations',     JsonOutput.prettyPrint(mainTargetConfigurations)))
                     }
                     if (pipeline_type == "evaluation") {
-                        jobParams.add(text(name: 'targetConfigurations',     JsonOutput.prettyPrint(JsonOutput.toJson(evaluationTargetConfigurations))))
+                        jobParams.add(text(name: 'targetConfigurations',     JsonOutput.prettyPrint(evaluationTargetConfigurations)))
                     }
 
                     def job = build job: "${pipeline}", propagate: true, parameters: jobParams

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -86,11 +86,11 @@ def loadTargetConfigurations(String javaVersion, String variant, String configSe
     targetConfigurations = null
 
     configFile = "jdk${javaVersion}${configSet}.groovy"
-    def rc = sh(script: "curl -LO ${targetConfigPath}/${configFile}", returnStatus: true)
+    def rc = sh(script: "curl --fail -LO ${targetConfigPath}/${configFile}", returnStatus: true)
     if (rc != 0) {
         echo "Error loading ${targetConfigPath}/${configFile}, trying ${targetConfigPath}/jdk${javaVersion}u${configSet}.groovy"
         configFile = "jdk${javaVersion}u${configSet}.groovy"
-        rc = sh(script: "curl -LO ${targetConfigPath}/${configFile}", returnStatus: true)
+        rc = sh(script: "curl --fail -LO ${targetConfigPath}/${configFile}", returnStatus: true)
         if (rc != 0) {
             echo "Error loading ${targetConfigPath}/${configFile}"
         }

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -169,7 +169,7 @@ node('worker') {
         } else {
             def error =  "Unexpected HTTP code ${httpCode} when querying for existing build tag at $desiredRepoTagURL"
             echo "${error}"
-           throw new Exception("${error}")
+            throw new Exception("${error}")
         }
     } else {
         echo "FORCE triggering specified builds.."
@@ -202,9 +202,19 @@ if (triggerMainBuild || triggerEvaluationBuild) {
 
     if (triggerMainBuild) {
         pipelines["main"] = "build-scripts/openjdk${version}-pipeline"
+        if (!mainTargetConfigurations) {
+            def error =  "Empty mainTargetConfigurations"
+            echo "${error}"
+            throw new Exception("${error}
+        }
     }
     if (triggerEvaluationBuild) {
         pipelines["evaluation"] = "build-scripts/evaluation-openjdk${version}-pipeline"
+        if (!evaluationTargetConfigurations) {
+            def error =  "Empty evaluationTargetConfigurations"
+            echo "${error}"
+            throw new Exception("${error}
+        }
     }
 
     pipelines.keySet().each { pipeline_type ->

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -183,11 +183,11 @@ node('worker') {
         def evaluationTargetConfigurations = overrideEvaluationTargetConfigurations
         if (mainTargetConfigurations == "") {
             // Load "main" targetConfigurations from pipeline config
-            mainTargetConfigurations = loadTargetConfigurations(version, variant, "", ignore_platforms)
+            mainTargetConfigurations = loadTargetConfigurations((String)version, (String)variant, (String)"", (String)ignore_platforms)
         }
         if (evaluationTargetConfigurations == "") {
             // Load "evaluation" targetConfigurations from pipeline config
-            evaluationTargetConfigurations = loadTargetConfigurations(version, variant, "_evaluation", ignore_platforms)
+            evaluationTargetConfigurations = loadTargetConfigurations((String)version, (String)variant, (String)"_evaluation", (String)ignore_platforms)
         }
     }
 } // End: node('worker')

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -190,11 +190,11 @@ node('worker') {
         // Load the targetConfigurations
         if (triggerMainBuild && mainTargetConfigurations == "") {
             // Load "main" targetConfigurations from pipeline config
-            mainTargetConfigurations = loadTargetConfigurations((String)version, (String)variant, (String)"", (String)ignore_platforms)
+            mainTargetConfigurations = loadTargetConfigurations((String)version, variant, "", ignore_platforms)
         }
         if (triggerEvaluationBuild && evaluationTargetConfigurations == "") {
             // Load "evaluation" targetConfigurations from pipeline config
-            evaluationTargetConfigurations = loadTargetConfigurations(version, variant, "_evaluation", (String)ignore_platforms)
+            evaluationTargetConfigurations = loadTargetConfigurations((String)version, variant, "_evaluation", ignore_platforms)
         }
     }
 } // End: node('worker')
@@ -240,12 +240,12 @@ if (triggerMainBuild || triggerEvaluationBuild) {
                             string(name: 'additionalConfigureArgs', value: "$additionalConfigureArgs")
                         ]
 
-                    // Override targetConfigurations if specified
-                    if (pipeline_type == "main" && overrideMainTargetConfigurations != "") {
-                        jobParams.add(text(name: 'targetConfigurations',     value: JsonOutput.prettyPrint(overrideMainTargetConfigurations)))
+                    // Specify the required targetConfigurations
+                    if (pipeline_type == "main") {
+                        jobParams.add(text(name: 'targetConfigurations',     value: JsonOutput.prettyPrint(mainTargetConfigurations)))
                     }
-                    if (pipeline_type == "evaluation" && overrideEvaluationTargetConfigurations != "") {
-                        jobParams.add(text(name: 'targetConfigurations',     value: JsonOutput.prettyPrint(overrideEvaluationTargetConfigurations)))
+                    if (pipeline_type == "evaluation") {
+                        jobParams.add(text(name: 'targetConfigurations',     value: JsonOutput.prettyPrint(evaluationTargetConfigurations)))
                     }
 
                     def job = build job: "${pipeline}", propagate: true, parameters: jobParams

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -185,15 +185,16 @@ node('worker') {
         triggerEvaluationBuild = params.FORCE_EVALUATION
     }
 
+    // If we are going to trigger, then load the targetConfigurations
     if (triggerMainBuild || triggerEvaluationBuild) {
         // Load the targetConfigurations
-        if (mainTargetConfigurations == "") {
+        if (triggerMainBuild && mainTargetConfigurations == "") {
             // Load "main" targetConfigurations from pipeline config
             mainTargetConfigurations = loadTargetConfigurations((String)version, (String)variant, (String)"", (String)ignore_platforms)
         }
-        if (evaluationTargetConfigurations == "") {
+        if (triggerEvaluationBuild && evaluationTargetConfigurations == "") {
             // Load "evaluation" targetConfigurations from pipeline config
-            evaluationTargetConfigurations = loadTargetConfigurations((String)version, (String)variant, (String)"_evaluation", (String)ignore_platforms)
+            evaluationTargetConfigurations = loadTargetConfigurations(version, variant, "_evaluation", ignore_platforms)
         }
     }
 } // End: node('worker')

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -176,21 +176,23 @@ node('worker') {
         triggerMainBuild = params.FORCE_MAIN
         triggerEvaluationBuild = params.FORCE_EVALUATION
     }
+
+    if (triggerMainBuild || triggerEvaluationBuild) {
+        // Load the targetConfigurations
+        def mainTargetConfigurations       = overrideMainTargetConfigurations
+        def evaluationTargetConfigurations = overrideEvaluationTargetConfigurations
+        if (mainTargetConfigurations == "") {
+            // Load "main" targetConfigurations from pipeline config
+            mainTargetConfigurations = loadTargetConfigurations(version, variant, "", ignore_platforms)
+        }
+        if (evaluationTargetConfigurations == "") {
+            // Load "evaluation" targetConfigurations from pipeline config
+            evaluationTargetConfigurations = loadTargetConfigurations(version, variant, "_evaluation", ignore_platforms)
+        }
+    }
 } // End: node('worker')
 
 if (triggerMainBuild || triggerEvaluationBuild) {
-    // Load the targetConfigurations
-    def mainTargetConfigurations       = overrideMainTargetConfigurations
-    def evaluationTargetConfigurations = overrideEvaluationTargetConfigurations
-    if (mainTargetConfigurations == "") {
-        // Load "main" targetConfigurations from pipeline config
-        mainTargetConfigurations = loadTargetConfigurations(version, variant, "", ignore_platforms)
-    }
-    if (evaluationTargetConfigurations == "") {
-        // Load "evaluation" targetConfigurations from pipeline config
-        evaluationTargetConfigurations = loadTargetConfigurations(version, variant, "_evaluation", ignore_platforms)
-    }
-
     // Set version suffix, jdk8 has different mechanism to jdk11+
     def additionalConfigureArgs = (version > 8) ? "--with-version-opt=ea" : ""
 

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -118,7 +118,7 @@ def loadTargetConfigurations(String javaVersion, String variant, String configSe
 node('worker') {
     def adopt_tag_search = 'grep "_adopt"'
     if (mirrorRepo.contains("aarch32-jdk8u")) {
-        adopt_tag_search = adopt_tag_search + ' | grep "-aarch32-"'
+        adopt_tag_search = adopt_tag_search + ' | grep "\\-aarch32\\-"'
     }
 
     // Find latest _adopt tag for this version?

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -247,10 +247,10 @@ if (triggerMainBuild || triggerEvaluationBuild) {
 
                     // Specify the required targetConfigurations
                     if (pipeline_type == "main") {
-                        jobParams.add(text(name: 'targetConfigurations',     JsonOutput.toJson(mainTargetConfigurations)))
+                        jobParams.add(text(name: 'targetConfigurations',     JsonOutput.prettyPrint(JsonOutput.toJson(mainTargetConfigurations))))
                     }
                     if (pipeline_type == "evaluation") {
-                        jobParams.add(text(name: 'targetConfigurations',     JsonOutput.toJson(evaluationTargetConfigurations)))
+                        jobParams.add(text(name: 'targetConfigurations',     JsonOutput.prettyPrint(JsonOutput.toJson(evaluationTargetConfigurations))))
                     }
 
                     def job = build job: "${pipeline}", propagate: true, parameters: jobParams

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -85,14 +85,14 @@ def loadTargetConfigurations(String javaVersion, String variant, String configSe
     def to_be_ignored = ignore_platforms.split("[, ]+")
     targetConfigurations = null
 
-    configFile = "${targetConfigPath}/jdk${javaVersion}${configSet}.groovy"
-    def rc = sh(script: "curl -LO ${configFile}", returnStatus: true)
+    configFile = "jdk${javaVersion}${configSet}.groovy"
+    def rc = sh(script: "curl -LO ${targetConfigPath}/${configFile}", returnStatus: true)
     if (rc != 0) {
-        echo "Error loading ${configFile}, trying ${targetConfigPath}/jdk${javaVersion}u${configSet}.groovy"
-        configFile = "${targetConfigPath}/jdk${javaVersion}u${configSet}.groovy"
-        rc = sh(script: "curl -LO ${configFile}", returnStatus: true)
+        echo "Error loading ${targetConfigPath}/${configFile}, trying ${targetConfigPath}/jdk${javaVersion}u${configSet}.groovy"
+        configFile = "jdk${javaVersion}u${configSet}.groovy"
+        rc = sh(script: "curl -LO ${targetConfigPath}/${configFile}", returnStatus: true)
         if (rc != 0) {
-            echo "Error loading ${configFile}"
+            echo "Error loading ${targetConfigPath}/${configFile}"
         }
     }
 

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -247,10 +247,10 @@ if (triggerMainBuild || triggerEvaluationBuild) {
 
                     // Specify the required targetConfigurations
                     if (pipeline_type == "main") {
-                        jobParams.add(text(name: 'targetConfigurations',     value: mainTargetConfigurations))
+                        jobParams.add(text(name: 'targetConfigurations',     JsonOutput.toJson(mainTargetConfigurations)))
                     }
                     if (pipeline_type == "evaluation") {
-                        jobParams.add(text(name: 'targetConfigurations',     value: evaluationTargetConfigurations))
+                        jobParams.add(text(name: 'targetConfigurations',     JsonOutput.toJson(evaluationTargetConfigurations)))
                     }
 
                     def job = build job: "${pipeline}", propagate: true, parameters: jobParams

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -131,7 +131,12 @@ node('worker') {
     echo "Latest Adoptium tag from ${mirrorRepo} = ${latestAdoptTag}"
 
     // publishJobTag is TAG that gets passed to the Adoptium "publish job"
-    publishJobTag = latestAdoptTag.replaceAll("_adopt","-ea")
+    if (mirrorRepo.contains("aarch32-jdk8u")) {
+        publishJobTag = latestAdoptTag.substring(0, latestAdoptTag.indexOf("-aarch32"))+"-ea"
+    } else {
+        publishJobTag = latestAdoptTag.replaceAll("_adopt","-ea")
+    }
+    echo "publishJobTag = ${publishJobTag}"
 
     // binariesRepoTag is the resulting published github binaries release tag created by the Adoptium "publish job"
     def binariesRepoTag = publishJobTag + "-beta"

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -42,6 +42,9 @@ def overrideMainTargetConfigurations = params.OVERRIDE_MAIN_TARGET_CONFIGURATION
 def overrideEvaluationTargetConfigurations = params.OVERRIDE_EVALUATION_TARGET_CONFIGURATIONS
 def ignore_platforms = "${params.IGNORE_PLATFORMS}" // platforms not to build
 
+def mainTargetConfigurations       = overrideMainTargetConfigurations
+def evaluationTargetConfigurations = overrideEvaluationTargetConfigurations
+
 def latestAdoptTag
 def publishJobTag
 
@@ -179,8 +182,6 @@ node('worker') {
 
     if (triggerMainBuild || triggerEvaluationBuild) {
         // Load the targetConfigurations
-        def mainTargetConfigurations       = overrideMainTargetConfigurations
-        def evaluationTargetConfigurations = overrideEvaluationTargetConfigurations
         if (mainTargetConfigurations == "") {
             // Load "main" targetConfigurations from pipeline config
             mainTargetConfigurations = loadTargetConfigurations((String)version, (String)variant, (String)"", (String)ignore_platforms)

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -549,7 +549,7 @@ node('worker') {
         }
 
         // Slack message:
-        //slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
         echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }
@@ -654,7 +654,7 @@ node('worker') {
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
                 def fullMessage = "${featureRelease} latest pipeline publish status: *${health}*. Build: ${releaseLink}.${lastPublishedMsg}${errorMsg}${missingMsg}"
                 echo "===> ${fullMessage}"
-                //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
+                slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }
             echo '----------------------------------------------------------------'
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -34,7 +34,7 @@ def getLatestOpenjdkBuildTag(String version) {
     // Need to include jdk8u to avoid picking up old tag format    
     def jdk8Filter = (version.contains("jdk8u")) ? "| grep 'jdk8u'" : ""
     if (version == "aarch32-jdk8u") {
-        jdk8Filter += " | grep '\-aarch32\-'"
+        jdk8Filter += " | grep '\\-aarch32\\-'"
     }
 
     def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | grep -v '\\-ga' ${jdk8Filter} | sort -V -r | head -1 | tr -d '\\n'")

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -324,7 +324,9 @@ node('worker') {
                   i += 1
                 } else {
                   foundNonEvaluationBinaries = true
+echo "JJJ"
                   healthStatus[featureRelease] = status
+echo "KKK"
                 }
               }
             }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -24,19 +24,20 @@ import java.time.temporal.ChronoUnit
 
 // Get the latest upstream openjdk build tag
 def getLatestOpenjdkBuildTag(String version) {
+echo "AA"
     def openjdkRepo = "https://github.com/openjdk/${version}.git"
     if (version == "aarch32-jdk8u") {
         openjdkRepo = "https://github.com/openjdk/aarch32-port-jdk8u.git"
     } else if (version == "alpine-jdk8u") {
         openjdkRepo = "https://github.com/openjdk/jdk8u.git"
     }
-
+echo "BB"
     // Need to include jdk8u to avoid picking up old tag format    
     def jdk8Filter = (version.contains("jdk8u")) ? "| grep 'jdk8u'" : ""
     if (version == "aarch32-jdk8u") {
         jdk8Filter += " | grep '\\-aarch32\\-'"
     }
-
+echo "CC"
     def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | grep -v '\\-ga' ${jdk8Filter} | sort -V -r | head -1 | tr -d '\\n'")
     echo "latest upstream openjdk/${version} tag = ${latestTag}"
 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -599,12 +599,12 @@ node('worker') {
                         if (upstreamTagAge > 3 && inProgressBuildUrl == "") {
                             slackColor = 'danger'
                             health = "Unhealthy"
-                            errorMsg = "\nLatest Adoptium publish binaries "+status['releaseName']+" != latest upstream openjdk build "+status['expectedReleaseName'].replaceAll("-ea-beta", "")+" published ${upstreamTagAge} days ago. *No build is in progress*."
+                            errorMsg = "\nLatest Adoptium publish binaries "+status['releaseName']+" != latest upstream openjdk build "+status['upstreamTag']+" published ${upstreamTagAge} days ago. *No build is in progress*."
                         } else {
                             if (inProgressBuildUrl != "") {
-                                errorMsg = "\nLatest upstream openjdk build "+status['expectedReleaseName'].replaceAll("-ea-beta", "")+" published ${upstreamTagAge} days ago. <" + inProgressBuildUrl + "|Build is in progress>."
+                                errorMsg = "\nLatest upstream openjdk build "+status['upstreamTag']+" published ${upstreamTagAge} days ago. <" + inProgressBuildUrl + "|Build is in progress>."
                             } else {
-                                errorMsg = "\nLatest upstream openjdk build "+status['expectedReleaseName'].replaceAll("-ea-beta", "")+" published ${upstreamTagAge} days ago. *Build is awaiting 'trigger'*."
+                                errorMsg = "\nLatest upstream openjdk build "+status['upstreamTag']+" published ${upstreamTagAge} days ago. *Build is awaiting 'trigger'*."
                             }
                         }
                     }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -182,7 +182,7 @@ def verifyReleaseContent(String version, String release, String variant, Map sta
                 def missingForArch = []
 
                 def imagetypes = ["debugimage", "jdk", "jre", "sbom"]
-                if (version != "jdk8u") {
+                if (!version.contains("jdk8u")) {
                     imagetypes.add("static-libs")
                     imagetypes.add("testimage")
                 }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -552,7 +552,7 @@ node('worker') {
         }
 
         // Slack message:
-        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
         echo 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -554,7 +554,7 @@ node('worker') {
         // Slack message:
         slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
-        echo 'Adoptium last 7 days Overall Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
+        echo 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }
 
     stage('printPublishStats') {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -277,7 +277,7 @@ node('worker') {
     def amberTestAlertLevel  = params.AMBER_TEST_ALERT_LEVEL  ? params.AMBER_TEST_ALERT_LEVEL as Integer : -99
     def nonTagBuildReleases = "${params.NON_TAG_BUILD_RELEASES}".split("[, ]+")
 
-    def healthStatus = []
+    def healthStatus = [:]
     def testStats = []
 
     stage('getPipelineStatus') {
@@ -325,7 +325,7 @@ node('worker') {
                 } else {
                   foundNonEvaluationBinaries = true
 echo "JJJ"
-                  healthStatus["${featureRelease}"] = status
+                  healthStatus[featureRelease] = status
 echo "KKK"
                 }
               }
@@ -339,7 +339,7 @@ echo "KKK"
               status = [releaseName: releaseName, expectedReleaseName: "${latestOpenjdkBuild}-ea-beta"]
               verifyReleaseContent(tipRelease, releaseName, variant, status)
               echo "  ${tipRelease} release binaries verification: "+status['assets']
-              healthStatus["${tipRelease}"] = status
+              healthStatus[tipRelease] = status
             }
         }
     }
@@ -564,7 +564,7 @@ echo "KKK"
             allReleases.each { featureRelease ->
                 def featureReleaseInt = (featureRelease == "aarch32-jdk8u" || featureRelease == "alpine-jdk8u") ? 8 : featureRelease.replaceAll("u", "").replaceAll("jdk", "").toInteger()
 
-                def status = healthStatus["${featureRelease}"]
+                def status = healthStatus[featureRelease]
 
                 def slackColor = 'good'
                 def health = "Healthy"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -25,9 +25,17 @@ import java.time.temporal.ChronoUnit
 // Get the latest upstream openjdk build tag
 def getLatestOpenjdkBuildTag(String version) {
     def openjdkRepo = "https://github.com/openjdk/${version}.git"
+    if (version == "aarch32-jdk8u") {
+        openjdkRepo = "https://github.com/openjdk/aarch32-port-jdk8u.git"
+    } else if (version == "alpine-jdk8u") {
+        openjdkRepo = "https://github.com/openjdk/jdk8u.git"
+    }
 
     // Need to include jdk8u to avoid picking up old tag format    
-    def jdk8Filter = (version == "jdk8u") ? "| grep 'jdk8u'" : ""
+    def jdk8Filter = (version.contains("jdk8u")) ? "| grep 'jdk8u'" : ""
+    if (version == "aarch32-jdk8u") {
+        jdk8Filter += " | grep '\-aarch32\-'"
+    }
 
     def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | grep -v '\\-ga' ${jdk8Filter} | sort -V -r | head -1 | tr -d '\\n'")
     echo "latest upstream openjdk/${version} tag = ${latestTag}"
@@ -38,6 +46,11 @@ def getLatestOpenjdkBuildTag(String version) {
 // Get how long ago the given upstream tag was published?
 def getOpenjdkBuildTagAge(String version, String tag) {
     def openjdkRepo = "https://github.com/openjdk/${version}.git"
+    if (version == "aarch32-jdk8u") {
+        openjdkRepo = "https://github.com/openjdk/aarch32-port-jdk8u.git"
+    } else if (version == "alpine-jdk8u") {
+        openjdkRepo = "https://github.com/openjdk/jdk8u.git"
+    } 
 
     def date = sh(returnStdout: true, script:"(rm -rf tmpRepo; git clone --depth 1 --branch ${tag} ${openjdkRepo} tmpRepo; cd tmpRepo; git log --tags --simplify-by-decoration --pretty=\"format:PUBLISH_DATE=%cI\") | grep PUBLISH_DATE | cut -d\"=\" -f2 | tr -d '\\n'")
     def tagTs = Instant.parse(date).atZone(ZoneId.of('UTC'))
@@ -58,7 +71,7 @@ def getLatestBinariesTag(String version) {
 }
 
 // Check if a given beta EA pipeline build is inprogress? if so return the buildUrl
-def getInProgressBuildUrl(String trssUrl, String pipelineName, String publishName) {
+def getInProgressBuildUrl(String trssUrl, String pipelineName, String publishName, String scmRef) {
     def inProgressBuildUrl = ""
 
     def pipeline = sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getBuildHistory?buildName=${pipelineName}")
@@ -66,15 +79,18 @@ def getInProgressBuildUrl(String trssUrl, String pipelineName, String publishNam
     if (pipelineJson.size() > 0) {
         pipelineJson.each { job ->
             def overridePublishName = ""
+            def buildScmRef = ""
 
             job.buildParams.each { buildParam ->
                 if (buildParam.name == "overridePublishName") {
                     overridePublishName = buildParam.value
+                } else if (buildParam.name == "scmReference") {
+                    buildScmRef = buildParam.value
                 }
             }
 
             // Is job for the required tag and currently inprogress?
-            if (overridePublishName == publishName && job.status != null && job.status.equals('Streaming')) {
+            if (overridePublishName == publishName && buildScmRef == scmRef && job.status != null && job.status.equals('Streaming')) {
                 inProgressBuildUrl = job.buildUrl
             }
         }
@@ -88,8 +104,14 @@ def verifyReleaseContent(String version, String release, String variant, Map sta
     echo "Verifying ${version} asserts in release: ${release}"
     status['assets'] = "Error"
 
+    def configVersion = version
+    // aarch32-jdk8u and alpine-jdk8u use "jdk8u" config
+    if (version == "aarch32-jdk8u" || version == "alpine-jdk8u") {
+        configVersion = "jdk8u"
+    }
+
     def escRelease = release.replaceAll("\\+", "%2B")
-    def releaseAssetsUrl = "https://api.github.com/repos/${params.BINARIES_REPO}/releases/tags/${escRelease}".replaceAll("_NN_", version.replaceAll("u","").replaceAll("jdk",""))
+    def releaseAssetsUrl = "https://api.github.com/repos/${params.BINARIES_REPO}/releases/tags/${escRelease}".replaceAll("_NN_", configVersion.replaceAll("u","").replaceAll("jdk",""))
 
     // Transform to browser URL for use in Slack message link
     status['assetsUrl'] = releaseAssetsUrl.replaceAll("api.github.com","github.com").replaceAll("/repos/","/").replaceAll("/tags/","/")
@@ -104,18 +126,30 @@ def verifyReleaseContent(String version, String release, String variant, Map sta
         echo "Error loading release assets list for ${releaseAssetsUrl}"
         status['assets'] = "Error loading ${releaseAssetsUrl}"
     } else {
-        def configFile = "${version}.groovy"   
-        def targetConfigPath = "${params.BUILD_CONFIG_URL}/${configFile}"
-        echo "    Loading pipeline config file: ${targetConfigPath}"
-        rc = sh(script: "curl -LO ${targetConfigPath}", returnStatus: true)
-        if (rc != 0) {
-            echo "Error loading ${targetConfigPath}"
-            status['assets'] = "Error loading ${targetConfigPath}"
-        } else {
-            // Load the targetConfiguration
-            targetConfigurations = null
-            load configFile
+        def configFile = "${configVersion}.groovy"
 
+        targetConfigurations = null
+        // aarch32-jdk8u and alpine-jdk8u are single configurations
+        if (version == "aarch32-jdk8u") {
+            targetConfigurations = [:]
+            targetConfigurations['arm32Linux'] = ['temurin']
+        } else if (version == "alpine-jdk8u") {
+            targetConfigurations = [:]
+            targetConfigurations['x64AlpineLinux'] = ['temurin']
+        } else {
+            def targetConfigPath = "${params.BUILD_CONFIG_URL}/${configFile}"
+            echo "    Loading pipeline config file: ${targetConfigPath}"
+            rc = sh(script: "curl -LO ${targetConfigPath}", returnStatus: true)
+            if (rc != 0) {
+                echo "Error loading ${targetConfigPath}"
+                status['assets'] = "Error loading ${targetConfigPath}"
+            } else {
+                // Load the targetConfiguration
+                load configFile
+            }
+        }
+
+        if (targetConfigurations) {
             // Map of config architecture to artifact name
             def archToAsset = [x64Linux:       "x64_linux",
                                x64Windows:     "x64_windows",
@@ -252,7 +286,7 @@ node('worker') {
             // Check the binary is published
             // The release asset list is also verified
             featureReleases.each { featureRelease ->
-              def featureReleaseInt = featureRelease.replaceAll("u", "").replaceAll("jdk", "").toInteger()
+              def featureReleaseInt = (featureRelease == "aarch32-jdk8u" || featureRelease == "alpine-jdk8u") ? 8 : featureRelease.replaceAll("u", "").replaceAll("jdk", "").toInteger()
               def assets = sh(returnStdout: true, script: "wget -q -O - '${apiUrl}/v3/assets/feature_releases/${featureReleaseInt}/ea?image_type=jdk&sort_method=DATE&pages=1&jvm_impl=${apiVariant}'")
               def assetsJson = new JsonSlurper().parseText(assets)
 
@@ -270,7 +304,11 @@ node('worker') {
                   status = [releaseName: releaseName, maxStaleDays: nightlyStaleDays, actualDays: days]
                 } else {
                   def latestOpenjdkBuild = getLatestOpenjdkBuildTag(featureRelease)
-                  status = [releaseName: releaseName, expectedReleaseName: "${latestOpenjdkBuild}-ea-beta"]
+                  def expectedReleaseName = "${latestOpenjdkBuild}-ea-beta"
+                  if (featureRelease == "aarch32-jdk8u") {
+                      expectedReleaseName = latestOpenjdkBuild.substring(0, latestOpenjdkBuild.indexOf("-aarch32"))+"-ea-beta"
+                  }
+                  status = [releaseName: releaseName, expectedReleaseName: expectedReleaseName, upstreamTag: latestOpenjdkBuild]
                 }
 
                 // Verify the given release contains all the expected assets
@@ -281,7 +319,7 @@ node('worker') {
                   i += 1
                 } else {
                   foundNonEvaluationBinaries = true
-                  healthStatus[featureReleaseInt] = status
+                  healthStatus[featureRelease] = status
                 }
               }
             }
@@ -320,10 +358,12 @@ node('worker') {
             allReleases.add(tipRelease)
         }
         allReleases.each { release ->
-           def featureReleaseStr = release.replaceAll("u", "").replaceAll("jdk", "")
+           def featureReleaseStr = (release == "aarch32-jdk8u" || release == "alpine-jdk8u") ? "8" : release.replaceAll("u", "").replaceAll("jdk", "")
 
-           // Only interested in nightly/triggered openjdkNN-pipeline's
-           pipelinesOfInterest += ",openjdk${featureReleaseStr}-pipeline"
+           // Only interested in triggered openjdkNN-pipeline's
+           if (!pipelinesOfInterest.contains(",openjdk${featureReleaseStr}-pipeline")) {
+               pipelinesOfInterest += ",openjdk${featureReleaseStr}-pipeline"
+           }
         }
 
         // Get top level builds names
@@ -337,14 +377,12 @@ node('worker') {
 
                 // Are we interested in this pipeline?
                 if (pipelinesOfInterest.contains(pipelineName)) {
-                  // Find the last "Done" pipeline builds started by "timer", "weekly-" or "releaseTrigger"
+                  // Find all the "Done" pipeline builds in the last 7 days, started by "timer", or upstream project "build-scripts/utils/betaTrigger_"
                   def pipeline = sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getBuildHistory?buildName=${pipelineName}")
                   def pipelineJson = new JsonSlurper().parseText(pipeline)
-                  def foundBuild = false
                   if (pipelineJson.size() > 0) {
-                    // Find first in list started by "timer", "weekly-" or "releaseTrigger"
+                    // Find first in list started by "timer", upstream project "build-scripts/utils/betaTrigger_"
                     pipelineJson.each { job ->
-                        if (!foundBuild) {
                             def pipeline_id = null
                             def pipelineUrl
                             def buildJobComplete = 0
@@ -368,20 +406,13 @@ node('worker') {
                             if (job.status != null && job.status.equals('Done') && job.startBy != null &&
                                 (!build._id.buildName.startsWith('release-') || days < 7)) {
                                 if (job.startBy.startsWith('timer')) {
-                                    // Nightly scheduled job
+                                    // Timer scheduled job
                                     pipeline_id = job._id
                                     pipelineUrl = job.buildUrl
-                                    foundBuild = true
-                                } else if (job.startBy.startsWith("upstream project \"build-scripts/weekly-")) {
-                                    // Weekend weekly scheduled job
-                                    pipeline_id = job._id
-                                    pipelineUrl = job.buildUrl
-                                    foundBuild = true
-                                } else if (job.startBy.startsWith("upstream project \"build-scripts/utils/releaseTrigger_")) {
+                                } else if (job.startBy.startsWith("upstream project \"build-scripts/utils/betaTrigger_")) {
                                     // Build tag triggered build
                                     pipeline_id = job._id
                                     pipelineUrl = job.buildUrl
-                                    foundBuild = true
                                 }
                             }
                             // Was job a "match"?
@@ -434,7 +465,6 @@ node('worker') {
                                       testJobNumber:    testJobNumber]
                                 testStats.add(testResult)
                             }
-                        }
                     }
                   }
                 }
@@ -511,7 +541,7 @@ node('worker') {
         }
 
         // Slack message:
-        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        //slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
         echo 'Adoptium Latest Builds Success : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }
@@ -525,8 +555,9 @@ node('worker') {
                 allReleases.add(tipRelease)
             }
             allReleases.each { featureRelease ->
-                def featureReleaseInt = featureRelease.replaceAll("u", "").replaceAll("jdk", "").toInteger()
-                def status = healthStatus[featureReleaseInt]
+                def featureReleaseInt = (featureRelease == "aarch32-jdk8u" || featureRelease == "alpine-jdk8u") ? 8 : featureRelease.replaceAll("u", "").replaceAll("jdk", "").toInteger()
+
+                def status = healthStatus[featureRelease]
 
                 def slackColor = 'good'
                 def health = "Healthy"
@@ -551,12 +582,12 @@ node('worker') {
                     }
                 } else {
                     // Check if build in-progress
-                    inProgressBuildUrl = getInProgressBuildUrl(trssUrl, "openjdk${featureReleaseInt}-pipeline", status['expectedReleaseName'].replaceAll("-beta", ""))
+                    inProgressBuildUrl = getInProgressBuildUrl(trssUrl, "openjdk${featureReleaseInt}-pipeline", status['expectedReleaseName'].replaceAll("-beta", ""), status['upstreamTag']+"_adopt")
 
                     // Check latest published binaries are for the latest openjdk build tag
                     if (status['releaseName'] != status['expectedReleaseName']) {
                         def upstreamRepoVersion = (featureRelease == tipRelease) ? "jdk" : featureRelease
-                        def upstreamTagAge    = getOpenjdkBuildTagAge(upstreamRepoVersion, status['expectedReleaseName'].replaceAll("-ea-beta", ""))
+                        def upstreamTagAge    = getOpenjdkBuildTagAge(upstreamRepoVersion, status['upstreamTag'])
                         if (upstreamTagAge > 3 && inProgressBuildUrl == "") {
                             slackColor = 'danger'
                             health = "Unhealthy"
@@ -615,7 +646,7 @@ node('worker') {
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
                 def fullMessage = "${featureRelease} latest pipeline publish status: *${health}*. Build: ${releaseLink}.${lastPublishedMsg}${errorMsg}${missingMsg}"
                 echo "===> ${fullMessage}"
-                slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
+                //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }
             echo '----------------------------------------------------------------'
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -170,6 +170,9 @@ def verifyReleaseContent(String version, String release, String variant, Map sta
             def missingAssets = []
             def foundAtLeastOneAsset = false
             targetConfigurations.keySet().each { osarch ->
+              if (version == "jdk8u" && (osarch == "arm32Linux" || osarch == "x64AlpineLinux")) {
+                echo "ignoring jdk8u:$osarch is built in a unique feature release"
+              } else {
                 def variants = targetConfigurations[osarch]
                 if (!variants.contains(variant)) {
                     return // variant not built for this osarch
@@ -242,6 +245,7 @@ def verifyReleaseContent(String version, String release, String variant, Map sta
                 } else {
                     echo "    $osarch : Complete"
                 }
+              }
             }
 
             // Set overall assets status for this release

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -325,7 +325,7 @@ node('worker') {
                 } else {
                   foundNonEvaluationBinaries = true
 echo "JJJ"
-                  healthStatus[featureRelease] = status
+                  healthStatus["${featureRelease}"] = status
 echo "KKK"
                 }
               }
@@ -339,7 +339,7 @@ echo "KKK"
               status = [releaseName: releaseName, expectedReleaseName: "${latestOpenjdkBuild}-ea-beta"]
               verifyReleaseContent(tipRelease, releaseName, variant, status)
               echo "  ${tipRelease} release binaries verification: "+status['assets']
-              healthStatus[tipVersion] = status
+              healthStatus["${tipRelease}"] = status
             }
         }
     }
@@ -564,7 +564,7 @@ echo "KKK"
             allReleases.each { featureRelease ->
                 def featureReleaseInt = (featureRelease == "aarch32-jdk8u" || featureRelease == "alpine-jdk8u") ? 8 : featureRelease.replaceAll("u", "").replaceAll("jdk", "").toInteger()
 
-                def status = healthStatus[featureRelease]
+                def status = healthStatus["${featureRelease}"]
 
                 def slackColor = 'good'
                 def health = "Healthy"


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3654

This PR enables the following features
**betaTrigger changes:**
- betaTrigger_8ea_arm32Linux : Trigger a jdk8u aarch32 linux build when an aarch32 build tag is mirrored into adoptium/aarch32-jdk8u
- betaTrigger_8ea_x64AplineLinux : Trigger a jdk8u x64 Alpine linux linux build when an build tag is mirrored into adoptium/alpine-jdk8u
- ensure betaTrigger_8ea does not build arm32Linux and x64AlpineLinux, by adding an IGNORE_PLATFORMS parameter
- update the betaTrigger logic to load the master pipeline targetConfiguration for the given version so as to only trigger the required platforms & variant
- update betaTrigger job to have a VARIANT parameter which determines the variant to be triggered from reading the targetConfiguration (ci.adoptium.net default betaTrigger_NNea jobs will now only trigger "temurin" builds)
- The OVERRIDE_... targetConfigurations are not just relevant to "force", for example they are defaulted to jdk8u excluding arm32Linux, when building "jdk8u"

**Daily #build Slack status changes:**
- update the Daily Slack #build status to report on aarch32-jdk8u and alpine-jdk8u build availability & status
- fix issues with the Daily Slack #build status to simplify pipieline build&test status reporting, which will now report the success rating from any builds launched in the last "7 days" by either "timer" or a "trigger" job
