### PR TITLE
Set dev.system test_dir and remove docker label for dev.system

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -394,7 +394,7 @@ class Build {
                             DYNAMIC_COMPILE = true
                         }
                         def additionalTestLabel = buildConfig.ADDITIONAL_TEST_LABEL
-                        if (testType  == 'dev.openjdk' || testType  == 'dev.system') {
+                        if (testType  == 'dev.openjdk') {
                             context.println "${testType} need extra label sw.tool.docker"
                             if (additionalTestLabel == '') {
                                 additionalTestLabel = 'sw.tool.docker'

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -359,6 +359,7 @@ class Build {
 
         def vendorTestRepos = ''
         def vendorTestBranches = ''
+        def vendorTestDirs = ''
         List testList = buildConfig.TEST_LIST
         List dynamicList = buildConfig.DYNAMIC_LIST
         List numMachines = buildConfig.NUM_MACHINES
@@ -407,6 +408,7 @@ class Build {
                             vendorTestBranches = useAdoptShellScripts ? ADOPT_DEFAULTS_JSON['repository']['build_branch'] : DEFAULTS_JSON['repository']['build_branch']
                             vendorTestRepos = useAdoptShellScripts ? ADOPT_DEFAULTS_JSON['repository']['build_url'] :  DEFAULTS_JSON['repository']['build_url']
                             vendorTestRepos = vendorTestRepos - ('.git')
+                            vendorTestDirs = '/test/system'
                             // Use BUILD_REF override if specified
                             vendorTestBranches = buildConfig.BUILD_REF ?: vendorTestBranches
                         }
@@ -481,6 +483,7 @@ class Build {
                         context.booleanParam(name: 'DYNAMIC_COMPILE', value: DYNAMIC_COMPILE),
                         context.string(name: 'VENDOR_TEST_REPOS', value: vendorTestRepos),
                         context.string(name: 'VENDOR_TEST_BRANCHES', value: vendorTestBranches),
+                        context.string(name: 'VENDOR_TEST_DIRS', value: vendorTestDirs),
                         context.string(name: 'RERUN_ITERATIONS', value: "${rerunIterations}")
                         ]
 


### PR DESCRIPTION
Fix https://github.com/adoptium/temurin-build/issues/3674

also remove docker requirement for dev.system as this is not required for reproducible comparing tests.

Current test_dirs(VENDOR_DIRS) supports multi dirs separated by comma. However that is multi dir strings for multi Vendor_repos. That is one test_dir for one vendor_repo. So we can't do this by set default test_dirs to ["/test/functional, /test/system"](https://github.com/adoptium/ci-jenkins-pipelines/blob/master/pipelines/defaults.json#L5) in defaults.jason.
