### PR TITLE
Windows docker fixes/workarounds

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1587,8 +1587,7 @@ class Build {
                     // Perform a git clean outside of checkout to avoid the Jenkins enforced 10 minute timeout
                     // https://github.com/adoptium/infrastucture/issues/1553
                     if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE ) { 
-
-                        context.sh(script: 'git config --global safe.directory $(cygpath ${WORKSPACE})')
+                        context.sh(script: 'git config --global safe.directory $(cygpath ' + '\$' + '{WORKSPACE})')
                     }
                     context.sh(script: 'git clean -fdx')
 
@@ -2213,7 +2212,7 @@ class Build {
                 // Run Smoke Tests and AQA Tests
                 if (enableTests) {
                   if (currentBuild.currentResult != "SUCCESS") {
-                    context.println("[ERROR] Build stages were not successful, not running AQA tests")
+                    context.println('[ERROR] Build stages were not successful, not running AQA tests')
                   } else {
                     try {
                         //Only smoke tests succeed TCK and AQA tests will be triggerred.

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2099,7 +2099,7 @@ class Build {
                                 }
                             } else {
                                 dockerImageDigest = dockerImageDigest.replaceAll("\\[", "").replaceAll("\\]", "")
-                                String dockerRunArg="-e \"BUILDIMAGESHA=$dockerImageDigest\" --init"
+                                String dockerRunArg="-e BUILDIMAGESHA=abcde --init"
 
                                 // Are we running podman in Docker CLI Emulation mode?
                                 def isPodman = context.sh(script: "docker --version | grep podman", returnStatus:true)

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1587,6 +1587,7 @@ class Build {
                     // Perform a git clean outside of checkout to avoid the Jenkins enforced 10 minute timeout
                     // https://github.com/adoptium/infrastucture/issues/1553
                     if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE ) { 
+
                         context.sh(script: 'git config --global safe.directory $(cygpath ${WORKSPACE})')
                     }
                     context.sh(script: 'git clean -fdx')
@@ -2067,7 +2068,11 @@ class Build {
                                 }
                             }
                             // Store the pulled docker image digest as 'buildinfo'
-                            dockerImageDigest = context.sh(script: "docker inspect --format='{{.RepoDigests}}' ${buildConfig.DOCKER_IMAGE}", returnStdout:true)
+                            if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE ) { 
+                                dockerImageDigest = context.sh(script: "docker inspect --format={{.Id}} ${buildConfig.DOCKER_IMAGE} | /bin/cut -d: -f2", returnStdout:true)
+                            } else {
+                                dockerImageDigest = context.sh(script: "docker inspect --format='{{.RepoDigests}}' ${buildConfig.DOCKER_IMAGE}", returnStdout:true)
+                            }
 
                             // Use our dockerfile if DOCKER_FILE is defined
                             if (buildConfig.DOCKER_FILE) {
@@ -2102,7 +2107,7 @@ class Build {
                                 }
                             } else {
                                 dockerImageDigest = dockerImageDigest.replaceAll("\\[", "").replaceAll("\\]", "")
-                                String dockerRunArg="-e BUILDIMAGESHA=abcde --init"
+                                String dockerRunArg="-e \"BUILDIMAGESHA=$dockerImageDigest\" --init"
 
                                 // Are we running podman in Docker CLI Emulation mode?
                                 def isPodman = context.sh(script: "docker --version | grep podman", returnStatus:true)

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1586,6 +1586,9 @@ class Build {
 
                     // Perform a git clean outside of checkout to avoid the Jenkins enforced 10 minute timeout
                     // https://github.com/adoptium/infrastucture/issues/1553
+                    if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE ) { 
+                        context.sh(script: 'git config --global safe.directory $(cygpath ${WORKSPACE})')
+                    }
                     context.sh(script: 'git clean -fdx')
 
                     printGitRepoInfo()


### PR DESCRIPTION
A few changes.
Follow up to https://github.com/adoptium/infrastructure/pull/3702
Fixes https://github.com/adoptium/infrastructure/issues/3713
1. Docker SHA for the build image parameter is now set to `{{.id}}` since `{{.RepoDigest}}`' is not available in our case (possibly due to it being a local image, but a quick check suggests that the same problem doesn't look like it exists on Linux/s390x)
2. Workspace is set "safe" via `git config --global safe.directory` otherwise it objects to it being owned by the user on the host and will not complete.