### PR TITLE
Update runAQATests JDK repo & branch for jdk23+ version branching

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -223,7 +223,7 @@ class Build {
             } else if (buildConfig.VARIANT == 'temurin') {
                 // jdk(head) now contains version branched stabilisation branches, eg.dev_jdk23
                 if (getJavaVersionNumber() >= 23 && !buildConfig.JAVA_TO_BUILD.endsWith('u') && buildConfig.JAVA_TO_BUILD != "jdk") {
-                    jdkBranch = 'dev_'+getJavaVersionNumber()
+                    jdkBranch = 'dev_'+buildConfig.JAVA_TO_BUILD
                 } else {
                     jdkBranch = 'dev'
                 }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -221,7 +221,12 @@ class Build {
             } else if (buildConfig.VARIANT == 'hotspot') {
                 jdkBranch = 'master'
             } else if (buildConfig.VARIANT == 'temurin') {
-                jdkBranch = 'dev'
+                // jdk(head) now contains version branched stabilisation branches, eg.dev_jdk23
+                if (getJavaVersionNumber() >= 23 && !buildConfig.JAVA_TO_BUILD.endsWith('u') && buildConfig.JAVA_TO_BUILD != "jdk") {
+                    jdkBranch = 'dev_'+getJavaVersionNumber()
+                } else {
+                    jdkBranch = 'dev'
+                }
             } else if (buildConfig.VARIANT == 'dragonwell') {
                 jdkBranch = 'master'
             } else if (buildConfig.VARIANT == 'fast_startup') {
@@ -264,7 +269,12 @@ class Build {
                 } else if (buildConfig.ARCHITECTURE == 'riscv64' && buildConfig.JAVA_TO_BUILD == 'jdk11u') {
                     suffix = 'adoptium/riscv-port-jdk11u'
                 } else {
-                    suffix = "adoptium/${buildConfig.JAVA_TO_BUILD}"
+                    // jdk(head) repo now contains the version branched stabilisation branches, eg.dev_jdk23
+                    if (javaNumber >= 23 && !buildConfig.JAVA_TO_BUILD.endsWith('u')) {
+                        suffix = "adoptium/jdk"
+                    } else {
+                        suffix = "adoptium/${buildConfig.JAVA_TO_BUILD}"
+                    }
                 }
                 break
             case 'hotspot':
@@ -273,7 +283,12 @@ class Build {
                         || buildConfig.JAVA_TO_BUILD == "jdk11u")) {
                     suffix = "openjdk/riscv-port-${buildConfig.JAVA_TO_BUILD}";
                 } else {
-                    suffix = "openjdk/${buildConfig.JAVA_TO_BUILD}"
+                    // jdk(head) repo now contains the version branched stabilisation branches, eg.jdk23
+                    if (javaNumber >= 23 && !buildConfig.JAVA_TO_BUILD.endsWith('u')) {
+                        suffix = "openjdk/jdk"
+                    } else {
+                        suffix = "openjdk/${buildConfig.JAVA_TO_BUILD}"
+                    }
                 }
                 break
             case 'dragonwell':


### PR DESCRIPTION
jdk-23+ stablisation versions are now in jdk(head) repo, mirror branches, dev_jdkNN and release_jdkNN.
Update runAQATests() to pass the correct JDKRepo and JDKBranch params...
