### PR TITLE
Add SBOM jsf signing to openjdk_build_pipeline.groovy

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1081,7 +1081,7 @@ class Build {
                 context.copyArtifacts(
                     projectName: 'build-scripts/release/sign_temurin_jsf',
                     selector: context.specific("${signSBOMJob.getNumber()}"),
-                    filter: '**/*.sig',
+                    filter: '**/*sbom*.json',
                     fingerprintArtifacts: true,
                     target: 'workspace/target/',
                     flatten: true)
@@ -1089,7 +1089,7 @@ class Build {
                 // Archive SBOM signatures in Jenkins
                 try {
                     context.timeout(time: buildTimeouts.ARCHIVE_ARTIFACTS_TIMEOUT, unit: 'HOURS') {
-                        context.archiveArtifacts artifacts: 'workspace/target/*.sig'
+                        context.archiveArtifacts artifacts: 'workspace/target/*sbom*.json'
                     }
                } catch (FlowInterruptedException e) {
                     throw new Exception("[ERROR] Archive artifact timeout (${buildTimeouts.ARCHIVE_ARTIFACTS_TIMEOUT} HOURS) for ${downstreamJobName} has been reached. Exiting...")

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1067,7 +1067,7 @@ class Build {
                   context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
                   context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
                   context.string(name: 'UPSTREAM_DIR', value: 'workspace'),
-                  context.string(name:'SBOM_LIBRARY_JOB_NUMBER', value: "${buildSBOMLibrariesJob.getNumber()}")
+                  context.string(name: 'SBOM_LIBRARY_JOB_NUMBER', value: "${buildSBOMLibrariesJob.getNumber()}")
            ]
 
             context.println "RUNNING sign_temurin_jsf for ${buildConfig.TARGET_OS}/${buildConfig.ARCHITECTURE} ..."

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1867,8 +1867,6 @@ class Build {
                             context.archiveArtifacts artifacts: 'workspace/target/*.json'
                         } else {
                             context.archiveArtifacts artifacts: 'workspace/target/*'
-                            // Archive cyclone dx jars
-                            context.archiveArtifacts artifacts: "workspace/build-scripts/jobs/${buildConfig.JAVA_TO_BUILD}-${buildConfig.TARGET_OS}-${buildConfig.ARCHITECTURE}-temurin/cyclonedx-lib/**/*.jar"
                         }
                     }
                 } catch (FlowInterruptedException e) {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1066,14 +1066,14 @@ class Build {
             def paramsJsf = [
                   context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
                   context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
-                  context.string(name: 'UPSTREAM_DIR', value: 'workspace'),
+                  context.string(name: 'UPSTREAM_DIR', value: 'workspace/target'),
                   context.string(name: 'SBOM_LIBRARY_JOB_NUMBER', value: "${buildSBOMLibrariesJob.getNumber()}")
            ]
 
             context.println "RUNNING sign_temurin_jsf for ${buildConfig.TARGET_OS}/${buildConfig.ARCHITECTURE} ..."
             def signSBOMJob = context.build job: 'build-scripts/release/sign_temurin_jsf',
                propagate: true,
-               parameters: params
+               parameters: paramsJsf
 
             context.node('worker') {
                 // Remove any previous workspace artifacts


### PR DESCRIPTION
ref https://github.com/adoptium/temurin-build/issues/3946

Code to run the (incomplete) https://ci.adoptium.net/job/build-scripts/job/release/job/sign_temurin_jsf/ job which signs the SBOM using https://github.com/adoptium/temurin-build/blob/master/cyclonedx-lib/sign_src/TemurinSignSBOM.java

On line 1866 it should archive the `temurin-sign-sbom.jar` so that it can be used later to sign the SBOM on the eclipse worker node. The artifact should get copied over during the sign_temurin_jsf job

Lines 1057 to 1094 is just the gpgSign() function repeated for the sign_temurin_jsf job

This pr is together with https://github.com/adoptium/temurin-build/pull/4017