### PR TITLE
add `--init` to docker run commands in builds to prevent excessive resource consumption

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2079,7 +2079,7 @@ class Build {
                                 }
                             } else {
                                 dockerImageDigest = dockerImageDigest.replaceAll("\\[", "").replaceAll("\\]", "")
-                                String dockerRunArg="-e \"BUILDIMAGESHA=$dockerImageDigest\""
+                                String dockerRunArg="-e \"BUILDIMAGESHA=$dockerImageDigest\" --init"
 
                                 // Are we running podman in Docker CLI Emulation mode?
                                 def isPodman = context.sh(script: "docker --version | grep podman", returnStatus:true)


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1066

Testing with this branch at:
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk22u/job/jdk22u-linux-aarch64-temurin/18
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk22u/job/jdk22u-linux-riscv64-temurin/45