### PR TITLE
Prevent jdk20+ linux jobs from running on rhel or centos 6 machines

### DIFF
--- a/pipelines/jobs/configurations/jdk20u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20u_pipeline_config.groovy
@@ -24,7 +24,8 @@ class Config20 {
                 ],
                 test                : 'default',
                 additionalTestLabels: [
-                        openj9      : '!(centos6||rhel6)'
+                        openj9      : '!(centos6||rhel6)',
+                        temurin     : '!(centos6||rhel6)'
                 ],
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',
@@ -89,6 +90,9 @@ class Config20 {
                 arch                : 's390x',
                 dockerImage         : 'rhel7_build_image',
                 test                : 'default',
+                additionalTestLabels: [
+                        temurin     : '!(centos6||rhel6)'
+                ],
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
@@ -100,6 +104,9 @@ class Config20 {
                 arch                : 'ppc64le',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
+                additionalTestLabels: [
+                        temurin     : '!(centos6||rhel6)'
+                ],
                 configureArgs       : [
                         'temurin'     : '--enable-dtrace',
                         'openj9'      : '--enable-dtrace'
@@ -114,6 +121,9 @@ class Config20 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
+                additionalTestLabels: [
+                        temurin     : '!(centos6||rhel6)'
+                ],
                 configureArgs : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
@@ -137,6 +147,9 @@ class Config20 {
                 dockerImage         : 'adoptopenjdk/ubuntu1604_build_image',
                 dockerArgs          : '--platform linux/arm/v7',
                 test                : 'default',
+                additionalTestLabels: [
+                        temurin     : '!(centos6||rhel6)'
+                ],
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
@@ -150,6 +163,9 @@ class Config20 {
                 dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                 dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',
+                additionalTestLabels: [
+                        temurin     : '!(centos6||rhel6)'
+                ],
                 configureArgs       : '--enable-headless-only=yes --enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'

--- a/pipelines/jobs/configurations/jdk20u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20u_pipeline_config.groovy
@@ -90,9 +90,6 @@ class Config20 {
                 arch                : 's390x',
                 dockerImage         : 'rhel7_build_image',
                 test                : 'default',
-                additionalTestLabels: [
-                        temurin     : '!(centos6||rhel6)'
-                ],
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
@@ -104,9 +101,6 @@ class Config20 {
                 arch                : 'ppc64le',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
-                additionalTestLabels: [
-                        temurin     : '!(centos6||rhel6)'
-                ],
                 configureArgs       : [
                         'temurin'     : '--enable-dtrace',
                         'openj9'      : '--enable-dtrace'
@@ -121,9 +115,6 @@ class Config20 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
-                additionalTestLabels: [
-                        temurin     : '!(centos6||rhel6)'
-                ],
                 configureArgs : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
@@ -147,9 +138,6 @@ class Config20 {
                 dockerImage         : 'adoptopenjdk/ubuntu1604_build_image',
                 dockerArgs          : '--platform linux/arm/v7',
                 test                : 'default',
-                additionalTestLabels: [
-                        temurin     : '!(centos6||rhel6)'
-                ],
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
@@ -163,9 +151,6 @@ class Config20 {
                 dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                 dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',
-                additionalTestLabels: [
-                        temurin     : '!(centos6||rhel6)'
-                ],
                 configureArgs       : '--enable-headless-only=yes --enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -32,7 +32,8 @@ class Config21 {
                         'temurin'   : true
                 ],
                 additionalTestLabels: [
-                        openj9      : '!(centos6||rhel6)'
+                        openj9      : '!(centos6||rhel6)',
+                        temurin     : '!(centos6||rhel6)'
                 ],
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',
@@ -101,6 +102,9 @@ class Config21 {
                 arch                : 's390x',
                 dockerImage         : 'rhel7_build_image',
                 test                : 'default',
+                additionalTestLabels: [
+                        temurin     : '!(centos6||rhel6)'
+                ],
                 reproducibleCompare : [
                         'temurin'   : true
                 ],
@@ -114,6 +118,9 @@ class Config21 {
                 arch                : 'ppc64le',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
+                additionalTestLabels: [
+                        temurin     : '!(centos6||rhel6)'
+                ],
                 reproducibleCompare : [
                         'temurin'   : true
                 ],
@@ -130,6 +137,9 @@ class Config21 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
+                additionalTestLabels: [
+                        temurin     : '!(centos6||rhel6)'
+                ],
                 reproducibleCompare : [
                         'temurin'   : true
                 ],
@@ -162,6 +172,9 @@ class Config21 {
                 dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                 dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',
+                additionalTestLabels: [
+                        temurin     : '!(centos6||rhel6)'
+                ],
                 configureArgs       : '--enable-headless-only=yes --enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -102,9 +102,6 @@ class Config21 {
                 arch                : 's390x',
                 dockerImage         : 'rhel7_build_image',
                 test                : 'default',
-                additionalTestLabels: [
-                        temurin     : '!(centos6||rhel6)'
-                ],
                 reproducibleCompare : [
                         'temurin'   : true
                 ],
@@ -118,9 +115,6 @@ class Config21 {
                 arch                : 'ppc64le',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
-                additionalTestLabels: [
-                        temurin     : '!(centos6||rhel6)'
-                ],
                 reproducibleCompare : [
                         'temurin'   : true
                 ],
@@ -137,9 +131,6 @@ class Config21 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
-                additionalTestLabels: [
-                        temurin     : '!(centos6||rhel6)'
-                ],
                 reproducibleCompare : [
                         'temurin'   : true
                 ],
@@ -172,9 +163,6 @@ class Config21 {
                 dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                 dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',
-                additionalTestLabels: [
-                        temurin     : '!(centos6||rhel6)'
-                ],
                 configureArgs       : '--enable-headless-only=yes --enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'

--- a/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
@@ -55,9 +55,6 @@ class Config22 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                additionalTestLabels: [
-                        temurin     : '!(centos6||rhel6)'
-                ],
                 configureArgs       : '--enable-headless-only=yes',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'

--- a/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
@@ -27,7 +27,8 @@ class Config22 {
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'dev.openjdk', 'dev.functional', 'dev.system']
                 ],
                 additionalTestLabels: [
-                        openj9      : '!(centos6||rhel6)'
+                        openj9      : '!(centos6||rhel6)',
+                        temurin     : '!(centos6||rhel6)'
                 ],
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',
@@ -54,6 +55,9 @@ class Config22 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
+                additionalTestLabels: [
+                        temurin     : '!(centos6||rhel6)'
+                ],
                 configureArgs       : '--enable-headless-only=yes',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
@@ -93,6 +97,9 @@ class Config22 {
                 arch                : 's390x',
                 dockerImage         : 'rhel7_build_image',
                 test                : 'default',
+                additionalTestLabels: [
+                        temurin     : '!(centos6||rhel6)'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit s390x-on-s390x.RH7'
                 ]
@@ -103,6 +110,9 @@ class Config22 {
                 arch                : 'ppc64le',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
+                additionalTestLabels: [
+                        temurin     : '!(centos6||rhel6)'
+                ],
                 configureArgs       : [
                         'openj9'      : '--enable-dtrace'
                 ],
@@ -116,6 +126,9 @@ class Config22 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
+                additionalTestLabels: [
+                        temurin     : '!(centos6||rhel6)'
+                ],
                 configureArgs : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b02'
@@ -139,6 +152,9 @@ class Config22 {
                 dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                 dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',
+                additionalTestLabels: [
+                        temurin     : '!(centos6||rhel6)'
+                ],
                 configureArgs       : '--enable-headless-only=yes --enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'

--- a/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
@@ -97,9 +97,6 @@ class Config22 {
                 arch                : 's390x',
                 dockerImage         : 'rhel7_build_image',
                 test                : 'default',
-                additionalTestLabels: [
-                        temurin     : '!(centos6||rhel6)'
-                ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit s390x-on-s390x.RH7'
                 ]
@@ -110,9 +107,6 @@ class Config22 {
                 arch                : 'ppc64le',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
-                additionalTestLabels: [
-                        temurin     : '!(centos6||rhel6)'
-                ],
                 configureArgs       : [
                         'openj9'      : '--enable-dtrace'
                 ],
@@ -126,9 +120,6 @@ class Config22 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
-                additionalTestLabels: [
-                        temurin     : '!(centos6||rhel6)'
-                ],
                 configureArgs : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b02'
@@ -152,9 +143,6 @@ class Config22 {
                 dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                 dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',
-                additionalTestLabels: [
-                        temurin     : '!(centos6||rhel6)'
-                ],
                 configureArgs       : '--enable-headless-only=yes --enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'

--- a/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
@@ -27,7 +27,8 @@ class Config23 {
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'dev.openjdk', 'dev.functional', 'dev.system']
                 ],
                 additionalTestLabels: [
-                        openj9      : '!(centos6||rhel6)'
+                        openj9      : '!(centos6||rhel6)',
+                        temurin     : '!(centos6||rhel6)'
                 ],
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',
@@ -103,6 +104,9 @@ class Config23 {
                 arch                : 'ppc64le',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
+                additionalTestLabels: [
+                        temurin     : '!(centos6||rhel6)'
+                ],
                 configureArgs       : [
                         'openj9'      : '--enable-dtrace'
                 ],
@@ -116,6 +120,9 @@ class Config23 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
+                additionalTestLabels: [
+                        temurin     : '!(centos6||rhel6)'
+                ],
                 configureArgs : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b02'
@@ -139,6 +146,9 @@ class Config23 {
                 dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                 dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',
+                additionalTestLabels: [
+                        temurin     : '!(centos6||rhel6)'
+                ],
                 configureArgs       : '--enable-headless-only=yes --enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'

--- a/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
@@ -104,9 +104,6 @@ class Config23 {
                 arch                : 'ppc64le',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
-                additionalTestLabels: [
-                        temurin     : '!(centos6||rhel6)'
-                ],
                 configureArgs       : [
                         'openj9'      : '--enable-dtrace'
                 ],
@@ -120,9 +117,6 @@ class Config23 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
-                additionalTestLabels: [
-                        temurin     : '!(centos6||rhel6)'
-                ],
                 configureArgs : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b02'
@@ -146,9 +140,6 @@ class Config23 {
                 dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                 dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',
-                additionalTestLabels: [
-                        temurin     : '!(centos6||rhel6)'
-                ],
                 configureArgs       : '--enable-headless-only=yes --enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'


### PR DESCRIPTION
ref https://github.com/adoptium/ci-jenkins-pipelines/issues/970