### PR TITLE
Remove master from code-freeze and fix release branch regex (#978)

### DIFF
--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -3,7 +3,7 @@ name: Code Freeze Bot
 # Controls when the workflow will run
 on:
   pull_request_target:
-    branches: [ "master", "v[0-9]{4}.[0-9]{2}.[0-9]{2}" ]
+    branches: [ "v[0-9]+.[0-9]+.[0-9]+" ]
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3703
As per PMC discussion, "master" branch removed from freeze
And corrected (confirmed this works on temurin-build repo) the release branch freezin