### PR TITLE
Re-order build pipeline build stages prior to AQA-tests

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2204,7 +2204,7 @@ class Build {
 
                 // Run Smoke Tests and AQA Tests
                 if (enableTests) {
-                  if (currentBuild.result != "SUCCESS") {
+                  if (currentBuild.currentResult != "SUCCESS") {
                     context.println("[ERROR] Build stages were not successful, not running AQA tests")
                   } else {
                     try {


### PR DESCRIPTION
Fixes #1086 

Re-order the build stages to before AQA-tests, and gate running AQA-tests on the successful completetion of all the build stages.

Test 1: Abort GPGSign, causing failure: https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-linux-ppc64le-temurin/153/
Test 2: Successful completion including running AQA tests: https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-linux-ppc64le-temurin/154/
