### PR TITLE
jdk-23.0.1 release jdkBranch GA tag check using wrong repo

### DIFF
--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -26,7 +26,8 @@ Map<String, ?> DEFAULTS_JSON = null
 def findGaCommitSHA(String jdkVersion, String jdkBranch, Boolean annotatedTag) {
     // Determine OpenJDK and Adoptium mirror repository
     def repo
-    if (jdkVersion.toInteger() >= 23) {
+    // Is it a jdk-23+ stablizationjdk branch version? ie.jdk-23, jdk-24, ... 
+    if (jdkVersion.toInteger() >= 23 && !jdkBranch.contains("\.0")) {
         // jdk-23+ first release is a branch within the jdk(head) repository
         repo = "jdk"
     } else {


### PR DESCRIPTION
jdk23+ update version GA tag check should be using updates repo