### PR TITLE
devkit: add RHEL support to patch and fix uname

### DIFF
--- a/pipelines/build/devkit/Makefile.patch
+++ b/pipelines/build/devkit/Makefile.patch
@@ -1,0 +1,13 @@
+diff --git a/make/devkit/Makefile b/make/devkit/Makefile
+index c85a7c21d29..8f69d23c325 100644
+--- a/make/devkit/Makefile
++++ b/make/devkit/Makefile
+@@ -58,7 +58,7 @@
+ COMMA := ,
+ 
+ os := $(shell uname -o)
+-cpu := $(shell uname -p)
++cpu := $(shell uname -m)
+ 
+ # Figure out what platform this is building on.
+ me := $(cpu)-$(if $(findstring Linux,$(os)),linux-gnu)

--- a/pipelines/build/devkit/Tools.gmk.patch
+++ b/pipelines/build/devkit/Tools.gmk.patch
@@ -1,5 +1,5 @@
 diff --git a/make/devkit/Tools.gmk b/make/devkit/Tools.gmk
-index 187320ca2..9f1454d5e 100644
+index 187320ca26e..7f334eb2834 100644
 --- a/make/devkit/Tools.gmk
 +++ b/make/devkit/Tools.gmk
 @@ -62,6 +62,23 @@ ifeq ($(BASE_OS), OL)
@@ -73,22 +73,28 @@ index 187320ca2..9f1454d5e 100644
    REQUIRED_MIN_MAKE_MAJOR_VERSION := 4
  else ifeq ($(GCC_VER), 11.2.0)
    gcc_ver := gcc-11.2.0
-@@ -246,7 +286,13 @@ download-rpms:
+@@ -245,8 +285,18 @@ download-rpms:
+ 	mkdir -p $(DOWNLOAD_RPMS)
          # Only run this if rpm dir is empty.
          ifeq ($(wildcard $(DOWNLOAD_RPMS)/*.rpm), )
- 	  cd $(DOWNLOAD_RPMS) && \
+-	  cd $(DOWNLOAD_RPMS) && \
 -	      wget -r -np -nd $(patsubst %, -A "*%*.rpm", $(RPM_LIST)) $(BASE_URL)
-+	    wget -e robots=off -r -np -nd $(patsubst %, -A "*%*.rpm", $(RPM_LIST)) $(BASE_URL)
-+	  gpg --keyserver keyserver.ubuntu.com --recv-keys \
-+	    $($(BASE_OS)_$(BASE_OS_MAJOR_VERSION)_GPG_KEY_$(ARCH))
-+	  rm -f $(DOWNLOAD_RPMS)/rpm.sig && gpg --armor --export \
-+	    $($(BASE_OS)_$(BASE_OS_MAJOR_VERSION)_GPG_KEY_$(ARCH)) > $(DOWNLOAD_RPMS)/rpm.sig
-+	  rpm --import $(DOWNLOAD_RPMS)/rpm.sig || true
-+	  rpm -K $(DOWNLOAD_RPMS)/*.rpm
++          ifeq ($(BASE_OS), RHEL)
++            yumdownloader --destdir=$(DOWNLOAD_RPMS) $(RPM_LIST)
++          else
++	    cd $(DOWNLOAD_RPMS) && \
++	      wget -e robots=off -r -np -nd $(patsubst %, -A "*%*.rpm", $(RPM_LIST)) $(BASE_URL)
++	    gpg --keyserver keyserver.ubuntu.com --recv-keys \
++	      $($(BASE_OS)_$(BASE_OS_MAJOR_VERSION)_GPG_KEY_$(ARCH))
++	    rm -f $(DOWNLOAD_RPMS)/rpm.sig && gpg --armor --export \
++	      $($(BASE_OS)_$(BASE_OS_MAJOR_VERSION)_GPG_KEY_$(ARCH)) > $(DOWNLOAD_RPMS)/rpm.sig
++	    rpm --import $(DOWNLOAD_RPMS)/rpm.sig || true
++	    rpm -K $(DOWNLOAD_RPMS)/*.rpm
++          endif
          endif
  
  ##########################################################################################
-@@ -271,6 +317,14 @@ define Download
+@@ -271,6 +321,14 @@ define Download
  
    $$($(1)_FILE) :
  	wget -P $(DOWNLOAD) $$($(1))
@@ -103,7 +109,7 @@ index 187320ca2..9f1454d5e 100644
  endef
  
  # Download and unpack all source packages
-@@ -323,6 +377,9 @@ $(foreach p,$(RPM_FILE_LIST),$(eval $(call unrpm,$(p))))
+@@ -323,6 +381,9 @@ $(foreach p,$(RPM_FILE_LIST),$(eval $(call unrpm,$(p))))
  # have it anyway, but just to make sure...
  # Patch libc.so and libpthread.so to force linking against libraries in sysroot
  # and not the ones installed on the build machine.
@@ -113,7 +119,7 @@ index 187320ca2..9f1454d5e 100644
  $(libs) : $(rpms)
  	@echo Patching libc and pthreads
  	@(for f in `find $(SYSROOT) -name libc.so -o -name libpthread.so`; do \
-@@ -332,6 +389,7 @@ $(libs) : $(rpms)
+@@ -332,6 +393,7 @@ $(libs) : $(rpms)
  	      -e 's|/lib/||g' ) > $$f.tmp ; \
  	  mv $$f.tmp $$f ; \
  	done)
@@ -121,7 +127,7 @@ index 187320ca2..9f1454d5e 100644
  	@mkdir -p $(SYSROOT)/usr/lib
  	@touch $@
  
-@@ -440,6 +498,9 @@ endif
+@@ -440,6 +502,9 @@ endif
  
  # Makefile creation. Simply run configure in build dir.
  # Setting CFLAGS to -O2 generates a much faster ld.
@@ -131,7 +137,7 @@ index 187320ca2..9f1454d5e 100644
  $(bfdmakes) \
  $(BUILDDIR)/$(binutils_ver)/Makefile \
      : $(BINUTILS_CFG)
-@@ -454,6 +515,7 @@ $(BUILDDIR)/$(binutils_ver)/Makefile \
+@@ -454,6 +519,7 @@ $(BUILDDIR)/$(binutils_ver)/Makefile \
  	      --with-sysroot=$(SYSROOT) \
  	      --disable-nls \
  	      --program-prefix=$(TARGET)- \

--- a/pipelines/build/devkit/make_devkit.sh
+++ b/pipelines/build/devkit/make_devkit.sh
@@ -37,9 +37,10 @@ openjdkRepo="https://github.com/openjdk/${VERSION}.git"
 git clone --depth 1 ${openjdkRepo} ${VERSION}
 cd ${VERSION}
 
-# Patch to support Centos7
+# Patch to support Centos7, RHEL, and uname fix
 cp ../binutils-2.39.patch make/devkit/patches/${ARCH}-binutils-2.39.patch
 patch -p1 < ../Tools.gmk.patch
+patch -p1 < ../Makefile.patch
 
 devkit_target="${ARCH}-linux-gnu"
 


### PR DESCRIPTION
Part of https://github.com/adoptium/temurin-build/issues/3749

Notes:
- This allows 'RHEL' to be used as the OS name, and will download the packages on-demand. This requires `yum-utils` to be installed ([infrastructure PR](https://github.com/adoptium/infrastructure/pull/3640)) unlike the previous solution (which required them to have been pre-downloaded by an administrator on the machine.
- The version number you specify to the script is irrelevant - it will only create a devkit for the RHEL version that's being used
