### PR TITLE
Schedule jdk11u evaluation weekly build of HEAD as riscv64Linux is not tagged regularly

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_evaluation.groovy
+++ b/pipelines/jobs/configurations/jdk11u_evaluation.groovy
@@ -36,6 +36,9 @@ targetConfigurations = [
         // ]
 ]
 
+// 08:05 Sat - Weekend schedule so we get riscv64Linux HEAD builds, since they don't operate regular build tagging...
+triggerSchedule_weekly  = 'TZ=UTC\n05 08 * * 6'
+
 // scmReferences to use for weekly evaluation build
 weekly_evaluation_scmReferences = [
         'hotspot'        : '',


### PR DESCRIPTION
jdk11u evaluation riscv64Linux is not tagged regularly as requires an upstream port branch merge by the maintainer.
This means tag builds of upstream new tags won't work unless that tag has been merged into the riscv_port branch.

jdk11u riscv64Linux needs a regular HEAD build instead, which we can't easily do just for riscv64Linux, so enabling a weekly schedule will also build windows/aarch64 HEAD as an undesireable consequence
