### PR TITLE
Update textenv -ga tag check to handle jdk8u aarch32 port repo and checking for Lightweight git tags

### DIFF
--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -22,7 +22,7 @@ def buildConfigurations = null
 Map<String, ?> DEFAULTS_JSON = null
 
 // Find the testenv ga commit SHA specified by the jdkBranch
-// Returns a Tuple of "repository", "gaCommitSHA"
+// Returns a Tuple2 of "repository", "gaCommitSHA"
 def findGaCommitSHA(String repo, String jdkBranch, Boolean annotatedTag) {
     def openjdkRepo = repo
 
@@ -52,7 +52,7 @@ def findGaCommitSHA(String repo, String jdkBranch, Boolean annotatedTag) {
     }
 
     if (gaCommitSHA != "") {
-        return new Tuple(openjdkRepo, gaCommitSHA)
+        return new Tuple2(openjdkRepo, gaCommitSHA)
     } else {
         return null
     }

--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -28,6 +28,9 @@ def resolveGaTag(String jdkVersion, String jdkBranch) {
     def resolvedTag = jdkBranch // Default to as-is
     
     def openjdkRepo = "https://github.com/openjdk/jdk${jdkVersion}.git"
+    if (jdkBranch.contains("jdk8u") && jdkBranch.contains("aarch32")) {
+        openjdkRepo = "https://github.com/openjdk/aarch32-port-jdk8u.git"
+    }
                       
     def gaCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep '\\^{}' | grep \"${jdkBranch}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
     if (gaCommitSHA == "") {

--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -25,7 +25,13 @@ Map<String, ?> DEFAULTS_JSON = null
 def findGaCommitSHA(String repo, String jdkBranch, Boolean annotatedTag) {
     def openjdkRepo = repo
 
-    def annotatedTagFilter = (annotatedTag ? "| grep '\\^{}'" : "| -v grep '\\^{}'")
+    if (annotatedTag) {
+        println "Searching for Annotated git tag with name '${jdkBranch}' using repo base: ${openjdkRepo}"
+    } else {
+        println "Searching for Lightweight git tag with name '${jdkBranch}' using repo base: ${openjdkRepo}"
+    }
+
+    def annotatedTagFilter = (annotatedTag ? "| grep '\\^{}'" : "| grep -v '\\^{}'")
 
     def gaCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} ${annotatedTagFilter} | grep \"${jdkBranch}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
     if (gaCommitSHA == "") {
@@ -68,7 +74,7 @@ def resolveGaTag(String jdkVersion, String jdkBranch) {
     if (gaCommitSHA == "") {
         println "[ERROR] Unable to resolve ${jdkBranch} upstream commit, will try to match tag as-is"
     } else {
-        def annotatedTagFilter = (annotatedTag ? "| grep '\\^{}'" : "| -v grep '\\^{}'")
+        def annotatedTagFilter = (annotatedTag ? "| grep '\\^{}'" : "| grep -v '\\^{}'")
         def upstreamTag = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} ${annotatedTagFilter} | grep \"${gaCommitSHA}\" | grep -v \"${jdkBranch}\" | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | sed \"s,\\^{},,\" | tr -d '\\n'")
         if (upstreamTag != "") {
             println "[INFO] Resolved ${jdkBranch} to upstream build tag ${upstreamTag}"


### PR DESCRIPTION
The jdk8u aarch32 repo is tagged with different different tag names, and uses git Lieghtweight tagging
Update the -ga commit search to handle the aarch32-port-jdk8u port repo, and the detection of Lightweight tags