### PR TITLE
Prevent Mac sign verification from running on old OS versions

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -956,7 +956,7 @@ class Build {
                 if (buildConfig.TARGET_OS == "windows") {
                     verifyNode = "ci.role.test&&sw.os.windows"
                 } else {
-                    verifyNode = "ci.role.test&&(sw.os.osx||sw.os.mac)"
+                    verifyNode = "ci.role.test&&(sw.os.osx||sw.os.mac)&&!sw.os.osx.10_14"
                 }
                 if (buildConfig.ARCHITECTURE == "aarch64") {
                     verifyNode = verifyNode + "&&hw.arch.aarch64"


### PR DESCRIPTION
Because later versions of OpenJDK (e.g. JDK22) cannot run on MacOS versions below 11. This extra tag prevents us from attempting to do so.

Making it universal rather than version-specific because I don't see any benefit from sign verification on MacOS 10.14, specifically. Testing yes, sign verification no.