### PR TITLE
use podman with UID 1002, GID 1003 instead of 1000 for s390x

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2046,7 +2046,7 @@ class Build {
                                 if (isPodman == 0) {
                                     // Note: --userns was introduced in podman 4.3.0
                                     // Add uid and gid userns mapping required for podman
-                                    dockerRunArg += " --userns keep-id:uid=1000,gid=1000"
+                                    dockerRunArg += " --userns keep-id:uid=1002,gid=1003"
                                 }
                                 context.docker.image(buildConfig.DOCKER_IMAGE).inside(buildConfig.DOCKER_ARGS+" "+dockerRunArg) {
                                     buildScripts(


### PR DESCRIPTION
Fixes the issue described in https://github.com/adoptium/temurin-build/issues/3700#issuecomment-2025772213 - UID 1000 was used by @andrew-m-leonard for some internal testing and is no longer required. This will fix it so that it matches what is on the Adoptium Marist s390x machines and allow the use of podman for the build process as per other reasons described in that issue.

I may switch this back or come up with a more generic solution in the future.