### PR TITLE
[v2024.04+1] Prevent jdk20+ linux jobs from running on rhel or centos 6 machines

### DIFF
--- a/pipelines/jobs/configurations/jdk20u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk20u_pipeline_config.groovy
@@ -24,7 +24,8 @@ class Config20 {
                 ],
                 test                : 'default',
                 additionalTestLabels: [
-                        openj9      : '!(centos6||rhel6)'
+                        openj9      : '!(centos6||rhel6)',
+                        temurin     : '!(centos6||rhel6)'
                 ],
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -32,7 +32,8 @@ class Config21 {
                         'temurin'   : true
                 ],
                 additionalTestLabels: [
-                        openj9      : '!(centos6||rhel6)'
+                        openj9      : '!(centos6||rhel6)',
+                        temurin     : '!(centos6||rhel6)'
                 ],
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',

--- a/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
@@ -27,7 +27,8 @@ class Config22 {
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'dev.openjdk', 'dev.functional', 'dev.system']
                 ],
                 additionalTestLabels: [
-                        openj9      : '!(centos6||rhel6)'
+                        openj9      : '!(centos6||rhel6)',
+                        temurin     : '!(centos6||rhel6)'
                 ],
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',

--- a/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
@@ -27,7 +27,8 @@ class Config23 {
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'dev.openjdk', 'dev.functional', 'dev.system']
                 ],
                 additionalTestLabels: [
-                        openj9      : '!(centos6||rhel6)'
+                        openj9      : '!(centos6||rhel6)',
+                        temurin     : '!(centos6||rhel6)'
                 ],
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',


### PR DESCRIPTION
Adding the changes from https://github.com/adoptium/ci-jenkins-pipelines/pull/1005 into the april 2024 release branch