### PR TITLE
Remove use of --user-openjdk-build-root-directory now JDK-8326685 backported

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1522,7 +1522,7 @@ class Build {
             def openjdk_build_dir
             def openjdk_build_dir_arg
 
-            # Build as default within OpenJDK src tree, necessary for Windows reproducible builds, due to relative paths
+            // Build as default within OpenJDK src tree, necessary for Windows reproducible builds, due to relative paths
             build_path = 'workspace/build/src/build'
             openjdk_build_dir =  context.WORKSPACE + '/' + build_path
             openjdk_build_dir_arg = ""

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1522,17 +1522,10 @@ class Build {
             def openjdk_build_dir
             def openjdk_build_dir_arg
 
-            if (getJavaVersionNumber() >= 21) {
-                // For reproducible jdk-21+ builds ensure not to build within the openjdk source folder
-                // so that debug symbols can be reproducibly mapped (https://bugs.openjdk.org/browse/JDK-8326685)
-                build_path = 'workspace/build/openjdkbuild'
-                openjdk_build_dir =  context.WORKSPACE + '/' + build_path
-                openjdk_build_dir_arg = " --user-openjdk-build-root-directory ${openjdk_build_dir}"
-            } else {
-                build_path = 'workspace/build/src/build'
-                openjdk_build_dir =  context.WORKSPACE + '/' + build_path
-                openjdk_build_dir_arg = ""
-            }
+            # Build as default within OpenJDK src tree, necessary for Windows reproducible builds, due to relative paths
+            build_path = 'workspace/build/src/build'
+            openjdk_build_dir =  context.WORKSPACE + '/' + build_path
+            openjdk_build_dir_arg = ""
 
             if (cleanWorkspace) {
                 try {


### PR DESCRIPTION
JDK-8326685 provides an official fix for the Linux debug map reproducible build issue, this is now backported to jdk-21.0.4, and the workaround to use a user build folder is not required.
The workaround was incorrectly applied to Windows, which then caused a subsequent non-reproducible issue due to relative path building not being used.

Fixes https://github.com/adoptium/temurin-build/issues/3790

