### PR TITLE
JENKINS_URL missing context prefix

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2154,7 +2154,7 @@ class Build {
                         throw new Exception("[ERROR] Installer job timeout (${buildTimeouts.INSTALLER_JOBS_TIMEOUT} HOURS) has been reached OR the downstream installer job failed. Exiting...")
                     }
                 }
-                if (!env.JOB_NAME.contains('pr-tester') && JENKINS_URL.contains('adopt')) {
+                if (!env.JOB_NAME.contains('pr-tester') && context.JENKINS_URL.contains('adopt')) {
                     try {
                         gpgSign()
                     } catch (Exception e) {


### PR DESCRIPTION
Fixes build break due to: https://github.com/adoptium/ci-jenkins-pipelines/commit/15c83ae0ce39b59e11c23d5dcae3fe686b7b2183

Needs "context.JENKINS_URL"
