### PR TITLE
Refer reprodicible tooling to new folder

### DIFF
--- a/tools/reproduce_comparison/Jenkinsfile
+++ b/tools/reproduce_comparison/Jenkinsfile
@@ -158,7 +158,7 @@ pipeline {
                         sh "find . -type f -name 'OpenJDK*-jdk*.tar.gz' -delete"
                     }
                     try {
-                        dir('temurin-build/tooling') {
+                        dir('temurin-build/tooling/reproducible') {
                             def rc = 0
                             if (COMPARED_JOB_NAME.contains('linux')) {
                                 rc = sh returnStatus: true, script: "./repro_compare.sh temurin ${WORKSPACE}/original temurin ${WORKSPACE}/reproduced Linux"


### PR DESCRIPTION
Reproducible tooling has been reorganized.

Fix #974 