### PR TITLE
Resolve testenv.properties "-ga" tags to the actual openjdk build tag for scm_ref check (#967)

### DIFF
--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -21,6 +21,46 @@ Closure configureBuild = null
 def buildConfigurations = null
 Map<String, ?> DEFAULTS_JSON = null
 
+
+// Resolve a "-ga" tag to the actual upstream openjdk build tag of the same commit
+// Also check adoptium mirror for "dryrun" tags
+def resolveGaTag(String jdkVersion, String jdkBranch) {
+    def resolvedTag = jdkBranch // Default to as-is
+    
+    def openjdkRepo = "https://github.com/openjdk/jdk${jdkVersion}.git"
+                      
+    def gaCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep '\\^{}' | grep \"${jdkBranch}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
+    if (gaCommitSHA == "") {
+        // Try "updates" repo..
+        openjdkRepo = "https://github.com/openjdk/jdk${jdkVersion}u.git"
+        gaCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep '\\^{}' | grep \"${jdkBranch}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
+    }
+    if (gaCommitSHA == "") {
+        // Maybe an Adoptium "dryrun" try Adoptium mirror repo..
+        openjdkRepo = "https://github.com/adoptium/jdk${jdkVersion}.git"
+        gaCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep '\\^{}' | grep \"${jdkBranch}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
+    }
+    if (gaCommitSHA == "") {
+        // Maybe an Adoptium "dryrun" try Adoptium mirror "updates" repo..
+        openjdkRepo = "https://github.com/adoptium/jdk${jdkVersion}u.git"
+        gaCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep '\\^{}' | grep \"${jdkBranch}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
+    }
+
+    if (gaCommitSHA == "") {
+        println "[ERROR] Unable to resolve ${jdkBranch} upstream commit, will try to match tag as-is"
+    } else {
+        def upstreamTag = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep '\\^{}' | grep \"${gaCommitSHA}\" | grep -v \"${jdkBranch}\" | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | sed \"s,\\^{},,\" | tr -d '\\n'")
+        if (upstreamTag != "") {
+            println "[INFO] Resolved ${jdkBranch} to upstream build tag ${upstreamTag}"
+            resolvedTag = upstreamTag
+        } else {
+            println "[ERROR] Unable to resolve ${jdkBranch} upstream commit, will try to match tag as-is"
+        }
+    }
+
+    return resolvedTag
+}
+
 node('worker') {
     // Ensure workspace is clean so we don't archive any old failed pipeline artifacts
     println '[INFO] Cleaning up controller worker workspace prior to running pipelines..'
@@ -57,6 +97,12 @@ node('worker') {
                 break
             }
         }
+
+        // If testenv tag is a "-ga" tag, then resolve to the actual openjdk build tag it's tagging
+        if (jdkBranch.contains("-ga")) {
+            jdkBranch = resolveGaTag("${params.jdkVersion}", jdkBranch)
+        }
+
         if (jdkBranch == buildTag) {
             println "[INFO] scmReference=${buildTag} matches with JDK${params.jdkVersion}_BRANCH=${jdkBranch} in ${propertyFile} in aqa-tests release branch."
         } else if (jdkOpenj9Branch == buildTag) {


### PR DESCRIPTION
Fix to resolve aqa-tests testenv.properties jdk "-ga" tag