### PR TITLE
Changes to allow building a devkit using podman on a RHEL8 host

### DIFF
--- a/pipelines/build/devkit/build_devkit.groovy
+++ b/pipelines/build/devkit/build_devkit.groovy
@@ -122,7 +122,7 @@ node(params.DEVKIT_BUILD_NODE) {
             docker.image(params.DOCKER_IMAGE).pull()
         }
         String dockerRunArg=""
-        // Add extra mapping for Marist s390x machiens if running podman
+        // Add extra mapping for Adoptium RHEL machines running podman
         if ( ! sh(script: "docker --version | grep podman", returnStatus:true) ) {
             dockerRunArg += " --userns keep-id:uid=1002,gid=1003"
         }

--- a/pipelines/build/devkit/build_devkit.groovy
+++ b/pipelines/build/devkit/build_devkit.groovy
@@ -118,8 +118,15 @@ node(params.DEVKIT_BUILD_NODE) {
 
     if (params.DOCKER_IMAGE != "") { 
         // Build within docker container
-        docker.image(params.DOCKER_IMAGE).pull()
-        docker.image(params.DOCKER_IMAGE).inside() {
+        if (!("${params.DOCKER_IMAGE}".contains('rhel'))) {
+            docker.image(params.DOCKER_IMAGE).pull()
+        }
+        String dockerRunArg=""
+        // Add extra mapping for Marist s390x machiens if running podman
+        if ( ! sh(script: "docker --version | grep podman", returnStatus:true) ) {
+            dockerRunArg += " --userns keep-id:uid=1002,gid=1003"
+        }
+        docker.image(params.DOCKER_IMAGE).inside(dockerRunArg) {
             build()
         }
     } else {

--- a/pipelines/build/devkit/make_devkit.sh
+++ b/pipelines/build/devkit/make_devkit.sh
@@ -44,15 +44,15 @@ patch -p1 < ../Tools.gmk.patch
 devkit_target="${ARCH}-linux-gnu"
 
 if [ "${BASE_OS}" = "rhel" ]; then
-  mkdir -p ../../../build/devkit/jdk21u/build/devkit/download/rpms/s390x-linux-gnu-Centos${BASE_OS_VERSION}
+  mkdir -p ../../../build/devkit/${VERSION}/build/devkit/download/rpms/s390x-linux-gnu-Centos${BASE_OS_VERSION}
   # Downlod RPMS from RHEL (Requires machine to be attached to RHEL subscription)
   RPMDIR=/var/cache/yum/s390x/7Server/rhel-7-for-system-z-rpms/packages
   pwd
   for A in glibc glibc-headers glibc-devel cups-libs cups-devel libX11 libX11-devel xorg-x11-proto-devel alsa-lib alsa-lib-devel libXext libXext-devel libXtst libXtst-devel libXrender libXrender-devel libXrandr libXrandr-devel freetype freetype-devel libXt libXt-devel libSM libSM-devel libICE libICE-devel libXi libXi-devel libXdmcp libXdmcp-devel libXau libXau-devel libgcc libxcrypt zlib zlib-devel libffi libffi-devel fontconfig fontconfig-devel kernel-headers; do
     if [ ! -z "$(ls $RPMDIR/${A}-[0-9]*${ARCH}*.rpm)" ]; then
-      cp -pv ${RPMDIR}/${A}-[0-9]*${ARCH}*.rpm "../../../build/devkit/jdk21u/build/devkit/download/rpms/s390x-linux-gnu-Centos${BASE_OS_VERSION}"
+      cp -pv ${RPMDIR}/${A}-[0-9]*${ARCH}*.rpm "../../../build/devkit/${VERSION}/build/devkit/download/rpms/s390x-linux-gnu-Centos${BASE_OS_VERSION}"
     elif [ ! -z "$(ls $RPMDIR/${A}-[0-9]*noarch.rpm)" ]; then
-      cp -pv ${RPMDIR}/${A}-[0-9]*noarch.rpm "../../../build/devkit/jdk21u/build/devkit/download/rpms/s390x-linux-gnu-Centos${BASE_OS_VERSION}"
+      cp -pv ${RPMDIR}/${A}-[0-9]*noarch.rpm "../../../build/devkit/${VERSION}/build/devkit/download/rpms/s390x-linux-gnu-Centos${BASE_OS_VERSION}"
     fi
   done
   # Temporary fudge to use Centos logic until we adjust Tools.gmk

--- a/pipelines/build/devkit/make_devkit.sh
+++ b/pipelines/build/devkit/make_devkit.sh
@@ -43,9 +43,25 @@ patch -p1 < ../Tools.gmk.patch
 
 devkit_target="${ARCH}-linux-gnu"
 
-# Perform devkit build
-cd make/devkit && make TARGETS=${devkit_target} BASE_OS=${BASE_OS} BASE_OS_VERSION=${BASE_OS_VERSION}
+if [ "${BASE_OS}" = "rhel" ]; then
+  mkdir -p ../../../build/devkit/jdk21u/build/devkit/download/rpms/s390x-linux-gnu-Centos${BASE_OS_VERSION}
+  # Downlod RPMS from RHEL (Requires machine to be attached to RHEL subscription)
+  RPMDIR=/var/cache/yum/s390x/7Server/rhel-7-for-system-z-rpms/packages
+  pwd
+  for A in glibc glibc-headers glibc-devel cups-libs cups-devel libX11 libX11-devel xorg-x11-proto-devel alsa-lib alsa-lib-devel libXext libXext-devel libXtst libXtst-devel libXrender libXrender-devel libXrandr libXrandr-devel freetype freetype-devel libXt libXt-devel libSM libSM-devel libICE libICE-devel libXi libXi-devel libXdmcp libXdmcp-devel libXau libXau-devel libgcc libxcrypt zlib zlib-devel libffi libffi-devel fontconfig fontconfig-devel kernel-headers; do
+    if [ ! -z "$(ls $RPMDIR/${A}-[0-9]*${ARCH}*.rpm)" ]; then
+      cp -pv ${RPMDIR}/${A}-[0-9]*${ARCH}*.rpm "../../../build/devkit/jdk21u/build/devkit/download/rpms/s390x-linux-gnu-Centos${BASE_OS_VERSION}"
+    elif [ ! -z "$(ls $RPMDIR/${A}-[0-9]*noarch.rpm)" ]; then
+      cp -pv ${RPMDIR}/${A}-[0-9]*noarch.rpm "../../../build/devkit/jdk21u/build/devkit/download/rpms/s390x-linux-gnu-Centos${BASE_OS_VERSION}"
+    fi
+  done
+  # Temporary fudge to use Centos logic until we adjust Tools.gmk
+  BASE_OS=Centos
+fi
 
+# Perform devkit build
+cd make/devkit && pwd && make TARGETS=${devkit_target} BASE_OS=${BASE_OS} BASE_OS_VERSION=${BASE_OS_VERSION}
+find ../../build/devkit -type f -print	
 # Back to original folder
 cd ../../..
 


### PR DESCRIPTION
Both of these changes are based on equivalents in the build pipelines:
- Adds UID option for podman to ensure bind mounts are writable by the jenkins user
- Avoid docker pull command if the image name contains `rhel`
