### PR TITLE
Add archive filename mapping for riscv64 daily status

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -180,7 +180,8 @@ def verifyReleaseContent(String version, String release, String variant, Map sta
                                arm32Linux:     "arm_linux",
                                x32Windows:     "x86-32_windows",
                                x64Solaris:     "x64_solaris",
-                               sparcv9Solaris: "sparcv9_solaris"
+                               sparcv9Solaris: "sparcv9_solaris",
+                               riscv64Linux:   "riscv64_linux"
                               ]
                                
             def missingAssets = []


### PR DESCRIPTION
riscv64 is new to the main jdk21u pipeline builds
the daily slack status was missing the pipeline config arch to filename mapping