### PR TITLE
Correct missing openjdkbuild dir location for windows/mac signing

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1581,7 +1581,7 @@ class Build {
                                         context.println 'Building an exploded image for signing'
                                         context.sh(script: "./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
                                     }
-                                    def base_path = context.sh(script: "ls -d workspace/build/src/build/* | tr -d '\\n'", returnStdout:true)
+                                    def base_path = context.sh(script: "ls -d ${openjdk_build_dir}/* | tr -d '\\n'", returnStdout:true)
                                     context.println "base build path for jmod signing = ${base_path}"
                                     context.stash name: 'jmods',
                                         includes: "${base_path}/hotspot/variant-server/**/*," +


### PR DESCRIPTION
With the change of openjdk build directory for jdk-21+ I missed one of the original path checks...!