### PR TITLE
Add archive taps as a single jar file

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -968,6 +968,16 @@ class Builder implements Serializable {
                                             throw new Exception("[ERROR] Archive artifact timeout (${pipelineTimeouts.ARCHIVE_ARTIFACTS_TIMEOUT} HOURS) for ${downstreamJobName}has been reached. Exiting...")
                                         }
 
+                                        //Archive tap files as a single tar file
+                                        context.sh "find . -type f -name '*.tap' -exec tar -czf AQAvitTapFiles.tar.gz {} + "
+                                        try {
+                                            context.timeout(time: pipelineTimeouts.ARCHIVE_ARTIFACTS_TIMEOUT, unit: 'HOURS') {
+                                                context.archiveArtifacts artifacts: "AQAvitTapFiles.tar.gz"
+                                            }
+                                        } catch (FlowInterruptedException e) {
+                                            throw new Exception("[ERROR] Archive AQAvitTapFiles.tar.gz timeout Exiting...")
+                                        }
+
                                         copyArtifactSuccess = true
                                         if (release) {
                                             def (String releaseToolUrl, String releaseComment) = publishBinary(config)

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -968,7 +968,7 @@ class Builder implements Serializable {
                                             throw new Exception("[ERROR] Archive artifact timeout (${pipelineTimeouts.ARCHIVE_ARTIFACTS_TIMEOUT} HOURS) for ${downstreamJobName}has been reached. Exiting...")
                                         }
 
-                                        //Archive tap files as a single tar file
+                                        // Archive tap files as a single tar file
                                         context.sh "find . -type f -name '*.tap' -exec tar -czf AQAvitTapFiles.tar.gz {} + "
                                         try {
                                             context.timeout(time: pipelineTimeouts.ARCHIVE_ARTIFACTS_TIMEOUT, unit: 'HOURS') {


### PR DESCRIPTION
Tap files per platforms keep as before.

Parts of https://github.com/adoptium/aqa-tests/issues/5242