### PR TITLE
OpenJ9: Don't version the cuda install folder

### DIFF
--- a/pipelines/build/dockerFiles/cuda.dockerfile
+++ b/pipelines/build/dockerFiles/cuda.dockerfile
@@ -1,10 +1,14 @@
 ARG image
+ARG cuda_ver=12.2.0
+ARG cuda_distro=ubuntu20.04
 
+FROM nvidia/cuda:${cuda_ver}-devel-${cuda_distro} as cuda
 FROM $image
 
 # Install cuda headers https://github.com/eclipse/openj9/blob/master/buildenv/docker/mkdocker.sh#L586-L593
-RUN mkdir -p /usr/local/cuda-9.0/nvvm
-COPY --from=nvidia/cuda:9.0-devel-ubuntu16.04 /usr/local/cuda-9.0/include /usr/local/cuda-9.0/include
-COPY --from=nvidia/cuda:9.0-devel-ubuntu16.04 /usr/local/cuda-9.0/nvvm/include /usr/local/cuda-9.0/nvvm/include
+RUN mkdir -p /usr/local/cuda/nvvm
+# TEMP: Copy the header files from the local compile box to the container.
+COPY --from=cuda /usr/local/cuda/include         /usr/local/cuda/include
+COPY --from=cuda /usr/local/cuda/nvvm/include    /usr/local/cuda/nvvm/include
 
-ENV CUDA_HOME="/usr/local/cuda-9.0"
+ENV CUDA_HOME="/usr/local/cuda"


### PR DESCRIPTION
We are now able to build against any cuda version.

Related ibmruntimes/temurin-build#94
ibmruntimes/ci-jenkins-pipeline#182
adoptium/temurin-build#3735