### PR TITLE
WIP: Trial using `context.bat` instead of `context.sh` on Windows in docker

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1658,7 +1658,8 @@ class Build {
                                     context.withEnv(['BUILD_ARGS=' + signBuildArgs]) {
                                         context.println 'Building an exploded image for signing'
                                         // windbld#254
-                                        context.bat(script: "bash -c 'curl https://ci.adoptium.net/userContent/windows/openjdk-cached-workspace.tar.gz | tar -C /cygdrive/c/workspace/openjdk-build -xpzf -'")
+                                        // context.bat(script: "bash -c 'curl https://ci.adoptium.net/userContent/windows/openjdk-cached-workspace.tar.gz | tar -C /cygdrive/c/workspace/openjdk-build -xpzf -'")
+                                        context.sh(script: "./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
                                     }
                                     def base_path = build_path
                                     if (openjdk_build_dir_arg == "") {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1794,8 +1794,8 @@ class Build {
                                     }
                                     context.withEnv(['BUILD_ARGS=' + buildArgs]) {
                                         context.println 'SXA: probably batable 1775'
-//                                        context.sh(script: "./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
-                                        context.bat(script: "bash -c 'curl https://ci.adoptium.net/userContent/windows/openjdk-cached-workspace.tar.gz | tar -C /cygdrive/c/workspace/openjdk-build -xpzf -'")
+                                        context.sh(script: "./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
+//                                        context.bat(script: "bash -c 'curl https://ci.adoptium.net/userContent/windows/openjdk-cached-workspace.tar.gz | tar -C /cygdrive/c/workspace/openjdk-build -xpzf -'")
                                     }
                                 }
                                 context.println '[CHECKOUT] Reverting pre-build adoptium/temurin-build checkout...'
@@ -1821,7 +1821,7 @@ class Build {
                                 context.withEnv(['BUILD_ARGS=' + buildArgs]) {
                                     context.println 'SXA: probably batable 1783'
                                     context.sh(script: "./${DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
-//                                        context.bat(script: "bash -c 'curl https://ci.adoptium.net/userContent/windows/openjdk-cached-workspace.tar.gz | tar -C /cygdrive/c/workspace/openjdk-build -xpzf -'")
+//                                    context.bat(script: "bash -c 'curl https://ci.adoptium.net/userContent/windows/openjdk-cached-workspace.tar.gz | tar -C /cygdrive/c/workspace/openjdk-build -xpzf -'")
                                 }
                                 context.println '[CHECKOUT] Reverting pre-build user temurin-build checkout...'
                                 repoHandler.checkoutUserPipelines(context)

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1057,7 +1057,7 @@ class Build {
     Lists and returns any compressed archived or sbom file contents of the top directory of the build node
     */
     List<String> listArchives() {
-        context.println 'SXA: try battable 1060 - windbld#273'
+        // context.println 'SXA: try battable 1060 - windbld#273'
         def files = context.bat(
                 script: '''sh -c "find workspace/target/ | egrep -e '(\\.tar\\.gz|\\.zip|\\.msi|\\.pkg|\\.deb|\\.rpm|-sbom_.*\\.json)$'" ''',
                 returnStdout: true,
@@ -1566,7 +1566,7 @@ class Build {
                     context.timeout(time: buildTimeouts.NODE_CLEAN_TIMEOUT, unit: 'HOURS') {
                         if (context.WORKSPACE != null && !context.WORKSPACE.isEmpty()) {
                             context.println 'Removing workspace openjdk build directory: ' + openjdk_build_dir
-                                context.println 'SXA: batable and batted 1568 windbld#261,262'
+                            context.println 'SXA: batable and batted 1568 windbld#261,262'
                             context.bat(script: 'rm -rf ' + openjdk_build_dir)
                         } else {
                             context.println 'Warning: Unable to remove workspace openjdk build directory as context.WORKSPACE is null/empty'
@@ -1594,8 +1594,8 @@ class Build {
                         context.println 'SXA: batable 1593 and batted for 269-272 - bat+bash for 278 (HOME wrong)'
                         context.bat(script: 'set & bash -c "git config --global safe.directory $(cygpath ' + '\$' + '{WORKSPACE})"')
                     }
-                    context.println 'SXA: batable 1596'
-                    context.sh(script: 'git clean -fdx')
+                    context.println 'SXA: batable 1596 windbld#280'
+                    context.bat(script: 'git clean -fdx')
 
                     printGitRepoInfo()
                 }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -870,7 +870,7 @@ class Build {
     }
 
     /*
-    Build installer master functionS. This builds the downstream installer jobs on completion of the sign and test jobs.
+    Build installer master function. This builds the downstream installer jobs on completion of the sign and test jobs.
     The installers create our rpm, msi and pkg files that allow for an easier installation of the jdk binaries over a compressed archive.
     For Mac, we also clean up pkgs on master node from previous runs, if needed (Ref openjdk-build#2350).
     */
@@ -1057,9 +1057,7 @@ class Build {
     Lists and returns any compressed archived or sbom file contents of the top directory of the build node
     */
     List<String> listArchives() {
-        // context.println 'SXA: try battable 1060 - windbld#273'
-//        def files = context.bat(
-//                script: '''sh -c "find workspace/target/ | grep -e '(\\.tar\\.gz|\\.zip|\\.msi|\\.pkg|\\.deb|\\.rpm|-sbom_.*\\.json)$'" ''',
+        context.println 'SXA: not trivially battable 1060 - windbld#273'
         def files = context.sh(
                 script: '''find workspace/target/ | egrep -e '(\\.tar\\.gz|\\.zip|\\.msi|\\.pkg|\\.deb|\\.rpm|-sbom_.*\\.json)$' ''',
                 returnStdout: true,
@@ -1606,16 +1604,11 @@ class Build {
                     // Perform a git clean outside of checkout to avoid the Jenkins enforced 10 minute timeout
                     // https://github.com/adoptium/infrastucture/issues/1553
                     if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE ) { 
-                        context.println 'SXA: batable 1593 and batted for 269-272 - bat+bash for 278 (HOME wrong)'
-                        context.bat(script: 'set & bash -c "git config --global safe.directory $(cygpath ' + '\$' + '{WORKSPACE})"')
-                    }
-                    context.println 'SXA: batable 1596 windbld#280'
-                    if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE ) { 
+                        context.bat(script: 'bash -c "git config --global safe.directory $(cygpath ' + '\$' + '{WORKSPACE})"')
                         context.bat(script: 'git clean -fdx')
                     } else {
                         context.sh(script: 'git clean -fdx')
                     }
-
                     printGitRepoInfo()
                 }
             } catch (FlowInterruptedException e) {
@@ -1660,12 +1653,6 @@ class Build {
                                     context.withEnv(['BUILD_ARGS=' + signBuildArgs]) {
                                         context.println 'Building an exploded image for signing'
                                         // windbld#254
-//                                        context.bat(script: "bash ./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
-                                        context.bat(script: "bash --version")
-                                        context.sh(script: "set")
-                                        
-                                        context.bat(script: "mkdir c:\\workspace\\openjdk-build\\workspace\\target")
-                                        context.bat(script: "touch /cygdrive/c/workspace/openjdk-build/workspace/target/openjdk.tar.gz")
                                         context.bat(script: "bash -c 'curl https://ci.adoptium.net/userContent/windows/openjdk-cached-workspace.tar.gz | tar -C /cygdrive/c/workspace/openjdk-build -xpzf -'")
                                     }
                                     def base_path = build_path
@@ -1802,10 +1789,6 @@ class Build {
                                     context.withEnv(['BUILD_ARGS=' + buildArgs]) {
                                         context.println 'SXA: probably batable 1775'
 //                                        context.sh(script: "./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
-//                                        context.bat(script: "bash --version")
-//                                        context.sh(script: "set")
-//                                        context.bat(script: "mkdir c:\\workspace\\openjdk-build\\workspace\\target")
-//                                        context.bat(script: "touch /cygdrive/c/workspace/openjdk-build/workspace/target/openjdk.tar.gz")
                                         context.bat(script: "bash -c 'curl https://ci.adoptium.net/userContent/windows/openjdk-cached-workspace.tar.gz | tar -C /cygdrive/c/workspace/openjdk-build -xpzf -'")
                                     }
                                 }
@@ -1831,9 +1814,7 @@ class Build {
                                 }
                                 context.withEnv(['BUILD_ARGS=' + buildArgs]) {
                                     context.println 'SXA: probably batable 1783'
-                                     context.sh(script: "./${DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
-//                                        context.bat(script: "mkdir c:\\workspace\\openjdk-build\\workspace\\target")
-//                                        context.bat(script: "touch /cygdrive/c/workspace/openjdk-build/workspace/target/openjdk.tar.gz")
+                                    context.sh(script: "./${DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
 //                                        context.bat(script: "bash -c 'curl https://ci.adoptium.net/userContent/windows/openjdk-cached-workspace.tar.gz | tar -C /cygdrive/c/workspace/openjdk-build -xpzf -'")
                                 }
                                 context.println '[CHECKOUT] Reverting pre-build user temurin-build checkout...'
@@ -1909,14 +1890,6 @@ class Build {
                                     } else {
                                          context.sh(script: 'rm -rf ' + openjdk_build_dir + ' ' + context.WORKSPACE + '/workspace/target ' + context.WORKSPACE + '/workspace/build/devkit ' + context.WORKSPACE + '/workspace/build/straceOutput')
                                     }
-
-//                                    context.bat(script: 'rm -rf ' + openjdk_build_dir)
-//                                    context.println 'Cleaning workspace build output files: ' + context.WORKSPACE + '/workspace/target'
-//                                    context.bat(script: 'rm -rf ' + context.WORKSPACE + '/workspace/target')
-//                                    context.println 'Cleaning workspace build output files: ' + context.WORKSPACE + '/workspace/build/devkit'
-//                                    context.bat(script: 'rm -rf ' + context.WORKSPACE + '/workspace/build/devkit')
-//                                    context.println 'Cleaning workspace build output files: ' + context.WORKSPACE + '/workspace/build/straceOutput - windbld#266'
-//                                    context.bat(script: 'rm -rf ' + context.WORKSPACE + '/workspace/build/straceOutput')
                                 }
                             } else {
                                 context.println 'Warning: Unable to clean workspace as context.WORKSPACE is null/empty'

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -870,7 +870,7 @@ class Build {
     }
 
     /*
-    Build installer master function. This builds the downstream installer jobs on completion of the sign and test jobs.
+    Build installer master functionS. This builds the downstream installer jobs on completion of the sign and test jobs.
     The installers create our rpm, msi and pkg files that allow for an easier installation of the jdk binaries over a compressed archive.
     For Mac, we also clean up pkgs on master node from previous runs, if needed (Ref openjdk-build#2350).
     */
@@ -1487,10 +1487,18 @@ class Build {
     def printGitRepoInfo() {
         context.println 'Checked out repo:'
         context.println 'batable and batted 1487 windbld #286-288'
-        context.bat(script: 'git status')
+        if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE ) { 
+           context.bat(script: 'git status')
+        } else {
+           context.sh(script: 'git status')
+        }
         context.println 'Checked out HEAD commit SHA:'
         // windbld#245
-        context.bat(script: 'git rev-parse HEAD')
+        if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE ) { 
+           context.bat(script: 'git rev-parse HEAD')
+        } else {
+           context.sh(script: 'git rev-parse HEAD')
+        }
     }
 
     /*
@@ -1570,7 +1578,11 @@ class Build {
                         if (context.WORKSPACE != null && !context.WORKSPACE.isEmpty()) {
                             context.println 'Removing workspace openjdk build directory: ' + openjdk_build_dir
                             context.println 'SXA: batable and batted 1568 windbld#261,262'
-                            context.bat(script: 'rm -rf ' + openjdk_build_dir)
+                            if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE ) { 
+                                 context.bat(script: 'rm -rf ' + openjdk_build_dir)
+                            } else {
+                                 context.sh(script: 'rm -rf ' + openjdk_build_dir)
+                            }
                         } else {
                             context.println 'Warning: Unable to remove workspace openjdk build directory as context.WORKSPACE is null/empty'
                         }
@@ -1598,7 +1610,11 @@ class Build {
                         context.bat(script: 'set & bash -c "git config --global safe.directory $(cygpath ' + '\$' + '{WORKSPACE})"')
                     }
                     context.println 'SXA: batable 1596 windbld#280'
-                    context.bat(script: 'git clean -fdx')
+                    if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE ) { 
+                        context.bat(script: 'git clean -fdx')
+                    } else {
+                        context.sh(script: 'git clean -fdx')
+                    }
 
                     printGitRepoInfo()
                 }
@@ -1888,13 +1904,19 @@ class Build {
                                 } else if (cleanWorkspaceBuildOutputAfter) {
                                     context.println 'SXA: batable and batted 1869 windbld 266'
                                     context.println 'Cleaning workspace build output files: ' + openjdk_build_dir
-                                    context.bat(script: 'rm -rf ' + openjdk_build_dir)
-                                    context.println 'Cleaning workspace build output files: ' + context.WORKSPACE + '/workspace/target'
-                                    context.bat(script: 'rm -rf ' + context.WORKSPACE + '/workspace/target')
-                                    context.println 'Cleaning workspace build output files: ' + context.WORKSPACE + '/workspace/build/devkit'
-                                    context.bat(script: 'rm -rf ' + context.WORKSPACE + '/workspace/build/devkit')
-                                    context.println 'Cleaning workspace build output files: ' + context.WORKSPACE + '/workspace/build/straceOutput - windbld#266'
-                                    context.bat(script: 'rm -rf ' + context.WORKSPACE + '/workspace/build/straceOutput')
+                                    if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE ) { 
+                                         context.bat(script: 'rm -rf ' + openjdk_build_dir + ' ' + context.WORKSPACE + '/workspace/target ' + context.WORKSPACE + '/workspace/build/devkit ' + context.WORKSPACE + '/workspace/build/straceOutput')
+                                    } else {
+                                         context.sh(script: 'rm -rf ' + openjdk_build_dir + ' ' + context.WORKSPACE + '/workspace/target ' + context.WORKSPACE + '/workspace/build/devkit ' + context.WORKSPACE + '/workspace/build/straceOutput')
+                                    }
+
+//                                    context.bat(script: 'rm -rf ' + openjdk_build_dir)
+//                                    context.println 'Cleaning workspace build output files: ' + context.WORKSPACE + '/workspace/target'
+//                                    context.bat(script: 'rm -rf ' + context.WORKSPACE + '/workspace/target')
+//                                    context.println 'Cleaning workspace build output files: ' + context.WORKSPACE + '/workspace/build/devkit'
+//                                    context.bat(script: 'rm -rf ' + context.WORKSPACE + '/workspace/build/devkit')
+//                                    context.println 'Cleaning workspace build output files: ' + context.WORKSPACE + '/workspace/build/straceOutput - windbld#266'
+//                                    context.bat(script: 'rm -rf ' + context.WORKSPACE + '/workspace/build/straceOutput')
                                 }
                             } else {
                                 context.println 'Warning: Unable to clean workspace as context.WORKSPACE is null/empty'
@@ -2060,7 +2082,9 @@ class Build {
                             // Cannot clean workspace from inside docker container
                             
                             context.println 'SXA: batable and batted 2042 (rm cyclonedx-lib)'
-                            context.bat('rm -rf c:/workspace/openjdk-build/cyclonedx-lib')
+                            if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE ) { 
+                                context.bat('rm -rf c:/workspace/openjdk-build/cyclonedx-lib')
+                            }
                             if (cleanWorkspace) {
                                 try {
                                     context.timeout(time: buildTimeouts.CONTROLLER_CLEAN_TIMEOUT, unit: 'HOURS') {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1057,9 +1057,9 @@ class Build {
     Lists and returns any compressed archived or sbom file contents of the top directory of the build node
     */
     List<String> listArchives() {
-        context.println 'SXA: not easily batable 1060 - windbld#273'
-        def files = context.sh(
-                script: '''find workspace/target/ | egrep -e '(\\.tar\\.gz|\\.zip|\\.msi|\\.pkg|\\.deb|\\.rpm|-sbom_.*\\.json)$' ''',
+        context.println 'SXA: try battable 1060 - windbld#273'
+        def files = context.bat(
+                script: '''sh -c "find workspace/target/ | egrep -e '(\\.tar\\.gz|\\.zip|\\.msi|\\.pkg|\\.deb|\\.rpm|-sbom_.*\\.json)$'" ''',
                 returnStdout: true,
                 returnStatus: false
         )
@@ -1591,7 +1591,7 @@ class Build {
                     // Perform a git clean outside of checkout to avoid the Jenkins enforced 10 minute timeout
                     // https://github.com/adoptium/infrastucture/issues/1553
                     if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE ) { 
-                        context.println 'SXA: batable 1593 and batted for 269-272'
+                        context.println 'SXA: batable 1593 and batted for 269-272 - bat+bash for 278 (HOME wrong)'
                         context.bat(script: 'set & bash -c "git config --global safe.directory $(cygpath ' + '\$' + '{WORKSPACE})"')
                     }
                     context.println 'SXA: batable 1596'

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1645,6 +1645,9 @@ class Build {
                                         context.println 'Building an exploded image for signing'
                                         // windbld#254
 //                                        context.bat(script: "bash ./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
+                                        context.bat(script: "bash --version")
+                                        context.sh(script: "set")
+                                        
                                         context.bat(script: "mkdir c:\\workspace\\openjdk-build\\workspace\\target")
                                         context.bat(script: "touch /cygdrive/c/workspace/openjdk-build/workspace/target/openjdk.tar.gz")
                                         context.bat(script: "bash -c 'curl https://ci.adoptium.net/userContent/windows/openjdk-cached-workspace.tar.gz | tar -C /cygdrive/c/workspace/openjdk-build -xpzf -'")
@@ -1783,8 +1786,10 @@ class Build {
                                     context.withEnv(['BUILD_ARGS=' + buildArgs]) {
                                         context.println 'SXA: probably batable 1775'
 //                                        context.sh(script: "./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
-                                        context.bat(script: "mkdir c:\\workspace\\openjdk-build\\workspace\\target")
-                                        context.bat(script: "touch /cygdrive/c/workspace/openjdk-build/workspace/target/openjdk.tar.gz")
+//                                        context.bat(script: "bash --version")
+//                                        context.sh(script: "set")
+//                                        context.bat(script: "mkdir c:\\workspace\\openjdk-build\\workspace\\target")
+//                                        context.bat(script: "touch /cygdrive/c/workspace/openjdk-build/workspace/target/openjdk.tar.gz")
                                         context.bat(script: "bash -c 'curl https://ci.adoptium.net/userContent/windows/openjdk-cached-workspace.tar.gz | tar -C /cygdrive/c/workspace/openjdk-build -xpzf -'")
                                     }
                                 }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1645,7 +1645,9 @@ class Build {
                                 repoHandler.checkoutAdoptBuild(context)
                                 printGitRepoInfo()
                                 context.println "SXAEC: ${buildConfig.ENABLE_SIGNER}"
-                                if ((buildConfig.TARGET_OS == 'mac' || buildConfig.TARGET_OS == 'windows') && buildConfig.JAVA_TO_BUILD != 'jdk8u' ) {
+                                // No idea why but despite the above showing as true if I add that to the if statement it doesn't go into this section so leaving it as-is for now
+//                              // if ((buildConfig.TARGET_OS == 'mac' || buildConfig.TARGET_OS == 'windows') && buildConfig.JAVA_TO_BUILD != 'jdk8u' && buildConfig.ENABLE_SIGNER == 'true') {
+                                if ((buildConfig.TARGET_OS == 'mac' || buildConfig.TARGET_OS == 'windows') && buildConfig.JAVA_TO_BUILD != 'jdk8u') {
                                     context.println "Processing exploded build, sign JMODS, and assemble build, for platform ${buildConfig.TARGET_OS} version ${buildConfig.JAVA_TO_BUILD}"
                                     def signBuildArgs
                                     if (env.BUILD_ARGS != null && !env.BUILD_ARGS.isEmpty()) {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1638,11 +1638,14 @@ class Build {
                             if (env.JOB_NAME.contains('pr-tester')) {
                                 updateGithubCommitStatus('PENDING', 'Build Started')
                             }
+                            context.println "SXAEC: Before UASS"
                             if (useAdoptShellScripts) {
+                                context.println "SXAEC: UASS=true"
                                 context.println '[CHECKOUT] Checking out to adoptium/temurin-build...'
                                 repoHandler.checkoutAdoptBuild(context)
                                 printGitRepoInfo()
-                                if ((buildConfig.TARGET_OS == 'mac' || buildConfig.TARGET_OS == 'windows') && buildConfig.JAVA_TO_BUILD != 'jdk8u' && buildConfig.ENABLE_SIGNER == "true") {
+                                context.println "SXAEC: ${buildConfig.ENABLE_SIGNER}"
+                                if ((buildConfig.TARGET_OS == 'mac' || buildConfig.TARGET_OS == 'windows') && buildConfig.JAVA_TO_BUILD != 'jdk8u' ) {
                                     context.println "Processing exploded build, sign JMODS, and assemble build, for platform ${buildConfig.TARGET_OS} version ${buildConfig.JAVA_TO_BUILD}"
                                     def signBuildArgs
                                     if (env.BUILD_ARGS != null && !env.BUILD_ARGS.isEmpty()) {
@@ -1779,7 +1782,7 @@ class Build {
                                         context.println 'SXA: probably batable 1764'
                                         context.sh(script: "./${ADOPT_DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
                                     }
-                                } else {
+                                } else { // Not Windows/Mac JDK11+ (i.e. doesn't require signing)
                                     def buildArgs
                                     if (env.BUILD_ARGS != null && !env.BUILD_ARGS.isEmpty()) {
                                         buildArgs = env.BUILD_ARGS + openjdk_build_dir_arg

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1057,6 +1057,7 @@ class Build {
     Lists and returns any compressed archived or sbom file contents of the top directory of the build node
     */
     List<String> listArchives() {
+        context.println 'SXA: not easily batable 1060 - windbld#273'
         def files = context.sh(
                 script: '''find workspace/target/ | egrep -e '(\\.tar\\.gz|\\.zip|\\.msi|\\.pkg|\\.deb|\\.rpm|-sbom_.*\\.json)$' ''',
                 returnStdout: true,
@@ -1590,8 +1591,8 @@ class Build {
                     // Perform a git clean outside of checkout to avoid the Jenkins enforced 10 minute timeout
                     // https://github.com/adoptium/infrastucture/issues/1553
                     if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE ) { 
-                        context.println 'SXA: batable 1593'
-                        context.sh(script: 'git config --global safe.directory $(cygpath ' + '\$' + '{WORKSPACE})')
+                        context.println 'SXA: batable 1593 and batted for 269-272'
+                        context.bat(script: 'set & bash -c "git config --global safe.directory $(cygpath ' + '\$' + '{WORKSPACE})"')
                     }
                     context.println 'SXA: batable 1596'
                     context.sh(script: 'git clean -fdx')
@@ -1645,7 +1646,7 @@ class Build {
                                     def base_path = build_path
                                     if (openjdk_build_dir_arg == "") {
                                         // If not using a custom openjdk build dir, then query what autoconf created as the build sub-folder
-                                        context.println 'SXA: not batable 1648'
+                                        context.println 'SXA: not batable 1648 - windbld#263'
                                         base_path = context.sh(script: "ls -d ${build_path}/* | tr -d '\\n'", returnStdout:true)
                                     }
                                     context.println "base build path for jmod signing = ${base_path}"
@@ -1866,15 +1867,15 @@ class Build {
                                         context.println "Failed to clean ${e}"
                                     }
                                 } else if (cleanWorkspaceBuildOutputAfter) {
-                                    context.println 'SXA: batable 1869'
+                                    context.println 'SXA: batable and batted 1869 windbld 266'
                                     context.println 'Cleaning workspace build output files: ' + openjdk_build_dir
-                                    context.sh(script: 'rm -rf ' + openjdk_build_dir)
+                                    context.bat(script: 'rm -rf ' + openjdk_build_dir)
                                     context.println 'Cleaning workspace build output files: ' + context.WORKSPACE + '/workspace/target'
-                                    context.sh(script: 'rm -rf ' + context.WORKSPACE + '/workspace/target')
+                                    context.bat(script: 'rm -rf ' + context.WORKSPACE + '/workspace/target')
                                     context.println 'Cleaning workspace build output files: ' + context.WORKSPACE + '/workspace/build/devkit'
-                                    context.sh(script: 'rm -rf ' + context.WORKSPACE + '/workspace/build/devkit')
-                                    context.println 'Cleaning workspace build output files: ' + context.WORKSPACE + '/workspace/build/straceOutput'
-                                    context.sh(script: 'rm -rf ' + context.WORKSPACE + '/workspace/build/straceOutput')
+                                    context.bat(script: 'rm -rf ' + context.WORKSPACE + '/workspace/build/devkit')
+                                    context.println 'Cleaning workspace build output files: ' + context.WORKSPACE + '/workspace/build/straceOutput - windbld#266'
+                                    context.bat(script: 'rm -rf ' + context.WORKSPACE + '/workspace/build/straceOutput')
                                 }
                             } else {
                                 context.println 'Warning: Unable to clean workspace as context.WORKSPACE is null/empty'

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1503,10 +1503,10 @@ class Build {
      */
     def batOrSh(command)
     {
-        if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE ) { 
-            context.bat(command)
-        } else {
+        if ( context.isUnix() ) {
             context.sh(command)
+        } else {
+            context.bat(command)
         }
     }
 


### PR DESCRIPTION
This is very much a 'work-in-progress' / feasibility study with the intention of diagnosing the problem described in https://github.com/adoptium/infrastructure/issues/3714. The PR is not ready for review (since it's mostly debug information and experiments) but I'm creating it in the spirit of openness to go alongside the issue :-)

I have attempted to put comments against all of the `context.sh` operations which are performed inside the containers during a docker build to identify which ones are causing problems.

I have converted some of them to `context.bat` based on some of the trial runs (Noting that this cannot be a final solution as-is as it won't work on non-Windows systems unless an `if windows` block is used to switch between them).

The four-digit numbers in the `battable` lines are the line number in the `openjdk_build_pipeline.groovy` and the `windbld` numbers are the job runs of windbld which showed the problem, so are instances where we have definitely hit an issue with those.