### PR TITLE
Resolve testenv.properties "-ga" tags to the actual openjdk build tag for scm_ref check

### DIFF
--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -99,7 +99,7 @@ node('worker') {
         }
 
         // If testenv tag is a "-ga" tag, then resolve to the actual openjdk build tag it's tagging
-        if (jdkBranch.contains("-ga"))
+        if (jdkBranch.contains("-ga")) {
             jdkBranch = resolveGaTag("${params.jdkVersion}", jdkBranch)
         }
 


### PR DESCRIPTION
testenv.properties branch tag contains a potential "-ga" or "-dryrun-ga" tag, eg: https://github.com/adoptium/aqa-tests/blob/2403f9f458a53d1b7c9d73c39606c5065ccbd798/testenv/testenv.properties#L20C14-L20C30
```
JDK22_BRANCH=jdk-22-dryrun-ga
```
In this case we need to resolve it to the actual upstream build tag, that is specified on the pipeline scm_ref.
Without this a release pipeline will fail like:
```
[ERROR] scmReference does not match with any JDK branch in testenv.properties in aqa-tests release branch. Please update aqa-tests v1.0.1-release release branch. Set the current build result to FAILURE!
```

Local tests with this PR:
```
[INFO] Resolved jdk-22-dryrun-ga to upstream build tag jdk-22+35
[INFO] Resolved jdk-11.0.22-ga to upstream build tag jdk-11.0.22+7
[INFO] Resolved jdk8u392-dryrun-ga to upstream build tag jdk8u392-b06
```
