### PR TITLE
avoid sign_temurin_gpg in non-adopt pipelines

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2125,7 +2125,7 @@ class Build {
                         throw new Exception("[ERROR] Installer job timeout (${buildTimeouts.INSTALLER_JOBS_TIMEOUT} HOURS) has been reached OR the downstream installer job failed. Exiting...")
                     }
                 }
-                if (!env.JOB_NAME.contains('pr-tester')) {
+                if (!env.JOB_NAME.contains('pr-tester') && JENKINS_URL.contains('adopt')) {
                     try {
                         gpgSign()
                     } catch (Exception e) {


### PR DESCRIPTION
fixes issue #981  

This is to avoid not adoptium pipelines pick the sign_temurin_gpg