### PR TITLE
Set JCK_GIT_REPO on Temurin remote jck trigger (#1111)

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -628,6 +628,7 @@ class Build {
                             job: 'AQA_Test_Pipeline',
                             parameters: context.MapParameters(parameters: [context.MapParameter(name: 'SDK_RESOURCE', value: 'customized'),
                                                                     context.MapParameter(name: 'TARGETS', value: "${targetTests}"),
+                                                                    context.MapParameter(name: 'JCK_GIT_REPO', value: "git@github.com:temurin-compliance/JCK${jdkVersion}-unzipped.git"),
                                                                     context.MapParameter(name: 'CUSTOMIZED_SDK_URL', value: "${sdkUrl}"),
                                                                     context.MapParameter(name: 'JDK_VERSIONS', value: "${jdkVersion}"),
                                                                     context.MapParameter(name: 'PARALLEL', value: parallel),


### PR DESCRIPTION
Cherry pick https://github.com/adoptium/ci-jenkins-pipelines/commit/d9429d510fecd3c5435c8b048eb899f5726afa85
so temurin-compliance JCK jobs are launched correctly