### PR TITLE
Fix daily Slack status

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -594,8 +594,6 @@ node('worker') {
                allReleases.addAll(nonTagBuildReleases)
             }
             allReleases.each { featureRelease ->
-                def featureReleaseInt = (featureRelease == "aarch32-jdk8u" || featureRelease == "alpine-jdk8u") ? 8 : featureRelease.replaceAll("u", "").replaceAll("jdk", "").toInteger()
-
                 def status = healthStatus[featureRelease]
 
                 def slackColor = 'good'

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -382,6 +382,9 @@ node('worker') {
         if (tipRelease != "") {
             allReleases.add(tipRelease)
         }
+        if (!nonTagBuildReleases.isEmpty()) {
+           allReleases.addAll(nonTagBuildReleases)
+        }
         allReleases.each { release ->
            def featureReleaseStr = (release == "aarch32-jdk8u" || release == "alpine-jdk8u") ? "8" : release.replaceAll("u", "").replaceAll("jdk", "")
 
@@ -581,6 +584,9 @@ node('worker') {
             allReleases.addAll(featureReleases)
             if (tipRelease != "") {
                 allReleases.add(tipRelease)
+            }
+            if (!nonTagBuildReleases.isEmpty()) {
+               allReleases.addAll(nonTagBuildReleases)
             }
             allReleases.each { featureRelease ->
                 def featureReleaseInt = (featureRelease == "aarch32-jdk8u" || featureRelease == "alpine-jdk8u") ? 8 : featureRelease.replaceAll("u", "").replaceAll("jdk", "").toInteger()

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -323,7 +323,7 @@ node('worker') {
               def status = []
               if (assetsJson.size() > 0) {
                 def releaseName = assetsJson[0].release_name
-                if (nonTagBuildReleases.contains(featureReleaseInt)) {
+                if (nonTagBuildReleases.contains(featureRelease)) {
                   // A non tag build, eg.a scheduled build for Oracle managed STS versions
                   def ts = assetsJson[0].timestamp // newest timestamp of a jdk asset
                   def assetTs = Instant.parse(ts).atZone(ZoneId.of('UTC'))
@@ -569,7 +569,7 @@ node('worker') {
         }
 
         // Slack message:
-        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        #slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
         echo 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }
@@ -595,7 +595,7 @@ node('worker') {
                 def inProgressBuildUrl = ""
 
                 // Is it a non-tag triggered build? eg.Oracle STS version
-                if (nonTagBuildReleases.contains(featureReleaseInt)) {
+                if (nonTagBuildReleases.contains(featureRelease)) {
                     // Check for stale published build
                     def days = status['actualDays'] as int
                     lastPublishedMsg = "\nPublished: ${days} day(s) ago." // might actually be days + N hours, where N < 24
@@ -674,7 +674,7 @@ node('worker') {
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
                 def fullMessage = "${featureRelease} latest pipeline publish status: *${health}*. Build: ${releaseLink}.${lastPublishedMsg}${errorMsg}${missingMsg}"
                 echo "===> ${fullMessage}"
-                slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
+                #slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }
             echo '----------------------------------------------------------------'
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -382,7 +382,7 @@ node('worker') {
         if (tipRelease != "") {
             allReleases.add(tipRelease)
         }
-        if (!nonTagBuildReleases.empty) {
+        if ("${params.NON_TAG_BUILD_RELEASES}".trim() != "") {
            allReleases.addAll(nonTagBuildReleases)
         }
         allReleases.each { release ->
@@ -585,7 +585,7 @@ node('worker') {
             if (tipRelease != "") {
                 allReleases.add(tipRelease)
             }
-            if (!nonTagBuildReleases.empty) {
+            if (("${params.NON_TAG_BUILD_RELEASES}".trim() != "")) {
                allReleases.addAll(nonTagBuildReleases)
             }
             allReleases.each { featureRelease ->

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -306,7 +306,12 @@ node('worker') {
             // In particular, look at first data set for latest published binaries.
             // Check the binary is published
             // The release asset list is also verified
-            featureReleases.each { featureRelease ->
+            def allNonTipReleases = []
+            allNonTipReleases.addAll(featureReleases)
+            if ("${params.NON_TAG_BUILD_RELEASES}".trim() != "") {
+                allNonTipReleases.addAll(nonTagBuildReleases)
+            }
+            allNonTipReleases.each { featureRelease ->
               def featureReleaseInt = (featureRelease == "aarch32-jdk8u" || featureRelease == "alpine-jdk8u") ? 8 : featureRelease.replaceAll("u", "").replaceAll("jdk", "").toInteger()
 
               // Extra filter to find latest jdk8u port assets

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -52,7 +52,7 @@ def getOpenjdkBuildTagAge(String version, String tag) {
         openjdkRepo = "https://github.com/openjdk/jdk8u.git"
     } 
 
-    def date = sh(returnStdout: true, script:"(rm -rf tmpRepo; git clone ${openjdkRepo} tmpRepo; cd tmpRepo; git for-each-ref --format=\"%(refname:short) %(taggerdate:format:%Y-%m-%dT%H:%M:%S%z)\" \"refs/tags/*\"; cd ..; rm -rf tmpRepo) | grep \"${tag}\" | cut -d\" \" -f2 | sed -e 's/.\\{22\\}/&:/1' | tr -d '\\n'")
+    def date = sh(returnStdout: true, script:"(rm -rf tmpRepo; git clone ${openjdkRepo} tmpRepo; cd tmpRepo; git for-each-ref --format=\"%(refname:short) %(creatordate:format:%Y-%m-%dT%H:%M:%S%z)\" \"refs/tags/*\"; cd ..; rm -rf tmpRepo) | grep \"${tag}\" | cut -d\" \" -f2 | sed -e 's/.\\{22\\}/&:/1' | tr -d '\\n'")
 
     def tagTs = Instant.parse(date).atZone(ZoneId.of('UTC'))
     def now = ZonedDateTime.now(ZoneId.of('UTC'))

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -577,7 +577,7 @@ node('worker') {
         }
 
         // Slack message:
-        //slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
         echo 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }
@@ -685,7 +685,7 @@ node('worker') {
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
                 def fullMessage = "${featureRelease} latest pipeline publish status: *${health}*. Build: ${releaseLink}.${lastPublishedMsg}${errorMsg}${missingMsg}"
                 echo "===> ${fullMessage}"
-                //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
+                slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }
             echo '----------------------------------------------------------------'
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -382,7 +382,7 @@ node('worker') {
         if (tipRelease != "") {
             allReleases.add(tipRelease)
         }
-        if (!nonTagBuildReleases.isEmpty()) {
+        if (!nonTagBuildReleases.empty) {
            allReleases.addAll(nonTagBuildReleases)
         }
         allReleases.each { release ->
@@ -585,7 +585,7 @@ node('worker') {
             if (tipRelease != "") {
                 allReleases.add(tipRelease)
             }
-            if (!nonTagBuildReleases.isEmpty()) {
+            if (!nonTagBuildReleases.empty) {
                allReleases.addAll(nonTagBuildReleases)
             }
             allReleases.each { featureRelease ->

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -569,7 +569,7 @@ node('worker') {
         }
 
         // Slack message:
-        #slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        //slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
         echo 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }
@@ -674,7 +674,7 @@ node('worker') {
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
                 def fullMessage = "${featureRelease} latest pipeline publish status: *${health}*. Build: ${releaseLink}.${lastPublishedMsg}${errorMsg}${missingMsg}"
                 echo "===> ${fullMessage}"
-                #slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
+                //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }
             echo '----------------------------------------------------------------'
         }


### PR DESCRIPTION
- Daily Slack status job fails to get the taggerdate of the latest build tag: https://ci.adoptium.net/view/Tooling/job/nightlyBuildAndTestStats_temurin/1466/console
taggerdate is only valid for annotated tags, upstream aarch32-jdk8u gets tagged with lightweight tags, to allow for both we should use creatordate
- non-tag driven release (Oracle managed releases) status not being published, eg.jdk22u
The logic for checking against the nonTagReleases had not being tested, been jdk22u the first to do this....
