### PR TITLE
Disable the reproduce_compare jobs now aqa-test Rebuild_Same_JDK_Reproducibility_Test_0 running

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -154,6 +154,7 @@ class Builder implements Serializable {
             adjustedScmReference = scmReference - ('_adopt')
         }
 
+context.echo "enableReproducibleCompare = "+enableReproducibleCompare
         return new IndividualBuildConfig(
             JAVA_TO_BUILD: javaToBuild,
             ARCHITECTURE: platformConfig.arch as String,
@@ -897,7 +898,6 @@ class Builder implements Serializable {
                         context.stage(configuration.key) {
                             // Triggering downstream job ${downstreamJobName}
 
-context.echo "config.enableReproducibleCompare = "+config.enableReproducibleCompare
                             def buildJobParams = config.toBuildParams()
 context.echo "buildJobParams = ${buildJobParams}"
 

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -160,7 +160,6 @@ class Builder implements Serializable {
             adjustedScmReference = scmReference - ('_adopt')
         }
 
-context.echo "enableReproducibleCompare = "+configEnableReproducibleCompare
         return new IndividualBuildConfig(
             JAVA_TO_BUILD: javaToBuild,
             ARCHITECTURE: platformConfig.arch as String,
@@ -905,7 +904,6 @@ context.echo "enableReproducibleCompare = "+configEnableReproducibleCompare
                             // Triggering downstream job ${downstreamJobName}
 
                             def buildJobParams = config.toBuildParams()
-context.echo "buildJobParams = ${buildJobParams}"
 
                             // Pass down constructed USER_REMOTE_CONFIGS if useAdoptShellScripts is false
                             // But not for pr-tester as it generates target jobs with required remoteConfigs

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -897,7 +897,9 @@ class Builder implements Serializable {
                         context.stage(configuration.key) {
                             // Triggering downstream job ${downstreamJobName}
 
+context.echo "config = ${config}"
                             def buildJobParams = config.toBuildParams()
+context.echo "buildJobParams = ${buildJobParams}"
 
                             // Pass down constructed USER_REMOTE_CONFIGS if useAdoptShellScripts is false
                             // But not for pr-tester as it generates target jobs with required remoteConfigs

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -128,10 +128,9 @@ class Builder implements Serializable {
             buildArgs += ' ' + additionalBuildArgs
         }
 
-        def configEnableReproducibleCompare = false
         if (enableReproducibleCompare) {
             // Pipeline parameter "enableReproducibleCompare" requests reproducibleCompare if enabled for this platform
-            configEnableReproducibleCompare = isEnableReproducibleCompare(platformConfig, variant)
+            enableReproducibleCompare = isEnableReproducibleCompare(platformConfig, variant)
         }
 
         def testList = getTestList(platformConfig, variant)
@@ -196,7 +195,7 @@ class Builder implements Serializable {
             WEEKLY: isWeekly,
             PUBLISH_NAME: publishName,
             ADOPT_BUILD_NUMBER: adoptBuildNumber,
-            ENABLE_REPRODUCIBLE_COMPARE: configEnableReproducibleCompare,
+            ENABLE_REPRODUCIBLE_COMPARE: enableReproducibleCompare,
             ENABLE_TESTS: enableTests,
             ENABLE_TESTDYNAMICPARALLEL: enableTestDynamicParallel,
             ENABLE_INSTALLERS: enableInstallers,

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -897,7 +897,7 @@ class Builder implements Serializable {
                         context.stage(configuration.key) {
                             // Triggering downstream job ${downstreamJobName}
 
-context.echo "config = ${config}"
+context.echo "config.enableReproducibleCompare = "+config.enableReproducibleCompare
                             def buildJobParams = config.toBuildParams()
 context.echo "buildJobParams = ${buildJobParams}"
 

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -127,7 +127,13 @@ class Builder implements Serializable {
         if (additionalBuildArgs) {
             buildArgs += ' ' + additionalBuildArgs
         }
-        def enableReproducibleCompare = isEnableReproducibleCompare(platformConfig, variant)
+
+        def configEnableReproducibleCompare = false
+        if (enableReproducibleCompare) {
+            // Pipeline parameter "enableReproducibleCompare" requests reproducibleCompare if enabled for this platform
+            configEnableReproducibleCompare = isEnableReproducibleCompare(platformConfig, variant)
+        }
+
         def testList = getTestList(platformConfig, variant)
 
         def dynamicTestsParameters = getDynamicParams(platformConfig, variant)
@@ -154,7 +160,7 @@ class Builder implements Serializable {
             adjustedScmReference = scmReference - ('_adopt')
         }
 
-context.echo "enableReproducibleCompare = "+enableReproducibleCompare
+context.echo "enableReproducibleCompare = "+configEnableReproducibleCompare
         return new IndividualBuildConfig(
             JAVA_TO_BUILD: javaToBuild,
             ARCHITECTURE: platformConfig.arch as String,
@@ -191,7 +197,7 @@ context.echo "enableReproducibleCompare = "+enableReproducibleCompare
             WEEKLY: isWeekly,
             PUBLISH_NAME: publishName,
             ADOPT_BUILD_NUMBER: adoptBuildNumber,
-            ENABLE_REPRODUCIBLE_COMPARE: enableReproducibleCompare,
+            ENABLE_REPRODUCIBLE_COMPARE: configEnableReproducibleCompare,
             ENABLE_TESTS: enableTests,
             ENABLE_TESTDYNAMICPARALLEL: enableTestDynamicParallel,
             ENABLE_INSTALLERS: enableInstallers,

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -9,9 +9,6 @@ class Config17 {
                         openj9      : '!sw.os.osx.10_11'
                 ],
                 test                : 'default',
-                reproducibleCompare : [
-                        'temurin'   : true
-                ],
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
@@ -30,9 +27,6 @@ class Config17 {
                 ],
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'sanity.external', 'dev.openjdk', 'dev.functional']
-                ],
-                reproducibleCompare : [
-                        'temurin'   : true
                 ],
                 additionalTestLabels: [
                         openj9      : '!(centos6||rhel6)'
@@ -76,9 +70,6 @@ class Config17 {
                 arch                : 'x64',
                 additionalNodeLabels: 'win2022&&vs2019',
                 test                : 'default',
-                reproducibleCompare : [
-                        'temurin'   : true
-                ],
                 configureArgs       : "--with-ucrt-dll-dir='C:/progra~2/wi3cf2~1/10/Redist/10.0.22000.0/ucrt/DLLs/x64'",
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
@@ -113,9 +104,6 @@ class Config17 {
                 arch                : 's390x',
                 dockerImage         : 'rhel7_build_image',
                 test                : 'default',
-                reproducibleCompare : [
-                        'temurin'   : true
-                ],
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
@@ -127,9 +115,6 @@ class Config17 {
                 arch                : 'ppc64le',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
-                reproducibleCompare : [
-                        'temurin'   : true
-                ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]
@@ -144,9 +129,6 @@ class Config17 {
                         'openj9'    : '--enable-dtrace',
                         'temurin'   : '--enable-dtrace --with-jobs=4'
                 ],
-                reproducibleCompare : [
-                        'temurin'   : true
-                ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]
@@ -158,9 +140,6 @@ class Config17 {
                 arch                : 'aarch64',
                 additionalNodeLabels: 'xcode15.0.1',
                 test                : 'default',
-                reproducibleCompare : [
-                        'temurin'   : true
-                ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -9,9 +9,6 @@ class Config21 {
                         openj9      : '!sw.os.osx.10_11'
                 ],
                 test                : 'default',
-                reproducibleCompare : [
-                        'temurin'   : true
-                ],
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
@@ -27,9 +24,6 @@ class Config21 {
                 ],
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'sanity.external', 'dev.openjdk', 'dev.functional', 'dev.system', 'special.system']
-                ],
-                reproducibleCompare : [
-                        'temurin'   : true
                 ],
                 additionalTestLabels: [
                         openj9      : '!(centos6||rhel6)',
@@ -76,9 +70,6 @@ class Config21 {
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system']
                 ],
-                reproducibleCompare : [
-                        'temurin'   : true
-                ],
                 configureArgs       : "--with-ucrt-dll-dir='C:/progra~2/wi3cf2~1/10/Redist/10.0.22621.0/ucrt/DLLs/x64'",
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
@@ -107,9 +98,6 @@ class Config21 {
                 arch                : 's390x',
                 dockerImage         : 'rhel7_build_image',
                 test                : 'default',
-                reproducibleCompare : [
-                        'temurin'   : true
-                ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
                 ]
@@ -120,9 +108,6 @@ class Config21 {
                 arch                : 'ppc64le',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
-                reproducibleCompare : [
-                        'temurin'   : true
-                ],
                 configureArgs       : [
                         'openj9'      : '--enable-dtrace'
                 ],
@@ -136,9 +121,6 @@ class Config21 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : 'default',
-                reproducibleCompare : [
-                        'temurin'   : true
-                ],
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',
                         'temurin'   : '--enable-dtrace --with-jobs=4'
@@ -153,9 +135,6 @@ class Config21 {
                 arch                : 'aarch64',
                 additionalNodeLabels: 'xcode15.0.1',
                 test                : 'default',
-                reproducibleCompare : [
-                        'temurin'   : true
-                ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1092

Disable ENABLE_REPRODUCIBLE_COMPARE by default, now we have Rebuild_Same_JDK_Reproducibility_Test_0 in aqa-tests.

Also fix the base pipeline groovy to correctly honour the "Enable Reproduce Compare" option, which mean if enabled for the given platform then enable for that build job... (hence why param description says "might run...")