### PR TITLE
Add aarch64Windows arch to filename mapping to daily slack status tool

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -214,6 +214,7 @@ def verifyReleaseContent(String version, String release, String variant, Map sta
             // Map of config architecture to artifact name
             def archToAsset = [x64Linux:       "x64_linux",
                                x64Windows:     "x64_windows",
+                               aarch64Windows: "aarch64_windows",
                                x64Mac:         "x64_mac",
                                x64AlpineLinux: "x64_alpine-linux",
                                ppc64Aix:       "ppc64_aix",


### PR DESCRIPTION
With the Windows aarch64 now promoted to main builds, we need the aarch64Windows -> aarch64_windows asset mapping adding to the daily Slack tool.
