### PR TITLE
Skip internal signing phase unless on windows/mac

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1520,6 +1520,7 @@ class Build {
         def base_path
         base_path = build_path
         def repoHandler = new RepoHandler(USER_REMOTE_CONFIGS, ADOPT_DEFAULTS_JSON, buildConfig.CI_REF, buildConfig.BUILD_REF)
+
         context.stage('internal sign') {
             context.node('eclipse-codesign') {
                 // Safety first!
@@ -1661,6 +1662,7 @@ def buildScriptsAssemble(
     def base_path
     base_path = build_path
     def assembleBuildArgs
+
     // Remove jmod directories to be replaced with the stash saved above
     batOrSh "rm -rf ${base_path}/hotspot/variant-server ${base_path}/support/modules_cmds ${base_path}/support/modules_libs"
     // JDK 16 + jpackage executables need to be signed as well
@@ -1883,12 +1885,12 @@ def buildScriptsAssemble(
                                     if (openjdk_build_dir_arg == "") {
                                         // If not using a custom openjdk build dir, then query what autoconf created as the build sub-folder
                                         if ( context.isUnix() ) {
-                                            base_path = context.sh(script: "ls -d ${build_path}/*", returnStdout:true)
+                                            base_path = context.sh(script: "ls -d ${build_path}/*", returnStdout:true).trim()
                                         } else {
                                             base_path = context.bat(script: "@ls -d ${build_path}/*", returnStdout:true).trim()
                                         }
                                     }
-                                    context.println "base build path for jmod signing = ${base_path}"
+                                    context.println "base_path for jmod signing = ${base_path}."
                                     context.stash name: 'jmods',
                                         includes: "${base_path}/hotspot/variant-server/**/*.exe," +
                                             "${base_path}/hotspot/variant-server/**/*.dll," +
@@ -1958,7 +1960,7 @@ def buildScriptsAssemble(
                     if ((buildConfig.TARGET_OS == 'mac' || buildConfig.TARGET_OS == 'windows') && buildConfig.JAVA_TO_BUILD != 'jdk8u' && enableSigner) {
                         context.println "openjdk_build_pipeline: Internal signing phase required - skipping metadata reading"
                     } else {
-                    // Run a downstream job on riscv machine that returns the java version. Otherwise, just read the version.txt
+                        // Run a downstream job on riscv machine that returns the java version. Otherwise, just read the version.txt
                         String versionOut
                             if (buildConfig.BUILD_ARGS.contains('--cross-compile')) {
                             context.println "[WARNING] Don't read faked version.txt on cross compiled build! Archiving early and running downstream job to retrieve java version..."
@@ -2126,6 +2128,7 @@ def buildScriptsAssemble(
                 String userOrgRepo = "${splitAdoptUrl[splitAdoptUrl.size() - 2]}/${splitAdoptUrl[splitAdoptUrl.size() - 1]}"
                 // e.g. adoptium/temurin-build/master/build-farm/platform-specific-configurations
                 envVars.add("ADOPT_PLATFORM_CONFIG_LOCATION=${userOrgRepo}/${adoptBranch}/${ADOPT_DEFAULTS_JSON['configDirectories']['platform']}" as String)
+                def internalSigningRequired = (buildConfig.TARGET_OS == 'windows' || buildConfig.TARGET_OS == 'mac')
 
                 context.stage('queue') {
                     /* This loads the library containing two Helper classes, and causes them to be
@@ -2293,7 +2296,7 @@ def buildScriptsAssemble(
                                     }
                                 }
                                 // Is thre potential for not enabling the signer on jdk8u instead of having this clause?
-                                if ( enableSigner && buildConfig.JAVA_TO_BUILD != 'jdk8u' ) {
+                                if ( enableSigner && internalSigningRequired && buildConfig.JAVA_TO_BUILD != 'jdk8u' ) {
                                     context.println "openjdk_build_pipeline: running eclipse signing phase"
                                     buildScriptsEclipseSigner()
                                     context.ws(workspace) {
@@ -2338,7 +2341,7 @@ def buildScriptsAssemble(
                                         enableSigner,
                                         envVars
                                     )
-                                    if ( enableSigner ) {
+                                    if ( enableSigner && internalSigningRequired ) {
                                         buildScriptsEclipseSigner()
                                         context.println "openjdk_build_pipeline: running assemble phase (invocation 2)"
                                         buildScriptsAssemble(
@@ -2358,7 +2361,7 @@ def buildScriptsAssemble(
                                     enableSigner,
                                     envVars
                                 )
-                                if ( enableSigner ) {
+                                if ( enableSigner && internalSigningRequired ) {
                                     buildScriptsEclipseSigner()
                                     context.println "openjdk_build_pipeline: running assemble phase (invocation 3)"
                                     buildScriptsAssemble(


### PR DESCRIPTION
The implementation of the internal signing phase which was adjusted in https://github.com/adoptium/ci-jenkins-pipelines/pull/1117 ([issue](https://github.com/adoptium/infrastructure/issues/3286)) caused that phase to be executed on more platforms than is necessary.

There are two fixes in here:
- `trim()` the output from `ls` when setting `build_path` so that it doesn't have a newline character on it (This was already done for windows but not on mac, but is required there too).
- Ensure that the internal signing + assemble phases are only executed on macos and windows. It was trying to run on Linux platforms and tripping up on the stash operations

Notes / alternative options:
- We could have a separate build flag for the internal signing instead of using `ENABLE_SIGNER` for both signing situations instead of doing this on a platform basis (probably a good idea in the future)
- This has been tested on Linux and macos and appears to do what is expected. Windows will take a little longer due to build times, but since macos looks ok this is likely safe to merge now.
- signing issues are not caught during the PR testing process. We could perhaps look at incorporating that in the future.