### PR TITLE
Replace RISC-V qemu build machine label with 'qemustatic'

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -192,7 +192,7 @@ class Config11 {
                         'temurin'    : '--platform linux/riscv64'
                 ],
                 crossCompile         : [
-                        'temurin'    : 'dockerhost-rise-ubuntu2204-aarch64-1',
+                        'temurin'    : 'qemustatic',
                         'openj9'     : 'x64',
                         'bisheng'    : 'x64'
                 ],

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -177,7 +177,7 @@ class Config17 {
         riscv64Linux      :  [
                 os                  : 'linux',
                 arch                : 'riscv64',
-                crossCompile        : 'dockerhost-rise-ubuntu2204-aarch64-1',
+                crossCompile        : 'qemustatic',
                 dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                 dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',

--- a/pipelines/jobs/configurations/jdk20u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20u_pipeline_config.groovy
@@ -146,7 +146,7 @@ class Config20 {
         riscv64Linux      :  [
                 os                  : 'linux',
                 arch                : 'riscv64',
-                crossCompile        : 'dockerhost-rise-ubuntu2204-aarch64-1',
+                crossCompile        : 'qemustatic',
                 dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                 dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -158,7 +158,7 @@ class Config21 {
         riscv64Linux      :  [
                 os                  : 'linux',
                 arch                : 'riscv64',
-                crossCompile        : 'dockerhost-rise-ubuntu2204-aarch64-1',
+                crossCompile        : 'qemustatic',
                 dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                 dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',

--- a/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
@@ -135,7 +135,7 @@ class Config22 {
         riscv64Linux      :  [
                 os                  : 'linux',
                 arch                : 'riscv64',
-                crossCompile        : 'dockerhost-rise-ubuntu2204-aarch64-1',
+                crossCompile        : 'qemustatic',
                 dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                 dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',

--- a/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
@@ -135,7 +135,7 @@ class Config23 {
         riscv64Linux      :  [
                 os                  : 'linux',
                 arch                : 'riscv64',
-                crossCompile        : 'dockerhost-rise-ubuntu2204-aarch64-1',
+                crossCompile        : 'qemustatic',
                 dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                 dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',


### PR DESCRIPTION
Supercedes https://github.com/adoptium/ci-jenkins-pipelines/pull/985
Allows us to use any machine that is set up appropriately (has qemu-user-static installed) by utilising a [qemustatic](https://ci.adoptium.net/label/qemustatic/) label  which has been applied to [dockerhost-azure-ubuntu2204-x64-1](https://ci.adoptium.net/computer/dockerhost-azure-ubuntu2204-x64-1)