### PR TITLE
Fix Signverify Job - Change WindowsKitPath to find latest signtool rather than earliest/first

### DIFF
--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -40,7 +40,7 @@ String find_signtool() {
 
     def windowsKitPath = "/cygdrive/c/'Program Files (x86)'/'Windows Kits'"
 
-    def files = sh(script:"find ${windowsKitPath} -type f -path */${arch}/signtool.exe", \
+    def files = sh(script:"find ${windowsKitPath} -type f -path */${arch}/signtool.exe | sort -r", \
                    returnStdout:true).split("\\r?\\n|\\r")
 
     // Return the first one we find


### PR DESCRIPTION
Fixes #917 

Amend the search for signtool.exe to perform a reverse sort on the search for signtool.exe. 

On arm64 in particular, the earliest version ( 17763 ) does not actually work, which I believe is a bug in the earlier SDKS, and the later versions work correctly.