### PR TITLE
Determine upstream actual tagging date rather than the commit for daily build status

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -52,7 +52,7 @@ def getOpenjdkBuildTagAge(String version, String tag) {
         openjdkRepo = "https://github.com/openjdk/jdk8u.git"
     } 
 
-    def date = sh(returnStdout: true, script:"(rm -rf tmpRepo; git clone ${openjdkRepo} tmpRepo; cd tmpRepo; git for-each-ref --format=\"%(refname:short) %(taggerdate:format:%Y-%m-%dT%H:%M:%S%z)\" \"refs/tags/*\"; cd ..; rm -rf tmpRepo) | grep \"${tag}\" | cut -d\" \" -f2 | sed -e 's/.\{22\}/&:/1' | tr -d '\\n'")
+    def date = sh(returnStdout: true, script:"(rm -rf tmpRepo; git clone ${openjdkRepo} tmpRepo; cd tmpRepo; git for-each-ref --format=\"%(refname:short) %(taggerdate:format:%Y-%m-%dT%H:%M:%S%z)\" \"refs/tags/*\"; cd ..; rm -rf tmpRepo) | grep \"${tag}\" | cut -d\" \" -f2 | sed -e 's/.\\{22\\}/&:/1' | tr -d '\\n'")
 
     def tagTs = Instant.parse(date).atZone(ZoneId.of('UTC'))
     def now = ZonedDateTime.now(ZoneId.of('UTC'))


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3666

Use this to get the tag creation date:
```
git for-each-ref --format="%(refname:short) | %(taggerdate:format:%Y-%m-%dT%H:%M:%S%z)" "refs/tags/*"
```
