### PR TITLE
avoids image name error when pulling from non-default registery

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2044,6 +2044,8 @@ class Build {
                                 }
                             }
                             // Store the pulled docker image digest as 'buildinfo'
+                            def long_docker_image_name = context.sh(script: "docker image ls | grep ${buildConfig.DOCKER_IMAGE} | head -n1 | awk '{print \$1}'", returnStdout:true).trim()
+                            context.sh(script: "docker tag '${long_docker_image_name}' '${buildConfig.DOCKER_IMAGE}'", returnStdout:false)
                             dockerImageDigest = context.sh(script: "docker inspect --format='{{.RepoDigests}}' ${buildConfig.DOCKER_IMAGE}", returnStdout:true)
 
                             // Use our dockerfile if DOCKER_FILE is defined


### PR DESCRIPTION
when pulling from a non-default registery, you will have local image in full name include docker registery in it. But the whole pipeline works with DEFAULT behaviour when pulling from dockerhub that creates local image with image name only. This change, adds a tag to pulled local image with image_name only and avoids issue in continue.

Signed-off-by: mahdi@ibm.com