### PR TITLE
Fix up pipeline stage result setting and exception handling

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -318,7 +318,7 @@ class Build {
     def setStageResult(String stage, String result) {
         if (result != "SUCCESS") {
             // Use catchError to issue error message and set build & stage result
-            catchError(buildResult: result, stageResult: result) {
+            context.catchError(buildResult: result, stageResult: result) {
                 context.error("${stage} not successful, setting stage result to: "+result)
             }
         } else {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -311,6 +311,21 @@ class Build {
 
         return jdkRepo
     }
+
+    /*
+      If the given result is not SUCCESS then set the current stage result and build result accordingly
+    */
+    def setStageResult(String stage, String result) {
+        if (result != "SUCCESS") {
+            // Use catchError to issue error message and set build & stage result
+            catchError(buildResult: result, stageResult: result) {
+                context.error("${stage} not successful, setting stage result to: "+result)
+            }
+        } else {
+            context.println "${stage} result was SUCCESS"
+        }
+    }
+
     /*
     Run smoke tests, which should block the running of downstream test jobs if there are failures.
     If a test job that doesn't exist, it will be created dynamically.
@@ -355,8 +370,9 @@ class Build {
                             context.string(name: 'VENDOR_TEST_REPOS', value: vendorTestRepos),
                             context.string(name: 'VENDOR_TEST_BRANCHES', value: vendorTestBranches),
                             context.string(name: 'TIME_LIMIT', value: '1')
-                    ]  
+                    ]
                 currentBuild.result = testJob.getResult()
+                setStageResult("smoke test", testJob.getResult())
                 return testJob.getResult()
             }
         } catch (Exception e) {
@@ -474,7 +490,7 @@ class Build {
                             }
                         }
 
-                    def testJobParams = [
+                        def testJobParams = [
                         context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
                         context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
                         context.string(name: 'SDK_RESOURCE', value: 'upstream'),
@@ -507,6 +523,7 @@ class Build {
                                         parameters: testJobParams,
                                         wait: true
                         currentBuild.result = testJob.getResult()
+                        setStageResult("${testType}", testJob.getResult())
                         context.node('worker') {
                             //Copy Taps files from downstream test jobs if files available. 
                             context.sh 'rm -f workspace/target/AQAvitTaps/*.tap'
@@ -530,6 +547,7 @@ class Build {
                 }
             } catch (Exception e) {
                 context.println "Failed to execute test: ${e.message}"
+                currentBuild.result = 'FAILURE'
             }
         }
         return testStages
@@ -896,6 +914,7 @@ class Build {
                     } catch (e) {
                         context.println("Failed to build ${buildConfig.TARGET_OS} installer ${e}")
                         currentBuild.result = 'FAILURE'
+                        setStageResult("installer", 'FAILURE')
                     }
                 }
             }
@@ -922,6 +941,7 @@ class Build {
                     } catch (e) {
                         context.println("Failed to build ${buildConfig.TARGET_OS} installer ${e}")
                         currentBuild.result = 'FAILURE'
+                        setStageResult("sign installer", 'FAILURE')
                     }
                 }
             }
@@ -961,6 +981,7 @@ class Build {
     // For Windows and Mac verify that all necessary executables are Signed and Notarized(mac)
     private void verifySigning() {
         if (buildConfig.TARGET_OS == "windows" || buildConfig.TARGET_OS == "mac") {
+          context.stage('sign verification') {
             try {
                 context.println "RUNNING sign_verification for ${buildConfig.TARGET_OS}/${buildConfig.ARCHITECTURE} ..."
 
@@ -990,7 +1011,9 @@ class Build {
             } catch (e) { 
                 context.println("Failed to sign_verification for ${buildConfig.TARGET_OS}/${buildConfig.ARCHITECTURE} ${e}")
                 currentBuild.result = 'FAILURE'
-            } 
+                setStageResult("sign verification", 'FAILURE')
+            }
+          }
         }
     }
 
@@ -2181,6 +2204,7 @@ class Build {
                         }
                     } catch (Exception e) {
                         context.println(e.message)
+                        currentBuild.result = 'FAILURE'
                     }
                 }
 
@@ -2199,6 +2223,7 @@ class Build {
                         gpgSign()
                     } catch (Exception e) {
                         context.println(e.message)
+                        currentBuild.result = 'FAILURE'
                     }
                 }
 
@@ -2209,6 +2234,7 @@ class Build {
                             verifySigning()
                         } catch (Exception e) {
                             context.println(e.message)
+                            currentBuild.result = 'FAILURE'
                         }
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1068

Problem:
- Because for several sub-jobs like "tests", we use propagate: false, the job result does not set the stage result, we currently only set the overall build result. (Note: We want propagate: false so we can run all the tests and then report all the failures, rather than exit the job at the very first failure)

This PR fixes:
- Ensure all sub-jobs called within "stages" also set the stage result
- Tidy up several catch(Exception) clauses that swallow exceptions, and were not setting overall build result to FAILURE
- Add missing "sign verification" stage

**Fixed tests:**
- Various x64Linux forced failures/aborts, showing correct SmokeTest stage results:
![Screenshot 2024-07-04 at 13 06 55](https://github.com/adoptium/ci-jenkins-pipelines/assets/31470007/f34487ea-7282-4fb1-85c2-261528a1b34a)
- Various Mac stages, aborted/failed, all showing correct Stage results:
![Screenshot 2024-07-04 at 12 39 21](https://github.com/adoptium/ci-jenkins-pipelines/assets/31470007/02ab3080-6c7a-4cee-b61d-27b5d4f4e605)
