### PR TITLE
Update linux-riscv64 jdk11u pipeline to temurin

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -254,6 +254,8 @@ class Build {
                     suffix = 'adoptium/aarch32-jdk8u'
                 } else if (buildConfig.TARGET_OS == 'alpine-linux' && buildConfig.JAVA_TO_BUILD == 'jdk8u') {
                     suffix = 'adoptium/alpine-jdk8u'
+                } else if (buildConfig.ARCHITECTURE == 'riscv64' && buildConfig.JAVA_TO_BUILD == 'jdk11u') {
+                    suffix = 'adoptium/riscv-jdk11u'
                 } else {
                     suffix = "adoptium/${buildConfig.JAVA_TO_BUILD}"
                 }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -255,7 +255,7 @@ class Build {
                 } else if (buildConfig.TARGET_OS == 'alpine-linux' && buildConfig.JAVA_TO_BUILD == 'jdk8u') {
                     suffix = 'adoptium/alpine-jdk8u'
                 } else if (buildConfig.ARCHITECTURE == 'riscv64' && buildConfig.JAVA_TO_BUILD == 'jdk11u') {
-                    suffix = 'adoptium/riscv-jdk11u'
+                    suffix = 'adoptium/riscv-port-jdk11u'
                 } else {
                     suffix = "adoptium/${buildConfig.JAVA_TO_BUILD}"
                 }

--- a/pipelines/jobs/configurations/jdk11u_evaluation.groovy
+++ b/pipelines/jobs/configurations/jdk11u_evaluation.groovy
@@ -4,7 +4,7 @@ targetConfigurations = [
                 'temurin'
         ],
         'riscv64Linux': [
-                'hotspot'
+                'temurin'
         ]
         // 'x64Mac'        : [
         //         'openj9'

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -205,7 +205,7 @@ class Config11 {
                 ],
                 configureArgs        : [
                         'hotspot'    : '--enable-headless-only=yes --enable-dtrace',
-                        'temurin'    : '--enable-headless-only=yes --enable-dtrace',
+                        'temurin'    : '--enable-headless-only=yes --enable-dtrace --disable-ccache',
                         'openj9'     : '--disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root',
                         'bisheng'    : '--openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-jvm-features=shenandoahgc'
                 ],

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -182,35 +182,29 @@ class Config11 {
                 os                   : 'linux',
                 arch                 : 'riscv64',
                 dockerImage          : [
-                        'hotspot'    : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                         'temurin'    : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                         'openj9'     : 'adoptopenjdk/centos6_build_image',
                         'bisheng'    : 'adoptopenjdk/centos6_build_image'
                 ],
                 dockerArgs           : [
-                        'hotspot'    : '--platform linux/riscv64',
                         'temurin'    : '--platform linux/riscv64'
                 ],
                 crossCompile         : [
-                        'hotspot'    : 'dockerhost-rise-ubuntu2204-aarch64-1',
                         'temurin'    : 'dockerhost-rise-ubuntu2204-aarch64-1',
                         'openj9'     : 'x64',
                         'bisheng'    : 'x64'
                 ],
                 buildArgs            : [
-                        'hotspot'    : '--create-sbom',
                         'temurin'    : '--create-sbom',
                         'openj9'     : '--cross-compile',
                         'bisheng'    : '--cross-compile --branch risc-v'
                 ],
                 configureArgs        : [
-                        'hotspot'    : '--enable-headless-only=yes --enable-dtrace',
                         'temurin'    : '--enable-headless-only=yes --enable-dtrace --disable-ccache',
                         'openj9'     : '--disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root',
                         'bisheng'    : '--openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-jvm-features=shenandoahgc'
                 ],
                 test                : [
-                        'hotspot'   : 'default',
                         'temurin'   : 'default',
                         'openj9'    : [
                                 nightly: ['sanity.openjdk'],

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -183,29 +183,35 @@ class Config11 {
                 arch                 : 'riscv64',
                 dockerImage          : [
                         'hotspot'    : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
+                        'temurin'    : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                         'openj9'     : 'adoptopenjdk/centos6_build_image',
                         'bisheng'    : 'adoptopenjdk/centos6_build_image'
                 ],
                 dockerArgs           : [
-                        'hotspot'    : '--platform linux/riscv64'
+                        'hotspot'    : '--platform linux/riscv64',
+                        'temurin'    : '--platform linux/riscv64'
                 ],
                 crossCompile         : [
                         'hotspot'    : 'dockerhost-rise-ubuntu2204-aarch64-1',
+                        'temurin'    : 'dockerhost-rise-ubuntu2204-aarch64-1',
                         'openj9'     : 'x64',
                         'bisheng'    : 'x64'
                 ],
                 buildArgs            : [
                         'hotspot'    : '--create-sbom',
+                        'temurin'    : '--create-sbom',
                         'openj9'     : '--cross-compile',
                         'bisheng'    : '--cross-compile --branch risc-v'
                 ],
                 configureArgs        : [
                         'hotspot'    : '--enable-headless-only=yes --enable-dtrace',
+                        'temurin'    : '--enable-headless-only=yes --enable-dtrace',
                         'openj9'     : '--disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root',
                         'bisheng'    : '--openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-jvm-features=shenandoahgc'
                 ],
                 test                : [
                         'hotspot'   : 'default',
+                        'temurin'   : 'default',
                         'openj9'    : [
                                 nightly: ['sanity.openjdk'],
                                 weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']


### PR DESCRIPTION
The backport has been merged upstream with [1].

[1] https://github.com/openjdk/riscv-port-jdk11u/commit/309291f166821443393818beed364de6f2de5c52