### PR TITLE
Archive all taps after parallel run

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -968,16 +968,6 @@ class Builder implements Serializable {
                                             throw new Exception("[ERROR] Archive artifact timeout (${pipelineTimeouts.ARCHIVE_ARTIFACTS_TIMEOUT} HOURS) for ${downstreamJobName}has been reached. Exiting...")
                                         }
 
-                                        // Archive tap files as a single tar file
-                                        context.sh "find . -type f -name '*.tap' -exec tar -czf AQAvitTapFiles.tar.gz {} + "
-                                        try {
-                                            context.timeout(time: pipelineTimeouts.ARCHIVE_ARTIFACTS_TIMEOUT, unit: 'HOURS') {
-                                                context.archiveArtifacts artifacts: "AQAvitTapFiles.tar.gz"
-                                            }
-                                        } catch (FlowInterruptedException e) {
-                                            throw new Exception("[ERROR] Archive AQAvitTapFiles.tar.gz timeout Exiting...")
-                                        }
-
                                         copyArtifactSuccess = true
                                         if (release) {
                                             def (String releaseToolUrl, String releaseComment) = publishBinary(config)
@@ -1006,6 +996,17 @@ class Builder implements Serializable {
                 }
             }
             context.parallel jobs
+            context.node('worker') {
+                // Archive tap files as a single tar file
+                context.sh "find . -type f -name '*.tap' -exec tar -czf AQAvitTapFiles.tar.gz {} + "
+                try {
+                    context.timeout(time: pipelineTimeouts.ARCHIVE_ARTIFACTS_TIMEOUT, unit: 'HOURS') {
+                        context.archiveArtifacts artifacts: "AQAvitTapFiles.tar.gz"
+                    }
+                } catch (FlowInterruptedException e) {
+                    throw new Exception("[ERROR] Archive AQAvitTapFiles.tar.gz timeout Exiting...")
+                }
+            }
             // publish to github if needed
             // Don't publish release automatically
             if (publish || release) {


### PR DESCRIPTION

Related with https://github.com/adoptium/ci-jenkins-pipelines/pull/1027

https://github.com/adoptium/aqa-tests/issues/5242