### PR TITLE
reproduce_compare needs longer than 2 hour time limit to do a Windows build

### DIFF
--- a/tools/reproduce_comparison/Jenkinsfile
+++ b/tools/reproduce_comparison/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
         stage('Prepare') { //Copy artifacts, reset parameters,trigger build and copyArtifacts
             agent { label NODE_LABEL }
             options {
-                timeout(time: 2, unit: 'HOURS')
+                timeout(time: 3, unit: 'HOURS')
             }
             steps {
                 cleanWs()


### PR DESCRIPTION
The tools/reproduce_comparison/Jenkinsfile job was only giving 2hours to do a Windows build and archive, needs longer than that, it was aborting at 2hours:
https://ci.adoptium.net/view/ReproducibleBuild/job/jdk21u-windows-x64-temurin_reproduce_compare/36/

Test run with 3hour timeout: https://ci.adoptium.net/view/ReproducibleBuild/job/jdk21u-windows-x64-temurin_reproduce_compare/38