### PR TITLE
Enable SBOM strace for all Linux platforms

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1839,6 +1839,8 @@ class Build {
                                     context.sh(script: 'rm -rf ' + context.WORKSPACE + '/workspace/target')
                                     context.println 'Cleaning workspace build output files: ' + context.WORKSPACE + '/workspace/build/devkit'
                                     context.sh(script: 'rm -rf ' + context.WORKSPACE + '/workspace/build/devkit')
+                                    context.println 'Cleaning workspace build output files: ' + context.WORKSPACE + '/workspace/build/straceOutput'
+                                    context.sh(script: 'rm -rf ' + context.WORKSPACE + '/workspace/build/straceOutput')
                                 }
                             } else {
                                 context.println 'Warning: Unable to clean workspace as context.WORKSPACE is null/empty'

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -60,7 +60,7 @@ class Config11 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-headless-only=yes',
-                        'temurin'   : '--enable-headless-only=yes --disable-ccache --with-jobs=16'
+                        'temurin'   : '--enable-headless-only=yes --disable-ccache --with-jobs=4'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom --enable-sbom-strace'
@@ -193,7 +193,7 @@ class Config11 {
                         dragonwell: 'armv8.2'
                 ],
                 configureArgs       : [
-                        'temurin'   : '--enable-dtrace=auto --disable-ccache --with-jobs=16',
+                        'temurin'   : '--enable-dtrace=auto --disable-ccache --with-jobs=4',
                         'openj9'    : '--enable-dtrace=auto',
                         'corretto'  : '--enable-dtrace=auto',
                         'dragonwell': "--enable-dtrace=auto --with-extra-cflags=\"-march=armv8.2-a+crypto\" --with-extra-cxxflags=\"-march=armv8.2-a+crypto\"",

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -8,7 +8,7 @@ class Config11 {
                 additionalNodeLabels: 'xcode15.0.1',
                 configureArgs       : [
                         'openj9'      : '--enable-dtrace=auto --with-cmake',
-                        'temurin'     : '--enable-dtrace=auto'
+                        'temurin'     : '--enable-dtrace=auto --disable-ccache'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom'
@@ -27,7 +27,7 @@ class Config11 {
                 ],
                 configureArgs       : [
                         'openj9'      : '--enable-dtrace=auto',
-                        'temurin'     : '--enable-dtrace=auto',
+                        'temurin'     : '--enable-dtrace=auto --disable-ccache',
                         'corretto'    : '--enable-dtrace=auto',
                         'SapMachine'  : '--enable-dtrace=auto',
                         'dragonwell'  : '--enable-dtrace=auto --enable-unlimited-crypto --with-jvm-variants=server --with-zlib=system --with-jvm-features=zgc',
@@ -44,7 +44,10 @@ class Config11 {
                 arch                : 'x64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--enable-headless-only=yes',
+                configureArgs       : [
+                        'openj9'    : '--enable-headless-only=yes',
+                        'temurin'   : '--enable-headless-only=yes --disable-ccache'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom --enable-sbom-strace'
                 ]
@@ -57,7 +60,7 @@ class Config11 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-headless-only=yes',
-                        'temurin'   : '--enable-headless-only=yes --with-jobs=16'
+                        'temurin'   : '--enable-headless-only=yes --disable-ccache --with-jobs=16'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom --enable-sbom-strace'
@@ -72,8 +75,11 @@ class Config11 {
                         openj9:     'win2012&&vs2017',
                         dragonwell: 'win2012'
                 ],
+                configureArgs       : [
+                        'temurin'   : '--disable-ccache'
+                ],
                 buildArgs : [
-                        temurin : '--jvm-variant client,server --create-sbom'
+                        'temurin' : '--jvm-variant client,server --create-sbom'
                 ],
                 test                : 'default'
         ],
@@ -82,8 +88,11 @@ class Config11 {
                 os                  : 'windows',
                 arch                : 'x86-32',
                 additionalNodeLabels: 'win2022&&vs2019',
+                configureArgs       : [
+                        'temurin'   : '--disable-ccache'
+                ],
                 buildArgs : [
-                        temurin : '--jvm-variant client,server --create-sbom'
+                        'temurin' : '--jvm-variant client,server --create-sbom'
                 ],
                 test                : 'default'
         ],
@@ -95,6 +104,9 @@ class Config11 {
                 test                : 'default',
                 additionalTestLabels: 'sw.os.aix.7_2',
                 cleanWorkspaceAfterBuild: true,
+                configureArgs       : [
+                        'temurin'   : '--disable-ccache'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom'
                 ]
@@ -105,7 +117,10 @@ class Config11 {
                 arch                : 's390x',
                 dockerImage         : 'rhel7_build_image',
                 test                : 'default',
-                configureArgs       : '--enable-dtrace=auto',
+                configureArgs       : [
+                        'openj9'    : '--enable-dtrace=auto',
+                        'temurin'   : '--enable-dtrace=auto --disable-ccache'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom --enable-sbom-strace'
                 ]
@@ -115,7 +130,10 @@ class Config11 {
                 os                  : 'solaris',
                 arch                : 'sparcv9',
                 test                : false,
-                configureArgs       : '--enable-dtrace=auto',
+                configureArgs       : [
+                        'openj9'    : '--enable-dtrace=auto',
+                        'temurin'   : '--enable-dtrace=auto --disable-ccache'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom'
                 ]
@@ -127,7 +145,7 @@ class Config11 {
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
                 configureArgs       : [
-                        'temurin'     : '--enable-dtrace=auto',
+                        'temurin'     : '--enable-dtrace=auto --disable-ccache',
                         'openj9'      : '--enable-dtrace=auto'
                 ],
                 buildArgs           : [
@@ -156,7 +174,7 @@ class Config11 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace=auto',
-                        'temurin'   : '--enable-dtrace=auto --with-jobs=4'
+                        'temurin'   : '--enable-dtrace=auto --disable-ccache --with-jobs=4'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom --enable-sbom-strace'
@@ -175,7 +193,7 @@ class Config11 {
                         dragonwell: 'armv8.2'
                 ],
                 configureArgs       : [
-                        'temurin'   : '--enable-dtrace=auto --with-jobs=16',
+                        'temurin'   : '--enable-dtrace=auto --disable-ccache --with-jobs=16',
                         'openj9'    : '--enable-dtrace=auto',
                         'corretto'  : '--enable-dtrace=auto',
                         'dragonwell': "--enable-dtrace=auto --with-extra-cflags=\"-march=armv8.2-a+crypto\" --with-extra-cxxflags=\"-march=armv8.2-a+crypto\"",
@@ -231,6 +249,9 @@ class Config11 {
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
+                configureArgs       : [
+                        'temurin'   : '--disable-ccache'
+                ], 
                 buildArgs       : [
                         'temurin'   : '--jvm-variant client,server --create-sbom --cross-compile'
                 ]

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -35,7 +35,7 @@ class Config11 {
                         'bisheng'     : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server --disable-warnings-as-errors'
                 ],
                 buildArgs            : [
-                        'temurin'     : '--create-source-archive --create-sbom'
+                        'temurin'     : '--create-source-archive --create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -46,7 +46,7 @@ class Config11 {
                 test                : 'default',
                 configureArgs       : '--enable-headless-only=yes',
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -55,9 +55,12 @@ class Config11 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--enable-headless-only=yes',
+                configureArgs       : [
+                        'openj9'    : '--enable-headless-only=yes',
+                        'temurin'   : '--enable-headless-only=yes --with-jobs=40'
+                ],
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -104,7 +107,7 @@ class Config11 {
                 test                : 'default',
                 configureArgs       : '--enable-dtrace=auto',
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -128,7 +131,7 @@ class Config11 {
                         'openj9'      : '--enable-dtrace=auto'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom --enable-sbom-strace'
                 ]
 
         ],
@@ -151,9 +154,12 @@ class Config11 {
                 dockerImage         : 'adoptopenjdk/ubuntu1604_build_image',
                 dockerArgs          : '--platform linux/arm/v7',
                 test                : 'default',
-                configureArgs       : '--enable-dtrace=auto',
+                configureArgs       : [
+                        'openj9'    : '--enable-dtrace=auto',
+                        'temurin'   : '--enable-dtrace=auto --with-jobs=40'
+                ],
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -169,14 +175,14 @@ class Config11 {
                         dragonwell: 'armv8.2'
                 ],
                 configureArgs       : [
-                        'temurin'   : '--enable-dtrace=auto',
+                        'temurin'   : '--enable-dtrace=auto --with-jobs=40',
                         'openj9'    : '--enable-dtrace=auto',
                         'corretto'  : '--enable-dtrace=auto',
                         'dragonwell': "--enable-dtrace=auto --with-extra-cflags=\"-march=armv8.2-a+crypto\" --with-extra-cxxflags=\"-march=armv8.2-a+crypto\"",
                         'bisheng'   : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom --enable-sbom-strace'
                 ]
         ],
 

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -156,7 +156,7 @@ class Config11 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace=auto',
-                        'temurin'   : '--enable-dtrace=auto --with-jobs=40'
+                        'temurin'   : '--enable-dtrace=auto --with-jobs=4'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom --enable-sbom-strace'

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -57,7 +57,7 @@ class Config11 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-headless-only=yes',
-                        'temurin'   : '--enable-headless-only=yes --with-jobs=40'
+                        'temurin'   : '--enable-headless-only=yes --with-jobs=16'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom --enable-sbom-strace'
@@ -175,7 +175,7 @@ class Config11 {
                         dragonwell: 'armv8.2'
                 ],
                 configureArgs       : [
-                        'temurin'   : '--enable-dtrace=auto --with-jobs=40',
+                        'temurin'   : '--enable-dtrace=auto --with-jobs=16',
                         'openj9'    : '--enable-dtrace=auto',
                         'corretto'  : '--enable-dtrace=auto',
                         'dragonwell': "--enable-dtrace=auto --with-extra-cflags=\"-march=armv8.2-a+crypto\" --with-extra-cxxflags=\"-march=armv8.2-a+crypto\"",

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -176,7 +176,7 @@ class Config17 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',
-                        'temurin'   : '--enable-dtrace --with-jobs=40'
+                        'temurin'   : '--enable-dtrace --with-jobs=4'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -42,7 +42,7 @@ class Config17 {
                         'temurin'   : '--enable-dtrace'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-source-archive --create-jre-image --create-sbom'
+                        'temurin'   : '--create-source-archive --create-jre-image --create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -53,7 +53,7 @@ class Config17 {
                 test                : 'default',
                 configureArgs       : '--enable-headless-only=yes',
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -62,9 +62,12 @@ class Config17 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--enable-headless-only=yes',
+                configureArgs       : [
+                        'openj9'    : '--enable-headless-only=yes',
+                        'temurin'   : '--enable-headless-only=yes --with-jobs=40'
+                ],
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -115,7 +118,7 @@ class Config17 {
                 ],
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -128,7 +131,7 @@ class Config17 {
                         'temurin'   : true
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -137,12 +140,15 @@ class Config17 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
-                configureArgs : '--enable-dtrace',
+                configureArgs       : [
+                        'openj9'    : '--enable-dtrace',
+                        'temurin'   : '--enable-dtrace --with-jobs=40'
+                ],
                 reproducibleCompare : [
                         'temurin'   : true
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]
 
         ],
@@ -168,9 +174,12 @@ class Config17 {
                 dockerImage         : 'adoptopenjdk/ubuntu1604_build_image',
                 dockerArgs          : '--platform linux/arm/v7',
                 test                : 'default',
-                configureArgs       : '--enable-dtrace',
+                configureArgs       : [
+                        'openj9'    : '--enable-dtrace',
+                        'temurin'   : '--enable-dtrace --with-jobs=40'
+                ],
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]
         ],
 

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -64,7 +64,7 @@ class Config17 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-headless-only=yes',
-                        'temurin'   : '--enable-headless-only=yes --with-jobs=40'
+                        'temurin'   : '--enable-headless-only=yes --with-jobs=16'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
@@ -142,7 +142,7 @@ class Config17 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',
-                        'temurin'   : '--enable-dtrace --with-jobs=40'
+                        'temurin'   : '--enable-dtrace --with-jobs=16'
                 ],
                 reproducibleCompare : [
                         'temurin'   : true

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -64,7 +64,7 @@ class Config17 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-headless-only=yes',
-                        'temurin'   : '--enable-headless-only=yes --with-jobs=16'
+                        'temurin'   : '--enable-headless-only=yes --with-jobs=4'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
@@ -142,7 +142,7 @@ class Config17 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',
-                        'temurin'   : '--enable-dtrace --with-jobs=16'
+                        'temurin'   : '--enable-dtrace --with-jobs=4'
                 ],
                 reproducibleCompare : [
                         'temurin'   : true

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -51,7 +51,7 @@ class Config21 {
                 test                : 'default',
                 configureArgs       : '--enable-headless-only=yes',
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -60,9 +60,12 @@ class Config21 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--enable-headless-only=yes',
+                configureArgs       : [
+                        'openj9'    : '--enable-headless-only=yes',
+                        'temurin'   : '--enable-headless-only=yes --with-jobs=40'
+                ],
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -108,7 +111,7 @@ class Config21 {
                         'temurin'   : true
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
                 ]
         ],
 

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -62,7 +62,7 @@ class Config21 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-headless-only=yes',
-                        'temurin'   : '--enable-headless-only=yes --with-jobs=40'
+                        'temurin'   : '--enable-headless-only=yes --with-jobs=16'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
@@ -141,7 +141,7 @@ class Config21 {
                 ],
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',
-                        'temurin'   : '--enable-dtrace --with-jobs=40'
+                        'temurin'   : '--enable-dtrace --with-jobs=16'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -62,7 +62,7 @@ class Config21 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-headless-only=yes',
-                        'temurin'   : '--enable-headless-only=yes --with-jobs=16'
+                        'temurin'   : '--enable-headless-only=yes --with-jobs=4'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
@@ -141,7 +141,7 @@ class Config21 {
                 ],
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',
-                        'temurin'   : '--enable-dtrace --with-jobs=16'
+                        'temurin'   : '--enable-dtrace --with-jobs=4'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'

--- a/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
@@ -57,7 +57,7 @@ class Config22 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-headless-only=yes',
-                        'temurin'   : '--enable-headless-only=yes --with-jobs=16'
+                        'temurin'   : '--enable-headless-only=yes --with-jobs=4'
                 ],  
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
@@ -124,7 +124,7 @@ class Config22 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',
-                        'temurin'   : '--enable-dtrace --with-jobs=16'
+                        'temurin'   : '--enable-dtrace --with-jobs=4'
                 ],  
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'

--- a/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
@@ -35,7 +35,7 @@ class Config22 {
                         'temurin'   : '--enable-dtrace'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-source-archive --create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
+                        'temurin'   : '--create-source-archive --create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
                 ]
         ],
 
@@ -46,7 +46,7 @@ class Config22 {
                 test                : 'default',
                 configureArgs       : '--enable-headless-only=yes',
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -55,9 +55,12 @@ class Config22 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--enable-headless-only=yes',
+                configureArgs       : [
+                        'openj9'    : '--enable-headless-only=yes',
+                        'temurin'   : '--enable-headless-only=yes --with-jobs=40'
+                ],  
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -97,7 +100,7 @@ class Config22 {
                 dockerImage         : 'rhel7_build_image',
                 test                : 'default',
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
                 ]
         ],
 
@@ -110,7 +113,7 @@ class Config22 {
                         'openj9'      : '--enable-dtrace'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
                 ]
         ],
 
@@ -119,9 +122,12 @@ class Config22 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
-                configureArgs : '--enable-dtrace',
+                configureArgs       : [
+                        'openj9'    : '--enable-dtrace',
+                        'temurin'   : '--enable-dtrace --with-jobs=40'
+                ],  
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'
                 ]
         ],
 

--- a/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
@@ -57,7 +57,7 @@ class Config22 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-headless-only=yes',
-                        'temurin'   : '--enable-headless-only=yes --with-jobs=40'
+                        'temurin'   : '--enable-headless-only=yes --with-jobs=16'
                 ],  
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
@@ -124,7 +124,7 @@ class Config22 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',
-                        'temurin'   : '--enable-dtrace --with-jobs=40'
+                        'temurin'   : '--enable-dtrace --with-jobs=16'
                 ],  
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'

--- a/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
@@ -57,7 +57,7 @@ class Config23 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-headless-only=yes',
-                        'temurin'   : '--enable-headless-only=yes --with-jobs=40'
+                        'temurin'   : '--enable-headless-only=yes --with-jobs=16'
                 ], 
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
@@ -124,7 +124,7 @@ class Config23 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',
-                        'temurin'   : '--enable-dtrace --with-jobs=40'
+                        'temurin'   : '--enable-dtrace --with-jobs=16'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'

--- a/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
@@ -57,7 +57,7 @@ class Config23 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-headless-only=yes',
-                        'temurin'   : '--enable-headless-only=yes --with-jobs=16'
+                        'temurin'   : '--enable-headless-only=yes --with-jobs=4'
                 ], 
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
@@ -124,7 +124,7 @@ class Config23 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',
-                        'temurin'   : '--enable-dtrace --with-jobs=16'
+                        'temurin'   : '--enable-dtrace --with-jobs=4'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'

--- a/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
@@ -35,7 +35,7 @@ class Config23 {
                         'temurin'   : '--enable-dtrace'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-source-archive --create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
+                        'temurin'   : '--create-source-archive --create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
                 ]
         ],
 
@@ -46,7 +46,7 @@ class Config23 {
                 test                : 'default',
                 configureArgs       : '--enable-headless-only=yes',
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -55,9 +55,12 @@ class Config23 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--enable-headless-only=yes',
+                configureArgs       : [
+                        'openj9'    : '--enable-headless-only=yes',
+                        'temurin'   : '--enable-headless-only=yes --with-jobs=40'
+                ], 
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -97,7 +100,7 @@ class Config23 {
                 dockerImage         : 'rhel7_build_image',
                 test                : 'default',
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
                 ]
         ],
 
@@ -110,7 +113,7 @@ class Config23 {
                         'openj9'      : '--enable-dtrace'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
                 ]
         ],
 
@@ -119,9 +122,12 @@ class Config23 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
-                configureArgs : '--enable-dtrace',
+                configureArgs       : [
+                        'openj9'    : '--enable-dtrace',
+                        'temurin'   : '--enable-dtrace --with-jobs=40'
+                ],
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'
                 ]
         ],
 

--- a/pipelines/jobs/configurations/jdk24_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk24_pipeline_config.groovy
@@ -57,7 +57,7 @@ class Config24 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-headless-only=yes',
-                        'temurin'   : '--enable-headless-only=yes --with-jobs=40'
+                        'temurin'   : '--enable-headless-only=yes --with-jobs=16'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
@@ -124,7 +124,7 @@ class Config24 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',
-                        'temurin'   : '--enable-dtrace --with-jobs=40'
+                        'temurin'   : '--enable-dtrace --with-jobs=16'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'

--- a/pipelines/jobs/configurations/jdk24_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk24_pipeline_config.groovy
@@ -57,7 +57,7 @@ class Config24 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-headless-only=yes',
-                        'temurin'   : '--enable-headless-only=yes --with-jobs=16'
+                        'temurin'   : '--enable-headless-only=yes --with-jobs=4'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
@@ -124,7 +124,7 @@ class Config24 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',
-                        'temurin'   : '--enable-dtrace --with-jobs=16'
+                        'temurin'   : '--enable-dtrace --with-jobs=4'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'

--- a/pipelines/jobs/configurations/jdk24_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk24_pipeline_config.groovy
@@ -35,7 +35,7 @@ class Config24 {
                         'temurin'   : '--enable-dtrace'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-source-archive --create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
+                        'temurin'   : '--create-source-archive --create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
                 ]
         ],
 
@@ -46,7 +46,7 @@ class Config24 {
                 test                : 'default',
                 configureArgs       : '--enable-headless-only=yes',
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -55,9 +55,12 @@ class Config24 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--enable-headless-only=yes',
+                configureArgs       : [
+                        'openj9'    : '--enable-headless-only=yes',
+                        'temurin'   : '--enable-headless-only=yes --with-jobs=40'
+                ],
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -97,7 +100,7 @@ class Config24 {
                 dockerImage         : 'rhel7_build_image',
                 test                : 'default',
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
                 ]
         ],
 
@@ -110,7 +113,7 @@ class Config24 {
                         'openj9'      : '--enable-dtrace'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
                 ]
         ],
 
@@ -119,9 +122,12 @@ class Config24 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
-                configureArgs : '--enable-dtrace',
+                configureArgs       : [
+                        'openj9'    : '--enable-dtrace',
+                        'temurin'   : '--enable-dtrace --with-jobs=40'
+                ],
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'
                 ]
         ],
 

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -51,7 +51,7 @@ class Config8 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--disable-headful',
-                        'temurin'   : '--disable-headful --with-jobs=40'
+                        'temurin'   : '--disable-headful --with-jobs=16'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom --enable-sbom-strace'
@@ -155,7 +155,7 @@ class Config8 {
                 ],
                 test                 : 'default',
                 configureArgs       : [
-                        'temurin'   : '--with-jobs=40'
+                        'temurin'   : '--with-jobs=16'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom --enable-sbom-strace'

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -139,7 +139,7 @@ class Config8 {
                 dockerArgs: '--platform linux/arm/v7',
                 test: 'default',
                 configureArgs       : [ 
-                        'temurin'   : '--with-jobs=40'
+                        'temurin'   : '--with-jobs=4'
                 ],    
                 buildArgs           : [
                         'temurin'   : '--create-sbom --enable-sbom-strace'

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -58,7 +58,7 @@ class Config8 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--disable-headful',
-                        'temurin'   : '--disable-headful --disable-ccache --with-jobs=16'
+                        'temurin'   : '--disable-headful --disable-ccache --with-jobs=4'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom --enable-sbom-strace'
@@ -183,7 +183,7 @@ class Config8 {
                 ],
                 test                 : 'default',
                 configureArgs       : [
-                        'temurin'   : '--disable-ccache --with-jobs=16'
+                        'temurin'   : '--disable-ccache --with-jobs=4'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom --enable-sbom-strace'

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -29,7 +29,7 @@ class Config8 {
                         'dragonwell'  : '--enable-unlimited-crypto --with-jvm-variants=server  --with-zlib=system',
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-source-archive --create-sbom'
+                        'temurin'   : '--create-source-archive --create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -40,7 +40,7 @@ class Config8 {
                 test                : 'default',
                 configureArgs       : '--disable-headful',
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -49,9 +49,12 @@ class Config8 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--disable-headful',
+                configureArgs       : [
+                        'openj9'    : '--disable-headful',
+                        'temurin'   : '--disable-headful --with-jobs=40'
+                ],
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -96,7 +99,7 @@ class Config8 {
                 ],
                 dockerImage         : 'rhel7_build_image',
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -124,7 +127,7 @@ class Config8 {
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -135,8 +138,11 @@ class Config8 {
                 dockerImage: 'adoptopenjdk/ubuntu1604_build_image',
                 dockerArgs: '--platform linux/arm/v7',
                 test: 'default',
+                configureArgs       : [ 
+                        'temurin'   : '--with-jobs=40'
+                ],    
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -148,8 +154,11 @@ class Config8 {
                         dragonwell: 'pipelines/build/dockerFiles/dragonwell_aarch64.dockerfile'
                 ],
                 test                 : 'default',
+                configureArgs       : [
+                        'temurin'   : '--with-jobs=40'
+                ],
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom --enable-sbom-strace'
                 ]
         ],
   ]

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -9,6 +9,9 @@ class Config8 {
                         openj9  : 'macos10.14'
                 ],
                 test                 : 'default',
+                configureArgs       : [
+                        'temurin'   : '--disable-ccache'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom'
                 ]
@@ -27,6 +30,7 @@ class Config8 {
                 ],
                 configureArgs       : [
                         'dragonwell'  : '--enable-unlimited-crypto --with-jvm-variants=server  --with-zlib=system',
+                        'temurin'     : '--disable-ccache'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-source-archive --create-sbom --enable-sbom-strace'
@@ -38,7 +42,10 @@ class Config8 {
                 arch                : 'x64',
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : 'default',
-                configureArgs       : '--disable-headful',
+                configureArgs       : [
+                        'openj9'    : '--disable-headful',
+                        'temurin'   : '--disable-headful --disable-ccache'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom --enable-sbom-strace'
                 ]
@@ -51,7 +58,7 @@ class Config8 {
                 test                : 'default',
                 configureArgs       : [
                         'openj9'    : '--disable-headful',
-                        'temurin'   : '--disable-headful --with-jobs=16'
+                        'temurin'   : '--disable-headful --disable-ccache --with-jobs=16'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom --enable-sbom-strace'
@@ -63,6 +70,9 @@ class Config8 {
                 arch                : 'x64',
                 additionalNodeLabels: 'win2022&&vs2017',
                 test                 : 'default',
+                configureArgs       : [
+                        'temurin'   : '--disable-ccache'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom'
                 ]
@@ -72,6 +82,9 @@ class Config8 {
                 os                  : 'windows',
                 arch                : 'x86-32',
                 additionalNodeLabels: 'win2022',
+                configureArgs       : [
+                        'temurin'   : '--disable-ccache'
+                ],
                 buildArgs : [
                         temurin : '--jvm-variant client,server --create-sbom'
                 ],
@@ -85,6 +98,9 @@ class Config8 {
                 test                 : 'default',
                 additionalTestLabels : 'sw.os.aix.7_2',
                 cleanWorkspaceAfterBuild: true,
+                configureArgs       : [
+                        'temurin'   : '--disable-ccache'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom'
                 ]
@@ -98,6 +114,9 @@ class Config8 {
                         openj9: 'default'
                 ],
                 dockerImage         : 'rhel7_build_image',
+                configureArgs       : [
+                        'temurin'   : '--disable-ccache'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom --enable-sbom-strace'
                 ]
@@ -107,6 +126,9 @@ class Config8 {
                 os  : 'solaris',
                 arch: 'sparcv9',
                 test: 'default',
+                configureArgs       : [
+                        'temurin'   : '--disable-ccache'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom'
                 ]
@@ -116,6 +138,9 @@ class Config8 {
                 os                  : 'solaris',
                 arch                : 'x64',
                 test                : 'default',
+                configureArgs       : [
+                        'temurin'   : '--disable-ccache'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom'
                 ]
@@ -126,6 +151,9 @@ class Config8 {
                 arch: 'ppc64le',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
+                configureArgs       : [
+                        'temurin'   : '--disable-ccache'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom --enable-sbom-strace'
                 ]
@@ -139,7 +167,7 @@ class Config8 {
                 dockerArgs: '--platform linux/arm/v7',
                 test: 'default',
                 configureArgs       : [ 
-                        'temurin'   : '--with-jobs=4'
+                        'temurin'   : '--disable-ccache --with-jobs=4'
                 ],    
                 buildArgs           : [
                         'temurin'   : '--create-sbom --enable-sbom-strace'
@@ -155,7 +183,7 @@ class Config8 {
                 ],
                 test                 : 'default',
                 configureArgs       : [
-                        'temurin'   : '--with-jobs=16'
+                        'temurin'   : '--disable-ccache --with-jobs=16'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom --enable-sbom-strace'


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1064

Enable SBOM strace for all Linux platforms (except riscv64 which fails in emulation environment)

Note: 
1. temurin aarch64 builds are 160 core, which exhausts memory when using strace, so are throttled to 16 cores.
2. temurin arm32 builds run on 160 core hosts, which exhausts resources when using strace causing very very slow build (8+hours), so are throttled to 4 cores (builds in under 1 hour !).

Also, fix "cleanWorkspaceBuildOutputAfterBuild" so it cleans straceOutput, since it is about 3Gb in size!
