### PR TITLE
Limit xMac JDK22+ testing to MacOS v11+

### DIFF
--- a/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
@@ -6,7 +6,8 @@ class Config22 {
                 arch                : 'x64',
                 additionalNodeLabels: 'xcode15.0.1',
                 additionalTestLabels: [
-                        openj9      : '!sw.os.osx.10_11'
+                        openj9      : '!sw.os.osx.10_11',
+                        temurin     : '!sw.os.osx.10_14'
                 ],
                 test                : 'default',
                 configureArgs       : '--enable-dtrace',

--- a/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
@@ -6,7 +6,8 @@ class Config23 {
                 arch                : 'x64',
                 additionalNodeLabels: 'xcode15.0.1',
                 additionalTestLabels: [
-                        openj9      : '!sw.os.osx.10_11'
+                        openj9      : '!sw.os.osx.10_11',
+                        temurin     : '!sw.os.osx.10_14'
                 ],
                 test                : 'default',
                 configureArgs       : '--enable-dtrace',


### PR DESCRIPTION
...because JDK22 and up are not built to be usable on MacOS versions under 11.