### PR TITLE
Remove sanity.external from 22+

### DIFF
--- a/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
@@ -24,7 +24,7 @@ class Config22 {
                         openj9      : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 test: [
-                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'sanity.external', 'dev.openjdk', 'dev.functional', 'dev.system']
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'dev.openjdk', 'dev.functional', 'dev.system']
                 ],
                 additionalTestLabels: [
                         openj9      : '!(centos6||rhel6)'

--- a/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
@@ -24,7 +24,7 @@ class Config23 {
                         openj9      : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 test: [
-                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'sanity.external', 'dev.openjdk', 'dev.functional', 'dev.system']
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'dev.openjdk', 'dev.functional', 'dev.system']
                 ],
                 additionalTestLabels: [
                         openj9      : '!(centos6||rhel6)'


### PR DESCRIPTION
Related: https://github.com/adoptium/aqa-tests/issues/5117

No official Temurin Docker images are produced for EA builds with no official release available yet, so we should refrain from running external tests for those versions (JDK 22+).  They can be enabled after the GA build is published (March for JDK 22, Sept for JDK 23).