### PR TITLE
Switch JDK22+ on AIX to use OpenXL17-compatible labels

### DIFF
--- a/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
@@ -78,12 +78,12 @@ class Config22 {
                 os                  : 'aix',
                 arch                : 'ppc64',
                 additionalNodeLabels: [
-                        temurin: 'xlc16&&aix720',
+                        temurin: 'openxl17&&aix720',
                         openj9:  'xlc16&&aix715'
                 ],
                 test                : 'default',
                 additionalTestLabels: [
-                        temurin      : 'sw.os.aix.7_2'
+                        temurin      : 'sw.os.aix.7_2TL5'
                 ],
                 cleanWorkspaceAfterBuild: true,
                 buildArgs           : [

--- a/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
@@ -78,12 +78,12 @@ class Config23 {
                 os                  : 'aix',
                 arch                : 'ppc64',
                 additionalNodeLabels: [
-                        temurin: 'xlc16&&aix720',
+                        temurin: 'openxl17&&aix720',
                         openj9:  'xlc16&&aix715'
                 ],
                 test                : 'default',
                 additionalTestLabels: [
-                        temurin      : 'sw.os.aix.7_2'
+                        temurin      : 'sw.os.aix.7_2TL5'
                 ],
                 cleanWorkspaceAfterBuild: true,
                 buildArgs           : [


### PR DESCRIPTION
Switch the pipelines to ensure that the JDK22+ jobs on AIX are only run on the machines that support OpenXL17

@smlambert I'm going to let you have a veto on this - I've added `openxl17` for the build machine and `sw.os.aix.7_2TL5` for test - the existing label we're using for earlier machines is the same without the `TL5` suffix.

FYI @suchismith1993
Ref: https://github.com/adoptium/temurin-build/pull/3822#issuecomment-2173804894
This will allow us to enable further machines as planned in https://github.com/adoptium/infrastructure/issues/3606
Part of https://github.com/adoptium/infrastructure/issues/3208