### PR TITLE
Now jdk-22.0.2 is GA and version is STS, we can disable the build pipeline

### DIFF
--- a/pipelines/jobs/configurations/jdk22u.groovy
+++ b/pipelines/jobs/configurations/jdk22u.groovy
@@ -47,4 +47,6 @@ weekly_release_scmReferences = [
         'dragonwell'     : ''
 ]
 
+disableJob = true
+
 return this


### PR DESCRIPTION
Now jdk-22.0.2 is GA and version is STS, we can disable the build pipeline
