### PR TITLE
Remove Linux/s390x from jdk22u pipelines to float patch

### DIFF
--- a/pipelines/jobs/configurations/jdk22u_release.groovy
+++ b/pipelines/jobs/configurations/jdk22u_release.groovy
@@ -20,9 +20,6 @@ targetConfigurations = [
         'ppc64leLinux': [
                 'temurin'
         ],
-        's390xLinux'  : [
-                'temurin'
-        ],
         'aarch64Linux': [
                 'temurin'
         ],


### PR DESCRIPTION
As per PMC meeting this week we intend to float a patch on Linux/s390x including https://github.com/openjdk/jdk22u/pull/137 which will require some manual effort to create a branch with the new tag after the official GA tag comes out. An s390x build without this patch will not be shippable, so we should not trigger it.