### PR TITLE
add riscv64 to JDK17 release pipeline

### DIFF
--- a/pipelines/jobs/configurations/jdk17u_release.groovy
+++ b/pipelines/jobs/configurations/jdk17u_release.groovy
@@ -35,7 +35,6 @@ targetConfigurations = [
         'riscv64Linux': [
                 'temurin'
         ]
-
 ]
 
 return this

--- a/pipelines/jobs/configurations/jdk17u_release.groovy
+++ b/pipelines/jobs/configurations/jdk17u_release.groovy
@@ -31,7 +31,11 @@ targetConfigurations = [
         ],
         'arm32Linux'  : [
                 'temurin'
+        ],
+        'riscv64Linux': [
+                'temurin'
         ]
+
 ]
 
 return this


### PR DESCRIPTION
This will be formally discussed at the next PMC meeting before performing a release, but this change will allow us to be able to release a JDK17 on Linux/riscv64 which is believed to be in a good state now, and this will allow us to fully prep and test a release prior to shipping.