### PR TITLE
Correct by platform archive AQAvitTapFiles.tar.gz location

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -974,7 +974,7 @@ class Builder implements Serializable {
                                             // Archive if any tap files were found
                                             if (context.fileExists("target/${config.TARGET_OS}/${config.ARCHITECTURE}/${config.VARIANT}/AQAvitTaps/AQAvitTapFiles.tar.gz")) {
                                                 context.timeout(time: pipelineTimeouts.ARCHIVE_ARTIFACTS_TIMEOUT, unit: 'HOURS') {
-                                                    context.archiveArtifacts artifacts: "AQAvitTapFiles.tar.gz"
+                                                    context.archiveArtifacts artifacts: "target/${config.TARGET_OS}/${config.ARCHITECTURE}/${config.VARIANT}/AQAvitTaps/AQAvitTapFiles.tar.gz"
                                                 }
                                             } else {
                                                 context.println "No AQAvit tap files found to archive for target/${config.TARGET_OS}/${config.ARCHITECTURE}/${config.VARIANT}"


### PR DESCRIPTION
The "by platform" AQAvitTapFiles.tar.gz archiveArtifact location is wrong, so is not finding it:
```
13:36:43  + find target/linux/x64/temurin/AQAvitTaps -type f -name *.tap -exec tar -czf target/linux/x64/temurin/AQAvitTaps/AQAvitTapFiles.tar.gz {} +
[Pipeline] fileExists
[Pipeline] {
[Pipeline] archiveArtifacts
13:36:44  Archiving artifacts
13:36:47  ‘AQAvitTapFiles.tar.gz’ doesn’t match anything, but ‘target/linux/x64/temurin/AQAvitTaps/AQAvitTapFiles.tar.gz’ does. Perhaps that’s what you mean?
[Pipeline] }
13:36:47  ERROR: Error during copy and archive artifacts for build job: build-scripts/jobs/jdk23/jdk23-linux-x64-temurin
13:36:47  ERROR: No artifacts found that match the file pattern "AQAvitTapFiles.tar.gz". Configuration error?
13:36:47  Setting overall build result to FAILURE
```

When I fixed the the platform AQAvitTapFiles.tar.gz’ location, I forgot to change the achived artifact target!