### PR TITLE
win_aarch64 unskip remove TCK trigger

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2241,13 +2241,11 @@ class Build {
                                     platform = 'x86-64_' + buildConfig.TARGET_OS
                                 } else {
                                     platform = buildConfig.ARCHITECTURE + '_' + buildConfig.TARGET_OS
-                                }           
-                                if ( !(platform =='aarch64_windows') ) {
-                                    if ( !(buildConfig.JAVA_TO_BUILD == 'jdk8u' && platform == 's390x_linux') ) {
-                                        context.echo "Remote trigger Eclipse Temurin AQA_Test_Pipeline job with ${platform} ${buildConfig.JAVA_TO_BUILD}"
-                                        def remoteTargets = remoteTriggerJckTests(platform, filename)
-                                        context.parallel remoteTargets
-                                    }
+                                }
+                                if ( !(buildConfig.JAVA_TO_BUILD == 'jdk8u' && platform == 's390x_linux') ) {
+                                    context.echo "Remote trigger Eclipse Temurin AQA_Test_Pipeline job with ${platform} ${buildConfig.JAVA_TO_BUILD}"
+                                    def remoteTargets = remoteTriggerJckTests(platform, filename)
+                                    context.parallel remoteTargets
                                 }
                             }
 


### PR DESCRIPTION
Now that Win aarch64 is a release platform we shouldn't be skipping the TCK remote trigger