### PR TITLE
Set JCK_GIT_REPO on Temurin remote jck trigger

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -628,6 +628,7 @@ class Build {
                             job: 'AQA_Test_Pipeline',
                             parameters: context.MapParameters(parameters: [context.MapParameter(name: 'SDK_RESOURCE', value: 'customized'),
                                                                     context.MapParameter(name: 'TARGETS', value: "${targetTests}"),
+                                                                    context.MapParameter(name: 'JCK_GIT_REPO', value: "git@github.com:temurin-compliance/JCK${jdkVersion}-unzipped.git"),
                                                                     context.MapParameter(name: 'CUSTOMIZED_SDK_URL', value: "${sdkUrl}"),
                                                                     context.MapParameter(name: 'JDK_VERSIONS', value: "${jdkVersion}"),
                                                                     context.MapParameter(name: 'PARALLEL', value: parallel),


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/980
```
12:34:25  BUILD FAILED
12:34:25  /home/jenkins/workspace/Test_openjdk23_hs_sanity.jck_x86-64_linux/aqa-tests/TKG/scripts/build_test.xml:95: The following error occurred while executing this line:
12:34:25  /home/jenkins/workspace/Test_openjdk23_hs_sanity.jck_x86-64_linux/aqa-tests/jck/build.xml:294: env.JCK_GIT_REPO: ${env.JCK_GIT_REPO} was not correctly set for running JCK tests. If you do not want to compile JCK tests,       please use BUILD_LIST to include test folders you want to test.
```

Set JCK_GIT_REPO for remote temurin compliance server, so it knows repo to use.
