### PR TITLE
Remove win32 for release pipelines - will trigger manually

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_release.groovy
+++ b/pipelines/jobs/configurations/jdk11u_release.groovy
@@ -11,9 +11,6 @@ targetConfigurations = [
         'x64Windows'    : [
                 'temurin'
         ],
-        'x32Windows'    : [
-                'temurin'
-        ],
         'ppc64Aix'      : [
                 'temurin'
         ],

--- a/pipelines/jobs/configurations/jdk17u_release.groovy
+++ b/pipelines/jobs/configurations/jdk17u_release.groovy
@@ -11,9 +11,6 @@ targetConfigurations = [
         'x64Windows'  : [
                 'temurin'
         ],
-        'x32Windows'  : [
-                'temurin'
-        ],
         'ppc64leLinux': [
                 'temurin'
         ],

--- a/pipelines/jobs/configurations/jdk8u_release.groovy
+++ b/pipelines/jobs/configurations/jdk8u_release.groovy
@@ -8,9 +8,6 @@ targetConfigurations = [
         'x64AlpineLinux' : [
                 'temurin'
         ],
-        'x32Windows'    : [
-                'temurin'
-        ],
         'x64Windows'    : [
                 'temurin'
         ],


### PR DESCRIPTION
Due to capacity issues on windows 64-bit systems which are used for testing both 32 and 64-bit Windows JDK builds and running five releases in parallel it makes sense to prioritise the 64-bit ones on the available hardware for all releases before the 32-bit ones. The simplest way to achieve this is to remove the 32-bit ones from the pipelines and trigger those manually - likely a day the 64-bit ones have run.

This PR therefore removes the x32Windows configurations from the three release pipelines where we build it (8, 11, 17)

I'm not putting this into master at the moment sine we should re-evaluate capacity post release when we enable additional ibmcloud windows machines as part of https://github.com/adoptium/infrastructure/issues/3238#issuecomment-2045959060