### PR TITLE
jdk23+ update version GA tag check should be using updates repo (#1127)

### DIFF
--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -26,7 +26,8 @@ Map<String, ?> DEFAULTS_JSON = null
 def findGaCommitSHA(String jdkVersion, String jdkBranch, Boolean annotatedTag) {
     // Determine OpenJDK and Adoptium mirror repository
     def repo
-    if (jdkVersion.toInteger() >= 23) {
+    // Is it a jdk-23+ stablizationjdk branch version? ie.jdk-23, jdk-24, ... 
+    if (jdkVersion.toInteger() >= 23 && !jdkBranch.contains(".0")) {
         // jdk-23+ first release is a branch within the jdk(head) repository
         repo = "jdk"
     } else {


### PR DESCRIPTION
Cherry pick jdk23u GA tag fix commit into master: https://github.com/adoptium/ci-jenkins-pipelines/commit/277131ebb6fbb4590f4410735e2d825b3876ab79
