### PR TITLE
Move dockerRegistry tag patch into with dockerRegistry section to avoid build break with image tags

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2056,6 +2056,8 @@ class Build {
                                                     context.docker.image(buildConfig.DOCKER_IMAGE).pull()
                                                 }
                                             }
+                                            def long_docker_image_name = context.sh(script: "docker image ls | grep ${buildConfig.DOCKER_IMAGE} | head -n1 | awk '{print \$1}'", returnStdout:true).trim()
+                                            context.sh(script: "docker tag '${long_docker_image_name}' '${buildConfig.DOCKER_IMAGE}'", returnStdout:false)
                                         } else {
                                             if (buildConfig.DOCKER_ARGS) {
                                                 context.sh(script: "docker pull ${buildConfig.DOCKER_IMAGE} ${buildConfig.DOCKER_ARGS}")
@@ -2069,8 +2071,6 @@ class Build {
                                 }
                             }
                             // Store the pulled docker image digest as 'buildinfo'
-                            def long_docker_image_name = context.sh(script: "docker image ls | grep ${buildConfig.DOCKER_IMAGE} | head -n1 | awk '{print \$1}'", returnStdout:true).trim()
-                            context.sh(script: "docker tag '${long_docker_image_name}' '${buildConfig.DOCKER_IMAGE}'", returnStdout:false)
                             dockerImageDigest = context.sh(script: "docker inspect --format='{{.RepoDigests}}' ${buildConfig.DOCKER_IMAGE}", returnStdout:true)
 
                             // Use our dockerfile if DOCKER_FILE is defined


### PR DESCRIPTION
Fixes: https://github.com/adoptium/ci-jenkins-pipelines/issues/1082

A patch to fix the above build break, fix https://github.com/adoptium/ci-jenkins-pipelines/pull/1076 was added to handle dockerRegistry and adding a local tage of DOCKER_IMAGE, but does not correctly handle the fact the image may have a :tag or @digest

This patch moves that code to the dockerRegistry section, but the proper fix for https://github.com/adoptium/ci-jenkins-pipelines/pull/1076 should be to not do that tagging, but instead probably to use context.docker.withRegistry when necessary to run the container, but that needs proper investigation.