### PR TITLE
don't skip docker SHA collection on RHEL containers

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2009,13 +2009,13 @@ class Build {
                                                 context.docker.image(buildConfig.DOCKER_IMAGE).pull()
                                             }
                                         }
-                                        // Store the pulled docker image digest as 'buildinfo'
-                                        dockerImageDigest = context.sh(script: "docker inspect --format='{{.RepoDigests}}' ${buildConfig.DOCKER_IMAGE}", returnStdout:true)
                                     }
                                 } catch (FlowInterruptedException e) {
                                     throw new Exception("[ERROR] Controller docker image pull timeout (${buildTimeouts.DOCKER_PULL_TIMEOUT} HOURS) has been reached. Exiting...")
                                 }
                             }
+                            // Store the pulled docker image digest as 'buildinfo'
+                            dockerImageDigest = context.sh(script: "docker inspect --format='{{.RepoDigests}}' ${buildConfig.DOCKER_IMAGE}", returnStdout:true)
 
                             // Use our dockerfile if DOCKER_FILE is defined
                             if (buildConfig.DOCKER_FILE) {


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3786 https://github.com/adoptium/ci-jenkins-pipelines/issues/1022

While we don't pull the container build image from an external location on RHEL/s390x, we should still collect the SHA for inclusion in the SBoM.

(Note: It gets into the SBoM via the `-e` parameter passed in from the pipeline when the container is started which sets `BUILDIMAGESHA` which is then stored in `metadata/docker.txt` by `sbin/prepareWorkspace.sh` which is read by `sbin/build.sh`, into `buildimagesha` which is then added to the SBoM by `sbin/build.sh`)