### PR TITLE
Fix configureArgs for linux-riscv64 for jdk17u

### DIFF
--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -181,7 +181,7 @@ class Config17 {
                 test                : 'default',
                 configureArgs       : '--enable-headless-only=yes --enable-dtrace',
                 buildArgs           : [
-                        'hotspot'   : '--create-jre-image --create-sbom'
+                        'temurin'   : '--create-jre-image --create-sbom'
                 ]
         ],
 


### PR DESCRIPTION
It was mistakenly pointing at hotspot rather than temurin