### PR TITLE
Save DevKit downloaded rpms from bootstrap build to save download in final build

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -64,3 +64,5 @@ jobs:
           VALIDATE_DOCKERFILE_HADOLINT: false
           # checkov fails
           VALIDATE_CHECKOV: false
+          # isgnore shell formatting checker
+          VALIDATE_SHELL_SHFMT: false

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -64,5 +64,5 @@ jobs:
           VALIDATE_DOCKERFILE_HADOLINT: false
           # checkov fails
           VALIDATE_CHECKOV: false
-          # isgnore shell formatting checker
+          # ignore shell formatting checker
           VALIDATE_SHELL_SHFMT: false


### PR DESCRIPTION
Update make_devkit.sh to use the downloaded rpms from the bootstrap gcc build, to use in the 2nd final build

Note: Disabled new super-linter 6.6.0 VALIDATE_SHELL_SHFMT, as not useful