### PR TITLE
Evaluation config can be empty for beta trigger if none for a version

### DIFF
--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -215,9 +215,11 @@ node('worker') {
             if (!config) {
                 def error =  "Empty evaluationTargetConfigurations"
                 echo "${error}"
-                throw new Exception("${error}")
+                // Evaluation config can be empty if none for this version
+                triggerEvaluationBuild = false
+            } else {
+                evaluationTargetConfigurations = JsonOutput.toJson(config) 
             }
-            evaluationTargetConfigurations = JsonOutput.toJson(config) 
         }
     }
 } // End: node('worker')


### PR DESCRIPTION
jdk21u does not have any evaluation targets now win aarch64 has been promoted, but trigger was assuming there should always be one...

Changed evaluation trigger to not throw error if no evaluation targets
