### PR TITLE
Default all test jobs to TIME_LIMIT 25 hours

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -188,11 +188,10 @@ class Build {
         def arch = buildConfig.ARCHITECTURE
         if (arch == 'x64') {
             arch = 'x86-64'
-        } else if (arch == 's390x') {
-            jobParams.put('TIME_LIMIT', '25')
-        } else if (arch == 'riscv64') {
-            jobParams.put('TIME_LIMIT', '25')
         }
+
+        // Default to a 25 hours for all test jobs
+        jobParams.put('TIME_LIMIT', '25')
 
         def arch_os = "${arch}_${buildConfig.TARGET_OS}"
         jobParams.put('ARCH_OS_LIST', arch_os)


### PR DESCRIPTION
We no longer get frequent "hangs", and the current 10hour limit is more of an issue now we have full sets of dev tests now running, so we are changing the default pipelines TEST_LIMIT to 25 hours

Test with this PR:
```
[Pipeline] timeout
14:13:29  Timeout set to expire in 1 day 1 hr
[Pipeline] {
```
