### PR TITLE
revert sbom-strace on jdk11u/arm32

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -177,7 +177,7 @@ class Config11 {
                         'temurin'   : '--enable-dtrace=auto --disable-ccache --with-jobs=4'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-sbom --enable-sbom-strace'
+                        'temurin'   : '--create-sbom'
                 ]
         ],
 


### PR DESCRIPTION
Tactical fix as the one least likely to have an impact on the build of the two options listed in https://github.com/adoptium/temurin-build/issues/3889#issuecomment-2230445636

This will allow the release builds to run. It is a partial revert of https://github.com/adoptium/ci-jenkins-pipelines/pull/1065

Testing an equivalent change in order to look at the SBoM output in https://ci.adoptium.net/job/build-scripts/job/jobs/job/release/job/jobs/job/jdk11u/job/jdk11u-release-linux-arm-temurin/22/console