### PR TITLE
Now building also jcstress-tests-all-20240222.jar 20220908.jar

### DIFF
--- a/tools/code-tools/jcstress.sh
+++ b/tools/code-tools/jcstress.sh
@@ -28,6 +28,20 @@ function detectJdks() {
   jdk17=$(readlink -f $(find ${jvm_dir} -maxdepth 1 | sort | grep -e java-17- -e jdk-17 | head -n 1))
 }
 
+function buildJcstress {
+  local jdk="${1}"
+  local checkout="${2}"
+  local target="${3}"
+  export JAVA_HOME="${jdk}"
+  mvn clean
+  git checkout "${checkout}"
+  mvn clean install
+  mv -v "tests-all/target/${main_name}.jar" "${target}"
+  mvn clean
+  git checkout master
+  unset JAVA_HOME
+}
+
 REPO_DIR="jcstress"
 main_name=$REPO_DIR
 main_file=$main_name.jar
@@ -45,38 +59,20 @@ pushd $REPO_DIR
   rc=$main_name-$latestRelease.jar
 
   # latest released
-  git checkout $latestRelease
-  export JAVA_HOME=$jdk11
-  mvn clean install
-  mv tests-all/target/$main_name.jar $rc
+  buildJcstress "${jdk11}" "${latestRelease}" "${rc}"
   echo "Manually renaming $rc as $main_file to provide latest-stable-recommended file"
   ln -fv $rc $main_file
-  mvn clean
 
   # tip
-  git checkout master
-  export JAVA_HOME=$jdk17
-  mvn clean install
-  mv tests-all/target/$main_file $main_name-$tip_shortened.jar
+  buildJcstress "${jdk17}" "master" "${main_name}-${tip_shortened}.jar"
   echo "Manually renaming $main_name-$tip_shortened.jar as $main_name-tip.jar to provide latest-unstable-recommended file"
   ln -fv $main_name-$tip_shortened.jar $main_name-tip.jar
-  mvn clean
 
   # 20240222
-  git checkout c565311051494f4b9f78ec86eac6282f1de977e2
-  export JAVA_HOME=$jdk11
-  mvn clean install
-  mv -v tests-all/target/$main_name.jar jcstress-tests-all-20240222.jar
-  mvn clean
+  buildJcstress "${jdk11}" "c565311051494f4b9f78ec86eac6282f1de977e2" "jcstress-20240222.jar"
 
   # 20220908
-  git checkout d118775943666d46ca48a50f21b4e07b9ec1f7ed
-  export JAVA_HOME=$jdk11
-  mvn clean install
-  mv -v tests-all/target/$main_name.jar jcstress-tests-all-20220908.jar
-  mvn clean
+  buildJcstress "${jdk11}" "d118775943666d46ca48a50f21b4e07b9ec1f7ed" "jcstress-20220908.jar"
 
-  echo "Resetting repo back to master"
-  git checkout master
   hashArtifacts
 popd


### PR DESCRIPTION
Those are based on closest (which were actually that day last) commit hashes. junit tests are passing.

In addition shortened hash to 7 latters and uses jdk17 to tip

Should be fixing https://github.com/adoptium/ci-jenkins-pipelines/issues/1016