### PR TITLE
Schedule jdk23u weekly builds as Oracle managed version

### DIFF
--- a/pipelines/jobs/configurations/jdk23u.groovy
+++ b/pipelines/jobs/configurations/jdk23u.groovy
@@ -38,6 +38,9 @@ targetConfigurations = [
         ]
 ]
 
+// 12:05 Sat - Weekend schedule for Oracle managed jdk23u.groovy version that has no published tags
+triggerSchedule_weekly  = 'TZ=UTC\n05 12 * * 6'
+
 // scmReferences to use for weekly release build
 weekly_release_scmReferences = [
         'hotspot'        : '',


### PR DESCRIPTION
jdk-23.0.1 and 23.0.2 are Oracle managed with no regular publish build tags
Hence, we need to schedule a weekly jdk23u head build to get regular builds and testing...
