### PR TITLE
Update daily EA build Slack status to handle when GA builds are published

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -49,7 +49,7 @@ def getLatestOpenjdkBuildTag(String version) {
     def gaCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep '\\^{}' | grep \"${gaCheckTag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
     if (gaCommitSHA != "" && buildCommitSHA == gaCommitSHA) {
         echo "latest upstream openjdk/${version} tag = ${latestTag}, which is a GA tag, looking for previous EA build tag..."
-        latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | grep -v '\\-ga' ${jdk8Filter} | grep -v \"${gaCheckTag}\" | sort -V -r | head -1 | tr -d '\\n'")
+        latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | grep -v '\\-ga' ${jdk8Filter} | grep -v \"${latestTag}\" | sort -V -r | head -1 | tr -d '\\n'")
     }
 
     echo "latest upstream openjdk/${version} tag = ${latestTag}"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -669,6 +669,7 @@ node('worker') {
                 }
 
                 // Verify if any artifacts missing?
+                def missingMsg = ""
                 // Don't check if upstream tag is a GA, as the ea-beta will only be for evaluation platforms
                 if (nonTagBuildReleases.contains(featureRelease) || !isGaTag(featureRelease, status['upstreamTag'])) {
                     def missingAssets = []
@@ -685,7 +686,6 @@ node('worker') {
                     }
                  
                     // Print out formatted missing artifacts if any missing
-                    def missingMsg = ""
                     if (missingAssets.size() > 0) {
                         missingMsg += " :"
                         // Collate by arch, array is sequenced by architecture

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -66,7 +66,7 @@ def getLatestOpenjdkBuildTag(String version) {
         jdk8Filter += " | grep '\\-aarch32\\-'"
     }
 
-    def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | grep -v '\\-ga' ${jdk8Filter} | sort -V -r | tail -1 | tr -d '\\n'")
+    def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | grep -v '\\-ga' ${jdk8Filter} | sort -V -r | head -1 | tr -d '\\n'")
 
     echo "latest upstream openjdk/${version} tag = ${latestTag}"
 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -32,11 +32,15 @@ def isGaTag(String version, String tag) {
 
     def tagCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep '\\^{}' | grep \"${tag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
 
-    def gaCheckTag
+    def gaCheckTag = "unknown"
     if (version.contains("jdk8u")) {
-        gaCheckTag = tag.substring(0, tag.indexOf("-"))+"-ga"
+        if (tag.indexOf("-") > 0) {
+            gaCheckTag = tag.substring(0, tag.indexOf("-"))+"-ga"
+        }
     } else {
-        gaCheckTag = tag.substring(0, tag.indexOf("+"))+"-ga"
+        if (tag.indexOf("+") > 0) {
+            gaCheckTag = tag.substring(0, tag.indexOf("+"))+"-ga"
+        }
     }
     def gaCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep '\\^{}' | grep \"${gaCheckTag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -23,6 +23,11 @@ import java.time.temporal.ChronoUnit
 
 // Check if the given tag is a -ga tag ?
 def isGaTag(String version, String tag) {
+    if (version == "${params.TIP_RELEASE}".trim()) {
+        // Tip release has no GA tags
+        return false
+    }
+
     def openjdkRepo = "https://github.com/openjdk/${version}.git"
     if (version == "aarch32-jdk8u") {
         openjdkRepo = "https://github.com/openjdk/aarch32-port-jdk8u.git"
@@ -359,11 +364,12 @@ node('worker') {
                 def releaseName = assetsJson[0].release_name
                 if (nonTagBuildReleases.contains(featureRelease)) {
                   // A non tag build, eg.a scheduled build for Oracle managed STS versions
+                  def latestOpenjdkBuild = getLatestOpenjdkBuildTag(featureRelease)
                   def ts = assetsJson[0].timestamp // newest timestamp of a jdk asset
                   def assetTs = Instant.parse(ts).atZone(ZoneId.of('UTC'))
                   def now = ZonedDateTime.now(ZoneId.of('UTC'))
                   def days = ChronoUnit.DAYS.between(assetTs, now)
-                  status = [releaseName: releaseName, maxStaleDays: nightlyStaleDays, actualDays: days]
+                  status = [releaseName: releaseName, maxStaleDays: nightlyStaleDays, actualDays: days, upstreamTag: latestOpenjdkBuild]
                 } else {
                   def latestOpenjdkBuild = getLatestOpenjdkBuildTag(featureRelease)
                   def expectedReleaseName = "${latestOpenjdkBuild}-ea-beta"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -607,7 +607,7 @@ node('worker') {
         }
 
         // Slack message:
-        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        //slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
         echo 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }
@@ -713,7 +713,7 @@ node('worker') {
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
                 def fullMessage = "${featureRelease} latest pipeline publish status: *${health}*. Build: ${releaseLink}.${lastPublishedMsg}${errorMsg}${missingMsg}"
                 echo "===> ${fullMessage}"
-                slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
+                //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }
             echo '----------------------------------------------------------------'
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -612,7 +612,7 @@ node('worker') {
         }
 
         // Slack message:
-        //slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
         echo 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }
@@ -719,9 +719,9 @@ node('worker') {
                 }
 
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
-                def fullMessage = "${featureRelease} latest pipeline publish status: *${health}*. Build: ${releaseLink}.${lastPublishedMsg}${errorMsg}${missingMsg}"
+                def fullMessage = "${featureRelease} latest 'EA Build' publish status: *${health}*. Build: ${releaseLink}.${lastPublishedMsg}${errorMsg}${missingMsg}"
                 echo "===> ${fullMessage}"
-                //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
+                slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }
             echo '----------------------------------------------------------------'
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -67,7 +67,6 @@ def getLatestOpenjdkBuildTag(String version) {
     }
 
     def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | grep -v '\\-ga' ${jdk8Filter} | sort -V -r | head -1 | tr -d '\\n'")
-
     echo "latest upstream openjdk/${version} tag = ${latestTag}"
 
     return latestTag

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -62,7 +62,7 @@ def getLatestOpenjdkBuildTag(String version, Integer headMinus) {
         jdk8Filter += " | grep '\\-aarch32\\-'"
     }
 
-    def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | grep -v '\\-ga' ${jdk8Filter} | sort -V -r | head ${headMinus} | tr -d '\\n'")
+    def latestTag = sh(returnStdout: true, script:"git ls-remote --sort=-v:refname --tags ${openjdkRepo} | grep -v '\\^{}' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | grep -v '\\-ga' ${jdk8Filter} | sort -V -r | head ${headMinus} | tail -1 | tr -d '\\n'")
 
     echo "latest(head ${headMinus}) upstream openjdk/${version} tag = ${latestTag}"
 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -626,7 +626,7 @@ node('worker') {
         }
 
         // Slack message:
-        //slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
         echo 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }
@@ -732,7 +732,7 @@ node('worker') {
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
                 def fullMessage = "${featureRelease} latest pipeline publish status: *${health}*. Build: ${releaseLink}.${lastPublishedMsg}${errorMsg}${missingMsg}"
                 echo "===> ${fullMessage}"
-                //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
+                slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }
             echo '----------------------------------------------------------------'
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -671,7 +671,7 @@ node('worker') {
                 // Verify if any artifacts missing?
                 def missingMsg = ""
                 // Don't check if upstream tag is a GA, as the ea-beta will only be for evaluation platforms
-                if (nonTagBuildReleases.contains(featureRelease) || !isGaTag(featureRelease, status['upstreamTag'])) {
+                if (!isGaTag(featureRelease, status['upstreamTag'])) {
                     def missingAssets = []
                     if (status['assets'] != 'Complete') {
                         slackColor = 'danger'

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -668,44 +668,47 @@ node('worker') {
                     }
                 }
 
-                // Verify if any artifacts missing?                    
-                def missingAssets = []
-                if (status['assets'] != 'Complete') {
-                    slackColor = 'danger'
-                    health = "Unhealthy"
-                    errorMsg += "\nArtifact status: "+status['assets']
-                    if (inProgressBuildUrl != "") {
-                        errorMsg += ", <" + inProgressBuildUrl + "|Build is in progress>"
-                    } else {
-                        errorMsg += ", *No build is in progress*"
-                    }
-                    missingAssets = status['missingAssets']
-                }
-                 
-                // Print out formatted missing artifacts if any missing
-                def missingMsg = ""
-                if (missingAssets.size() > 0) {
-                    missingMsg += " :"
-                    // Collate by arch, array is sequenced by architecture
-                    def archName = ""
-                    def missingFiles = ""
-                    missingAssets.each { missing ->
-                        // arch : imageType : fileType
-                        def missingFile = missing.split("[ :]+")
-                        if (missingFile[0] != archName) {
-                            if (archName != "") {
-                                missingMsg += "\n    *${archName}*: ${missingFiles}"
-                                echo "===> ${missingMsg}"
-                            }
-                            archName = missingFile[0]
-                            missingFiles = missingFile[1]+missingFile[2]
+                // Verify if any artifacts missing?
+                // Don't check if upstream tag is a GA, as the ea-beta will only be for evaluation platforms
+                if (nonTagBuildReleases.contains(featureRelease) || !isGaTag(featureRelease, status['upstreamTag'])) {
+                    def missingAssets = []
+                    if (status['assets'] != 'Complete') {
+                        slackColor = 'danger'
+                        health = "Unhealthy"
+                        errorMsg += "\nArtifact status: "+status['assets']
+                        if (inProgressBuildUrl != "") {
+                            errorMsg += ", <" + inProgressBuildUrl + "|Build is in progress>"
                         } else {
-                            missingFiles += ", "+missingFile[1]+missingFile[2]
-                        }                        
-                    } 
-                    if (missingFiles != "") {
-                        missingMsg += "\n    *${archName}*: ${missingFiles}"
-                        echo "===> ${missingMsg}"
+                            errorMsg += ", *No build is in progress*"
+                        }
+                        missingAssets = status['missingAssets']
+                    }
+                 
+                    // Print out formatted missing artifacts if any missing
+                    def missingMsg = ""
+                    if (missingAssets.size() > 0) {
+                        missingMsg += " :"
+                        // Collate by arch, array is sequenced by architecture
+                        def archName = ""
+                        def missingFiles = ""
+                        missingAssets.each { missing ->
+                            // arch : imageType : fileType
+                            def missingFile = missing.split("[ :]+")
+                            if (missingFile[0] != archName) {
+                                if (archName != "") {
+                                    missingMsg += "\n    *${archName}*: ${missingFiles}"
+                                    echo "===> ${missingMsg}"
+                                }
+                                archName = missingFile[0]
+                                missingFiles = missingFile[1]+missingFile[2]
+                            } else {
+                               missingFiles += ", "+missingFile[1]+missingFile[2]
+                            }                        
+                        } 
+                        if (missingFiles != "") {
+                            missingMsg += "\n    *${archName}*: ${missingFiles}"
+                            echo "===> ${missingMsg}"
+                        }
                     }
                 }
 


### PR DESCRIPTION
- If the latest upstream tag is a GA build then don't expect an ea-beta build for it
- Also if a version has published a GA tag, then don't expect the ea-beta releases to be built for all the latest tags, as sometimes more than one build tag is published on a GA release
- 