### PR TITLE
Platform-specific reproducibility healthcheck

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -209,11 +209,10 @@ echo "D6.3"
                     // - Does the build job for one of our listed platforms contain a successful build job?
                     if (onePipelineBuild.status.equals("Done") && (onePipelineBuild.buildResult.equals("UNSTABLE") || onePipelineBuild.buildResult.equals("SUCCESS"))) {
 echo "D6.4"
-                        if (onePipelineBuild.buildParams.toString() ==~ /ENABLE_TESTS..?\:.?true/)
+                        if (onePipelineBuild.buildParams.toString() ==~ /ENABLE_TESTS..?\:.?true/) {
 echo "D6.5"
                             onePipelinePlatformsMap[onePlatformKey] = onePipelineBuild._id
                         }
-                        
 echo "D7"
                     }
                 }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -152,7 +152,7 @@ def getLatestBinariesTag(String version) {
 // Calls wget with the given URL and returns the output.
 // Returns an empty string if fails.
 def callWgetSafely(String url) {
-    def testOutputRC = sh(returnStatus : true, returnStdout: false, script: "wget --spider ${url} > /dev/null")
+    def testOutputRC = sh(returnStatus : true, returnStdout: false, script: "wget --spider -q ${url} 2> /dev/null")
     if ( testOutputRC != 0 ) {
         echo "Warning: This URL's data could not be found, and is likely expired: ${url}"
         return ""

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -544,7 +544,7 @@ echo "Debug, hard-coding srcTag to jdk-21.0.6+2-ea-beta for testing."
                     def testOutput = sh(returnStatus : true, script: "${wgetCommand}")
 
                     // If we can find it, then we look for the anticipated percentage.
-                    if ( testOutput != 1 ) {
+                    if ( testOutput != 0 ) {
                         echo "Warning: This job's output could not be found in trss or jenkins, and is likely expired: ${testJob.buildUrl}"
                         echo "Skipping this test and moving on to the next one."
                         continue

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -209,7 +209,7 @@ echo "D6.3"
                     // - Does the build job for one of our listed platforms contain a successful build job?
                     if (onePipelineBuild.status.equals("Done") && (onePipelineBuild.buildResult.equals("UNSTABLE") || onePipelineBuild.buildResult.equals("SUCCESS"))) {
 echo "D6.4: ${onePipelineBuild.buildParams.toString()}"
-                        if (onePipelineBuild.buildParams.toString() ==~ /.*ENABLE_TESTS..?:\s?true.*/) {
+                        if (onePipelineBuild.buildParams.contains("ENABLE_TESTS\": true") || onePipelineBuild.buildParams.contains("ENABLE_TESTS\\\": true")) {
 echo "D6.5"
                             onePipelinePlatformsMap[onePlatformKey] = onePipelineBuild._id
                         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -484,8 +484,8 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
         results[jdkVersion][1].each { onePlatform, valueNotUsed ->
             mapOfMoreRecentBuildIDs[onePlatform] = ""
         }
-echo "Debug, hard-coding srcTag to jdk-21.0.6+2-ea-beta for testing."
-        getBuildIDsByPlatform(trssURL, jdkVersion, "jdk-21.0.6+2-ea-beta", mapOfMoreRecentBuildIDs)
+
+        getBuildIDsByPlatform(trssURL, jdkVersion, srcTag, mapOfMoreRecentBuildIDs)
 
         def jdkVersionInt = jdkVersion.replaceAll("[a-z]", "")
 
@@ -556,6 +556,7 @@ echo "debug A0.5"
 echo "debug A1"
                     // If we can find it, then we look for the anticipated percentage.
                     if ( !testOutput.contains("Running test "+reproTestName) ) {
+                        echo "This test does not contain ${reproTestName}. Skipping."
                         continue
                     }
 echo "debug A2"
@@ -568,26 +569,34 @@ echo "debug A2"
                 }
             }
         }
-
+echo "debug A3"
         // Now we have the percentages for each platform, we calculate the jdkVersion-specific average.
         BigDecimal overallAverage = 0.0
         // Ignoring the platforms where the test is not available yet.
         def naCount = 0
         for (String key in results[jdkVersion][1].keySet()) {
+echo "debug A3.1"
             def value = results[jdkVersion][1][key]
             if (value.equals("NA")) {
                 naCount++
             } else if ( value ==~ /^[0-9]+\.?[0-9]* %/ ) {
+echo "debug A3.2"
                 overallAverage += (value =~ /^[0-9]+\.?[0-9]*/)[0] as BigDecimal
             }
             // else do nothing, as we presume non-integer and non-NA values are 0.
         }
+echo "debug A3.3"
         if (overallAverage != 0) {
+echo "debug A3.4"
             overallAverage = overallAverage / (results[jdkVersion][1].size() - naCount)
+echo "debug A3.5"
         }
         // This reduces the output to 2 decimal places.
+echo "debug A3.6"
         results[jdkVersion][0] = ((overallAverage.toString()) =~ /[0-9]+\.?[0-9]?[0-9]?/)[0]+" %"
+echo "debug A3.7"
     }
+echo "debug A4"
 }
 
 node('worker') {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -46,11 +46,11 @@ def getPlatformConversionMap() {
 def getPlatformReproTestMap() {
     // A map to return the test bucket and test name for the repducibile platforms
     def platformReproTestMap = [x64Linux:           ["special.system", "Rebuild_Same_JDK_Reproducibility_Test"],
-                                x64Windows:         ["dev.system", "Rebuild_Same_JDK_Reproducibility_Test_win"],
+                                x64Windows:         ["special.system", "Rebuild_Same_JDK_Reproducibility_Test_win"],
                                 x64Mac:             ["NA", ""],
                                 ppc64leLinux:       ["special.system", "Rebuild_Same_JDK_Reproducibility_Test"],
                                 aarch64Linux:       ["special.system", "Rebuild_Same_JDK_Reproducibility_Test"],
-                                aarch64Mac:         ["dev.system", "Rebuild_Same_JDK_Reproducibility_Test_Mac"]
+                                aarch64Mac:         ["special.system", "Rebuild_Same_JDK_Reproducibility_Test_Mac"]
                                ]
     return platformReproTestMap
 }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -204,7 +204,7 @@ echo "D6.1"
                     continue
                 }
 echo "D6.2: ${onePipelineBuild.buildName} and ${platformConversionMap[onePlatformKey][0]}"
-                if (onePipelineBuild.buildName.contains("${jdkVersion}-${platformConversionMap[onePlatformKey][0]})") {
+                if (onePipelineBuild.buildName.contains("${jdkVersion}-${platformConversionMap[onePlatformKey][0]}")) {
 echo "D6.3"
                     // - Does the build job for one of our listed platforms contain a successful build job?
                     if (onePipelineBuild.status.equals("Done") && (onePipelineBuild.buildResult.equals("UNSTABLE") || onePipelineBuild.buildResult.equals("SUCCESS"))) {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -175,7 +175,7 @@ echo "D1"
 echo "D3"
 echo "D4: Checking if pipeline matches ${srcTag}"
         if (!onePipeline.toString().contains(srcTag.replaceAll("-beta",""))) {
-echo "D4.1: Skipping ${srcTag}"
+echo "D4.1: Skipping pipeline that does not match the tag."
             continue
         }
 echo "D4.5"
@@ -199,7 +199,7 @@ echo "D5"
             for (int k = 0 ; k < platformKeys.size() ; k++ ) {
                 String onePlatformKey = platformKeys[k]
                 String onePlatformValue = platformsList[onePlatformKey]
-echo "D6: Key: ${onePlatformKey} temp_value: ${onePlatformValue} stored_value: ${onePipelinePlatformsMap[onePlatformKey]} end"
+echo "D6: Key: ${onePlatformKey} temp_value: ${onePipelinePlatformsMap[onePlatformKey]} stored_value: ${onePlatformValue} end"
                 if (!onePlatformValue.isEmpty()) {
 echo "D6.1"
                     continue
@@ -503,7 +503,9 @@ echo "Debug, hard-coding srcTag to jdk-21.0.6+2-ea-beta for testing."
             def pipelineLink = trssURL+"/api/getAllChildBuilds?parentId=${trssId}\\&buildNameRegex=^${jdkVersion}\\-${platformConversionMap[onePlatform][0]}\\-temurin\$"
             if (mapOfMoreRecentBuildIDs.containsKey(onePlatform) && !mapOfMoreRecentBuildIDs[onePlatform].equals("")) {
                 pipelineLink = trssURL+"/api/getData?_id=${mapOfMoreRecentBuildIDs[onePlatform]}"
-                echo "Overriding the TRSS build ID for JDK${jdkVersion}, platform ${onePlatform}, with: ${pipelineLink}"
+                echo "Overriding the oldest TRSS build ID for JDK${jdkVersion}, platform ${onePlatform}, tag ${srcTag}"
+                echo "Original TRSS pipeline link: ${pipelineLink}"
+                echo "New link: ${trssURL}/api/getData?_id=${mapOfMoreRecentBuildIDs[onePlatform]}"
             }
             def trssBuildJobNames = sh(returnStdout: true, script: "wget -q -O - ${pipelineLink}")
             results[jdkVersion][1][onePlatform] = "???% - Build not found. Pipeline link: " + pipelineLink

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -197,7 +197,7 @@ echo "D6: ${onePlatformKey} and ${onePlatformValue} end"
 echo "D6.1"
                     continue
                 }
-echo "D6.2: ${onePipelineBuild.buildName} and platformConversionMap[onePlatformKey][0]"
+echo "D6.2: ${onePipelineBuild.buildName} and ${platformConversionMap[onePlatformKey][0]}"
                 if (onePipelineBuild.buildName.contains(platformConversionMap[onePlatformKey][0])) {
 echo "D6.3"
                     // - Does the build job for one of our listed platforms contain a successful build job?

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -169,10 +169,16 @@ echo "D1"
     // Then we iterate over the list of pipelines, seeking a pipeline that contains one of our platforms.
     for (def onePipeline : pipelineJson) {
 echo "D3"
+        if (!onePipeline.toString().contains(srcTag.replaceAll("-beta",""))) {
+echo "D4: ${srcTag}"
+            continue
+        }
+echo "D4.5"
         def pipelineBuilds = sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getChildBuilds?parentId=${onePipeline._id}")
         def pipelineBuildsJson = new JsonSlurper().parseText(pipelineBuilds)
-        if ((pipelineBuildsJson.size() == 0) || (!onePipeline.toString().contains(srcTag.replaceAll("-beta","")))) {
-echo "D4: ${srcTag}"
+
+        if (pipelineBuildsJson.size() == 0) {
+echo "D4.6"
             continue
         }
 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -551,7 +551,7 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
     }
 }
 
-node('test-osuosl-ubuntu1804-ppc64le-2') {
+node('build-linux-x64-ee1bc0') {
   try{
     def variant = "${params.VARIANT}"
     def trssUrl    = "${params.TRSS_URL}"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -557,7 +557,8 @@ echo "Debug, hard-coding srcTag to jdk-21.0.5+9-ea-beta for testing."
         BigDecimal overallAverage = 0.0
         // Ignoring the platforms where the test is not available yet.
         def naCount = 0
-        results[jdkVersion][1].each{key, value ->
+        for (String key in results[jdkVersion][1].keySet()) {
+            def value = results[jdkVersion][1][key]
             if (value.equals("NA")) {
                 naCount++
             } else if ( value ==~ /^[0-9]+\.?[0-9]* %/ ) {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -169,7 +169,8 @@ echo "D1"
     // Then we iterate over the list of pipelines, seeking a pipeline that contains one of our platforms.
     assert pipelineJson instanceof List
 
-    for (Map onePipeline : pipelineJson) {
+    for (int i = 0 ; i < pipelineJson.size() ; i++ ) {
+        Map onePipeline = pipelineJson[i]
 echo "D3"
         if (!onePipeline.toString().contains(srcTag.replaceAll("-beta",""))) {
 echo "D4: ${srcTag}"
@@ -193,10 +194,13 @@ echo "DEBUGGING: ${pipelineBuildsJson[0].buildName}"
 echo "DEBUGGING: ${pipelineBuildsJson[1].buildName}"
 echo "DEBUGGING: ${pipelineBuildsJson[2].buildName}"
         for (Map onePipelineBuild : pipelineBuildsJson) {
+        for (int j = 0 ; j < pipelineBuildsJson.size() ; j++ ) {
+            Map onePipelineBuild = pipelineBuildsJson[j]
 echo "D5"
             // - Is this platform in our platform list?
             Set platformKeys = platformsList.keySet()
-            for (String onePlatformKey : platformKeys) {
+            for (int k = 0 ; k < platformKeys.size() ; k++ ) {
+                String onePlatformKey = platformKeys[k]
                 String onePlatformValue = platformsList[onePlatformKey]
 echo "D6: ${onePlatformKey} and ${onePlatformValue} end"
                 if (!onePlatformValue.isEmpty()) {
@@ -230,7 +234,8 @@ echo "D9"
         if (pipelinePublishBool) {
 echo "D10"
             def platformsWithAValue = 0
-            for (String onePlatformKey : platformKeys) {
+            for (int m = 0 ; m < platformKeys.size() ; m++ ) {
+                String onePlatformKey = platformKeys[m]
                 if (platformsList[onePlatformKey].isEmpty()) {
                     if (onePipelinePlatformsMap.containsKey(onePlatformKey)) {
 echo "D11"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -180,7 +180,7 @@ echo "D4: ${srcTag}"
         def onePipelinePlatformsMap = [:]
 
         // For each build within a given pipeline:
-        pipelineBuildsJson.each { onePipelineBuild ->
+        for (def onePipelineBuild : pipelineBuildsJson) {
 echo "D5"
             // - Is this platform in our platform list?
             Set platformKeys = platformsList.keySet()

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -541,7 +541,7 @@ echo "Debug, hard-coding srcTag to jdk-21.0.6+2-ea-beta for testing."
                         wgetCommand = "wget -q -O - ${testJob.buildUrl}/consoleText"
                     }
 
-                    def testOutputRC = sh(returnStatus : true, script: "${wgetCommand}")
+                    def testOutputRC = sh(returnStatus : true, returnStdout: false, script: "${wgetCommand}")
 
                     // If we can find it, then we look for the anticipated percentage.
                     if ( testOutputRC != 0 ) {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -184,14 +184,17 @@ echo "D5"
             // - Is this platform in our platform list?
             def onePipelinePlatformsMap = [:]
             platformsList.each { onePlatformKey, onePlatformValue ->
-echo "D6"
+echo "D6: ${onePlatformKey} and ${onePlatformValue} end"
                 if (!onePlatformValue.isEmpty()) {
+echo "D6.1"
                     return
                 }
-
+echo "D6.2"
                 if (onePipelineBuild.buildName.contains(platformConversionMap[onePlatformKey][0])) {
+echo "D6.2"
                     // - Does the build job for one of our listed platforms contain a successful build job?
                     if (onePipelineBuild.status.equals("Done") && (onePipelineBuild.buildResult.equals("UNSTABLE") || onePipelineBuild.buildResult.equals("SUCCESS"))) {
+echo "D6.1"
                         onePipelinePlatformsMap[onePlatformKey] = onePipelineBuild._id
 echo "D7"
                     }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -202,7 +202,7 @@ echo "D6.1"
                     continue
                 }
 echo "D6.2: ${onePipelineBuild.buildName} and ${platformConversionMap[onePlatformKey][0]}"
-                if (onePipelineBuild.buildName.contains(platformConversionMap[onePlatformKey][0])) {
+                if (onePipelineBuild.buildName.contains("${jdkVersion}-${platformConversionMap[onePlatformKey][0]})") {
 echo "D6.3"
                     // - Does the build job for one of our listed platforms contain a successful build job?
                     if (onePipelineBuild.status.equals("Done") && (onePipelineBuild.buildResult.equals("UNSTABLE") || onePipelineBuild.buildResult.equals("SUCCESS"))) {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -173,8 +173,9 @@ echo "D1"
     for (int i = 0 ; i < pipelineJson.size() ; i++ ) {
         Map onePipeline = pipelineJson[i]
 echo "D3"
+echo "D4: Checking if pipeline matches ${srcTag}"
         if (!onePipeline.toString().contains(srcTag.replaceAll("-beta",""))) {
-echo "D4: ${srcTag}"
+echo "D4.1: Skipping ${srcTag}"
             continue
         }
 echo "D4.5"
@@ -198,7 +199,7 @@ echo "D5"
             for (int k = 0 ; k < platformKeys.size() ; k++ ) {
                 String onePlatformKey = platformKeys[k]
                 String onePlatformValue = platformsList[onePlatformKey]
-echo "D6: ${onePlatformKey} and ${onePlatformValue} end"
+echo "D6: Key: ${onePlatformKey} temp_value: ${onePlatformValue} stored_value: ${onePipelinePlatformsMap[onePlatformKey]} end"
                 if (!onePlatformValue.isEmpty()) {
 echo "D6.1"
                     continue
@@ -483,7 +484,8 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
         results[jdkVersion][1].each { onePlatform, valueNotUsed ->
             mapOfMoreRecentBuildIDs[onePlatform] = ""
         }
-        getBuildIDsByPlatform(trssURL, jdkVersion, srcTag, mapOfMoreRecentBuildIDs)
+echo "Debug, hard-coding srcTag to jdk-21.0.5+9-ea-beta for testing."
+        getBuildIDsByPlatform(trssURL, jdkVersion, "jdk-21.0.5+9-ea-beta", mapOfMoreRecentBuildIDs)
 
         def jdkVersionInt = jdkVersion.replaceAll("[a-z]", "")
 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -485,7 +485,7 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
             mapOfMoreRecentBuildIDs[onePlatform] = ""
         }
 echo "Debug, hard-coding srcTag to jdk-21.0.5+9-ea-beta for testing."
-        getBuildIDsByPlatform(trssURL, jdkVersion, "jdk-21.0.5+9-ea-beta", mapOfMoreRecentBuildIDs)
+        getBuildIDsByPlatform(trssURL, jdkVersion, "jdk-21.0.5+2-ea-beta", mapOfMoreRecentBuildIDs)
 
         def jdkVersionInt = jdkVersion.replaceAll("[a-z]", "")
 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -154,13 +154,14 @@ def getLatestBinariesTag(String version) {
 def getBuildIDsByPlatform(String trssUrl, String jdkVersion, String srcTag, Map platformsList) {
     // First we gather a list of the latest pipelines for this jdkVersion.
     echo "Gathering Build IDs by platform."
-    def pipelineName = "openjdk${jdkVersion}-pipeline"
+    def jdkVersionMinusTheU = jdkVersion.endsWith("u") ? jdkVersion.substring(0, jdkVersion.length() - 1) : jdkVersion
+    def pipelineName = "open${jdkVersionMinusTheU}-pipeline"
     def pipelines = sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getBuildHistory?buildName=${pipelineName}")
     def pipelineJson = new JsonSlurper().parseText(pipelines)
 echo "D1"
     if (pipelineJson.size() == 0) {
+        echo "WARNING: Cannot find pipelines for per-platform build job identification."
         return
-echo "D2"
     }
 
     def platformConversionMap = getPlatformConversionMap()

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -189,7 +189,9 @@ echo "D4.6"
 
         // For each build within a given pipeline:
         assert pipelineBuildsJson instanceof List
-echo "DEBUGGING: ${pipelineBuildsJson.toString()}"
+echo "DEBUGGING: ${pipelineBuildsJson[0].buildName}"
+echo "DEBUGGING: ${pipelineBuildsJson[1].buildName}"
+echo "DEBUGGING: ${pipelineBuildsJson[2].buildName}"
         for (Map onePipelineBuild : pipelineBuildsJson) {
 echo "D5"
             // - Is this platform in our platform list?

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -906,7 +906,7 @@ node('worker') {
 
                             getReproducibilityPercentage(featureRelease, reproBuildTrss, trssUrl, releaseName, reproducibleBuilds)
 
-                            if ( reproducibleBuilds[featureRelease][0] != "100%") {
+                            if ( reproducibleBuilds[featureRelease][0].startsWith("100") ) {
                                 if (!slackColor.equals('danger')) {
                                     slackColor = 'warning'
                                 }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -901,7 +901,7 @@ node('worker') {
                     if (reproducibleBuilds.containsKey(featureRelease)) {
                         def (reproBuildUrl, reproBuildTrss, ignorethisvariable) = getBuildUrl(trssUrl, variant, featureRelease, releaseName.replaceAll("-beta", ""), releaseName.replaceAll("-beta", "").replaceAll("-ea", "")+"_adopt")
 
-                        if ( probableBuildUrl != "" && sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getBuildHistory?buildUrl=${reproBuildUrl}") ==~ /.*name.:.enableTests.,.value.:true.*/ ) {
+                        if ( reproBuildUrl != "" && sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getBuildHistory?buildUrl=${reproBuildUrl}") ==~ /.*name.:.enableTests.,.value.:true.*/ ) {
                             echo "This pipeline has testing enabled: ${reproBuildUrl}"
 
                             getReproducibilityPercentage(featureRelease, reproBuildTrss, trssUrl, releaseName, reproducibleBuilds)

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -540,7 +540,7 @@ echo "Debug, hard-coding srcTag to jdk-21.0.5+9-ea-beta for testing."
                     if (testJob.buildOutputId == null) {
                         wgetCommand = "wget -q -O - ${testJob.buildUrl}/consoleText"
                     }
-                    def testOutput = sh(returnStdout: true, script: "wget -q -O - ${wgetCommand}")
+                    def testOutput = sh(returnStdout: true, script: "${wgetCommand}")
 
                     // If we can find it, then we look for the anticipated percentage.
                     if ( !testOutput.contains("Running test "+reproTestName) ) {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -190,10 +190,6 @@ echo "D4.6"
 
         // For each build within a given pipeline:
         assert pipelineBuildsJson instanceof List
-echo "DEBUGGING: ${pipelineBuildsJson[0].buildName}"
-echo "DEBUGGING: ${pipelineBuildsJson[1].buildName}"
-echo "DEBUGGING: ${pipelineBuildsJson[2].buildName}"
-        for (Map onePipelineBuild : pipelineBuildsJson) {
         for (int j = 0 ; j < pipelineBuildsJson.size() ; j++ ) {
             Map onePipelineBuild = pipelineBuildsJson[j]
 echo "D5"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -898,21 +898,14 @@ node('worker') {
                         }
                     }
 
-echo "DEBUG: expectedReleaseName - ${status['expectedReleaseName']}"
-echo "DEBUG: upstreamTag - ${status['upstreamTag']}"
-echo "DEBUG: releaseName - ${releaseName}"
-
-                    def (reproBuildUrl, reproBuildTrss, ignorethisvariable) = getBuildUrl(trssUrl, variant, featureRelease, status['expectedReleaseName'].replaceAll("-beta", ""), status['upstreamTag']+"_adopt")
-                    def testsShouldHaveRun = false
-                    if ( probableBuildUrl != "" && sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getBuildHistory?buildUrl=${reproBuildUrl}") ==~ /.*name.:.enableTests.,.value.:true.*/ ) {
-                        testsShouldHaveRun = true
-                        echo "This pipeline has testing enabled: ${reproBuildUrl}"
-                    } else {
-                        echo "This pipeline is either a blank string, or does not have testing enabled: ${reproBuildUrl}"
-                    }
                     if (reproducibleBuilds.containsKey(featureRelease)) {
-                        if (testsShouldHaveRun) {
+                        def (reproBuildUrl, reproBuildTrss, ignorethisvariable) = getBuildUrl(trssUrl, variant, featureRelease, releaseName.replaceAll("-beta", ""), releaseNamereplaceAll("-beta", "").replaceAll("-ea", "")+"_adopt")
+
+                        if ( probableBuildUrl != "" && sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getBuildHistory?buildUrl=${reproBuildUrl}") ==~ /.*name.:.enableTests.,.value.:true.*/ ) {
+                            echo "This pipeline has testing enabled: ${reproBuildUrl}"
+
                             getReproducibilityPercentage(featureRelease, reproBuildTrss, trssUrl, releaseName, reproducibleBuilds)
+
                             if ( reproducibleBuilds[featureRelease][0] != "100%") {
                                 if (!slackColor.equals('danger')) {
                                     slackColor = 'warning'
@@ -939,8 +932,9 @@ echo "DEBUG: releaseName - ${releaseName}"
                                 errorMsg += "\nBuild repro summary: "+summaryOfRepros
                             }
                         } else {
-                            // Ignore test results if the tests for this pipeline were intentionally disabled.
+                            // Ignore test results if the tests for this pipeline were intentionally disabled, or if we cannot find a likely pipeline job.
                             reproducibleBuilds[featureRelease][0] = "N/A - Tests disabled"
+                            echo "This pipeline is either a blank string, or does not have testing enabled: ${reproBuildUrl}"
                         }
                     }
                 }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -208,12 +208,8 @@ echo "D6.2: ${onePipelineBuild.buildName} and ${platformConversionMap[onePlatfor
 echo "D6.3"
                     // - Does the build job for one of our listed platforms contain a successful build job?
                     if (onePipelineBuild.status.equals("Done") && (onePipelineBuild.buildResult.equals("UNSTABLE") || onePipelineBuild.buildResult.equals("SUCCESS"))) {
-echo "D6.4: ${onePipelineBuild.buildParams.toString()}"
-                        if (onePipelineBuild.buildParams.contains("ENABLE_TESTS\": true") || onePipelineBuild.buildParams.contains("ENABLE_TESTS\\\": true")) {
 echo "D6.5"
-                            onePipelinePlatformsMap[onePlatformKey] = onePipelineBuild._id
-                        }
-echo "D7"
+                        onePipelinePlatformsMap[onePlatformKey] = onePipelineBuild._id
                     }
                 }
 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -197,7 +197,7 @@ echo "D6: ${onePlatformKey} and ${onePlatformValue} end"
 echo "D6.1"
                     continue
                 }
-echo "D6.2"
+echo "D6.2: ${onePipelineBuild.buildName} and platformConversionMap[onePlatformKey][0]"
                 if (onePipelineBuild.buildName.contains(platformConversionMap[onePlatformKey][0])) {
 echo "D6.3"
                     // - Does the build job for one of our listed platforms contain a successful build job?

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -203,7 +203,7 @@ def getBuildIDsByPlatform(String trssUrl, String jdkVersion, String srcTag, Map 
             def platformsWithAValue = 0
             platformsList.each{ onePlatformKey, onePlatformValue ->
                 if (platformsList[onePipelinePlatformKey].isEmpty()) {
-                    if (onePipelinePlatformsMap.contains(onePlatformKey)) {
+                    if (onePipelinePlatformsMap.containsKey(onePlatformKey)) {
                         platformsList[onePipelinePlatformKey] = onePipelinePlatformsMap[onePlatformKey]
                         platformsWithAValue++
                     }
@@ -463,7 +463,7 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
             }
 
             def pipelineLink = trssURL+"/api/getAllChildBuilds?parentId=${trssId}\\&buildNameRegex=^${jdkVersion}\\-${platformConversionMap[onePlatform][0]}\\-temurin\$"
-            if (mapOfMoreRecentBuildIDs.contains(onePlatform) && !mapOfMoreRecentBuildIDs[onePlatform].equals("")) {
+            if (mapOfMoreRecentBuildIDs.containsKey(onePlatform) && !mapOfMoreRecentBuildIDs[onePlatform].equals("")) {
                 pipelineLink = trssURL+"/api/getData?_id=${mapOfMoreRecentBuildIDs[onePlatform]}"
                 echo "Overriding the TRSS build ID for JDK${jdkVersion}, platform ${onePlatform}, with: ${pipelineLink}"
             }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -491,7 +491,6 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
                     return
                 }
 
-<<<<<<< HEAD
                 results[jdkVersion][1][onePlatform] = "???% - Found ${reproTestBucket}, but did not find ${reproTestName}. Build Link: " + buildJob.buildUrl
                 def testJobNamesJson = new JsonSlurper().parseText(trssTestJobNames)
 
@@ -509,18 +508,6 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
                     def matcherObject = testOutput =~ /ReproduciblePercent = (100|[0-9][0-9]?\.?[0-9]?[0-9]?) %/
                     if ( matcherObject ) {
                         results[jdkVersion][1][onePlatform] = ((matcherObject[0] =~ /(100|[0-9][0-9]?\.?[0-9]?[0-9]?) %/)[0][0])
-=======
-                            // If we can find it, then we look for the anticipated percentage.
-                            if ( testOutput.contains("Running test "+reproTestName) ) {
-                                platformResult = "???% - ${reproTestName} ran but failed to produce a percentage. Test Link: " + testJob.buildUrl
-                                // Now we know the test ran, 
-                                def matcherObject = testOutput =~ /ReproduciblePercent = (100|[0-9][0-9]?\.?[0-9]?[0-9]?) %/
-                                if ( matcherObject ) {
-                                    platformResult = ((matcherObject[0] =~ /(100|[0-9][0-9]?\.?[0-9]?[0-9]?) %/)[0][0])
-                                }
-                            }
-                        }
->>>>>>> refs/heads/master
                     }
                 }
             }
@@ -912,7 +899,7 @@ node('worker') {
                     }
 
                     if (reproducibleBuilds.containsKey(featureRelease)) {
-                        def (reproBuildUrl, reproBuildTrss, ignorethisvariable) = getBuildUrl(trssUrl, variant, featureRelease, releaseName.replaceAll("-beta", ""), releaseNamereplaceAll("-beta", "").replaceAll("-ea", "")+"_adopt")
+                        def (reproBuildUrl, reproBuildTrss, ignorethisvariable) = getBuildUrl(trssUrl, variant, featureRelease, releaseName.replaceAll("-beta", ""), releaseName.replaceAll("-beta", "").replaceAll("-ea", "")+"_adopt")
 
                         if ( probableBuildUrl != "" && sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getBuildHistory?buildUrl=${reproBuildUrl}") ==~ /.*name.:.enableTests.,.value.:true.*/ ) {
                             echo "This pipeline has testing enabled: ${reproBuildUrl}"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -171,7 +171,7 @@ echo "D1"
 echo "D3"
         def pipelineBuilds = sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getChildBuilds?parentId=${onePipeline._id}")
         def pipelineBuildsJson = new JsonSlurper().parseText(pipelineBuilds)
-        if ((pipelineBuildsJson.size() == 0) || (!onePipeline.toString().contains(srcTag.replaceAll("-beta")))) {
+        if ((pipelineBuildsJson.size() == 0) || (!onePipeline.toString().contains(srcTag.replaceAll("-beta","")))) {
 echo "D4: ${srcTag}"
             return
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -540,8 +540,8 @@ echo "Debug, hard-coding srcTag to jdk-21.0.6+2-ea-beta for testing."
                     if (testJob.buildOutputId == null) {
                         wgetCommand = "wget -q -O - ${testJob.buildUrl}/consoleText"
                     }
-
-                    def testOutputRC = sh(returnStatus : true, returnStdout: false, script: "${wgetCommand}")
+echo "debug A-1"
+                    def testOutputRC = sh(returnStatus : true, returnStdout: false, script: "${wgetCommand} > /dev/null")
 echo "debug A0"
                     // If we can find it, then we look for the anticipated percentage.
                     if ( testOutputRC != 0 ) {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -209,7 +209,7 @@ echo "D6.3"
                     // - Does the build job for one of our listed platforms contain a successful build job?
                     if (onePipelineBuild.status.equals("Done") && (onePipelineBuild.buildResult.equals("UNSTABLE") || onePipelineBuild.buildResult.equals("SUCCESS"))) {
 echo "D6.4"
-                        if (onePipelineBuild.buildParams.toString() ==~ /ENABLE_TESTS..?\:.?true/) {
+                        if (onePipelineBuild.buildParams.toString() ==~ /.*ENABLE_TESTS..?\:.?true.*/) {
 echo "D6.5"
                             onePipelinePlatformsMap[onePlatformKey] = onePipelineBuild._id
                         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -171,7 +171,7 @@ echo "D1"
 echo "D3"
         def pipelineBuilds = sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getChildBuilds?parentId=${onePipeline._id}")
         def pipelineBuildsJson = new JsonSlurper().parseText(pipelineBuilds)
-        if ((pipelineBuildsJson.size() == 0) || (!onePipeline.toString().contains(srcTag))) {
+        if ((pipelineBuildsJson.size() == 0) || (!onePipeline.toString().contains(srcTag.replaceAll("-beta")))) {
 echo "D4: ${srcTag}"
             return
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -901,6 +901,9 @@ node('worker') {
                     def testsShouldHaveRun = false
                     if ( probableBuildUrl != "" && sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getBuildHistory?buildUrl=${probableBuildUrl}") ==~ /.*name.:.enableTests.,.value.:true.*/ ) {
                         testsShouldHaveRun = true
+                        echo "This pipeline has testing enabled: ${probableBuildUrl}"
+                    } else {
+                        echo "This pipeline is either a blank string, or does not have testing enabled: ${probableBuildUrl}"
                     }
                     if (reproducibleBuilds.containsKey(featureRelease)) {
                         if (testsShouldHaveRun) {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -189,6 +189,7 @@ echo "D4.6"
 
         // For each build within a given pipeline:
         assert pipelineBuildsJson instanceof List
+echo "DEBUGGING: ${pipelineBuildsJson.toString()}"
         for (Map onePipelineBuild : pipelineBuildsJson) {
 echo "D5"
             // - Is this platform in our platform list?

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -516,7 +516,7 @@ echo "Debug, hard-coding srcTag to jdk-21.0.5+9-ea-beta for testing."
             def buildJobNamesJson = new JsonSlurper().parseText(trssBuildJobNames)
 
             // For each build, search the test output for the unit test we need, then look for reproducibility percentage.
-            assert pipelineBuildsJson instanceof Map
+            assert buildJobNamesJson instanceof List
             for ( Map buildJob in buildJobNamesJson ) {
                 results[jdkVersion][1][onePlatform] = "???% - Build found, but no reproducibility tests. Build link: " + buildJob.buildUrl
                 def testPlatform = platformConversionMap[onePlatform][1]

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -208,8 +208,8 @@ echo "D6.2: ${onePipelineBuild.buildName} and ${platformConversionMap[onePlatfor
 echo "D6.3"
                     // - Does the build job for one of our listed platforms contain a successful build job?
                     if (onePipelineBuild.status.equals("Done") && (onePipelineBuild.buildResult.equals("UNSTABLE") || onePipelineBuild.buildResult.equals("SUCCESS"))) {
-echo "D6.4"
-                        if (onePipelineBuild.buildParams.toString() ==~ /.*ENABLE_TESTS..?\:.?true.*/) {
+echo "D6.4: ${onePipelineBuild.buildParams.toString()}"
+                        if (onePipelineBuild.buildParams.toString() ==~ /.*ENABLE_TESTS..?:\s?true.*/) {
 echo "D6.5"
                             onePipelinePlatformsMap[onePlatformKey] = onePipelineBuild._id
                         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -165,6 +165,7 @@ echo "D1"
     }
 
     def platformConversionMap = getPlatformConversionMap()
+    Set platformKeys = platformsList.keySet()
 
     // Then we iterate over the list of pipelines, seeking a pipeline that contains one of our platforms.
     assert pipelineJson instanceof List
@@ -194,7 +195,6 @@ echo "D4.6"
             Map onePipelineBuild = pipelineBuildsJson[j]
 echo "D5"
             // - Is this platform in our platform list?
-            Set platformKeys = platformsList.keySet()
             for (int k = 0 ; k < platformKeys.size() ; k++ ) {
                 String onePlatformKey = platformKeys[k]
                 String onePlatformValue = platformsList[onePlatformKey]

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -947,10 +947,11 @@ node('worker') {
                     }
 
                     if (reproducibleBuilds.containsKey(featureRelease)) {
-                        def (reproBuildUrl, reproBuildTrss, ignorethisvariable) = getBuildUrl(trssUrl, variant, featureRelease, releaseName.replaceAll("-beta", ""), releaseName.replaceAll("-beta", "").replaceAll("-ea", "")+"_adopt")
+                        def (reproBuildUrl, reproBuildTrss, reproBuildStatus) = getBuildUrl(trssUrl, variant, featureRelease, releaseName.replaceAll("-beta", ""), releaseName.replaceAll("-beta", "").replaceAll("-ea", "")+"_adopt")
 
                         if ( reproBuildUrl != "" && callWgetSafely("${trssUrl}/api/getBuildHistory?buildUrl=${reproBuildUrl}") ==~ /.*name.:.enableTests.,.value.:true.*/ ) {
                             echo "This pipeline has testing enabled: ${reproBuildUrl}"
+                            echo "This pipeline's current status is ${reproBuildStatus}"
 
                             getReproducibilityPercentage(featureRelease, reproBuildTrss, trssUrl, releaseName, reproducibleBuilds)
 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -542,14 +542,14 @@ echo "Debug, hard-coding srcTag to jdk-21.0.6+2-ea-beta for testing."
                     }
 
                     def testOutputRC = sh(returnStatus : true, returnStdout: false, script: "${wgetCommand}")
-
+echo "debug A0"
                     // If we can find it, then we look for the anticipated percentage.
                     if ( testOutputRC != 0 ) {
                         echo "Warning: This job's output could not be found in trss or jenkins, and is likely expired: ${testJob.buildUrl}"
                         echo "Skipping this test and moving on to the next one."
                         continue
                     }
-
+echo "debug A0.5"
                     def testOutput = sh(returnStdout: true, script: "${wgetCommand}")
 echo "debug A1"
                     // If we can find it, then we look for the anticipated percentage.

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -551,7 +551,7 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
     }
 }
 
-node('x64&&linux') {
+node('worker') {
   try{
     def variant = "${params.VARIANT}"
     def trssUrl    = "${params.TRSS_URL}"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -536,7 +536,15 @@ echo "Debug, hard-coding srcTag to jdk-21.0.5+9-ea-beta for testing."
                 // For each test job (including testList subjobs), we now search for the reproducibility test.
                 assert testJobNamesJson instanceof List
                 for ( Map testJob in testJobNamesJson ) {
-                    def testOutput = sh(returnStdout: true, script: "wget -q -O - ${trssURL}/api/getOutputById?id=${testJob.buildOutputId}")
+                    def testOutputStream = new StringBuilder()
+                    def wgetCommand = "wget -q -O - ${trssURL}/api/getOutputById?id=${testJob.buildOutputId}"
+                    if (testJob.buildOutputId == null) {
+                        wgetCommand = "wget -q -O - ${testJob.buildUrl}/consoleText"
+                    }
+                    def wgetProcess = wgetCommand.execute()
+                    wgetProcess.consumeProcessOutputStream(testOutputStream)
+                    wgetProcess.waitForOrKill(30*1000)
+                    def testOutput = testOutputStream.toString()
 
                     // If we can find it, then we look for the anticipated percentage.
                     if ( !testOutput.contains("Running test "+reproTestName) ) {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -498,10 +498,10 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
 
             def pipelineLink = "${trssURL}/api/getAllChildBuilds?parentId=${trssId}\\&buildNameRegex=^${jdkVersion}\\-${platformConversionMap[onePlatform][0]}\\-temurin\$"
             if (mapOfMoreRecentBuildIDs.containsKey(onePlatform) && !mapOfMoreRecentBuildIDs[onePlatform].equals("")) {
-                pipelineLink = "${trssURL}/api/getData?_id=${mapOfMoreRecentBuildIDs[onePlatform]}"
-                echo "Overriding the oldest TRSS build ID for JDK${jdkVersion}, platform ${onePlatform}, tag ${srcTag}"
+                echo "Overriding the TRSS build ID for ${jdkVersion}, platform ${onePlatform}, tag ${srcTag}"
                 echo "Original TRSS pipeline link: ${pipelineLink}"
                 echo "New link: ${trssURL}/api/getData?_id=${mapOfMoreRecentBuildIDs[onePlatform]}"
+                pipelineLink = "${trssURL}/api/getData?_id=${mapOfMoreRecentBuildIDs[onePlatform]}"
             }
             def trssBuildJobNames = callWgetSafely("${pipelineLink}")
             results[jdkVersion][1][onePlatform] = "???% - Build not found. Pipeline link: " + pipelineLink

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -153,6 +153,7 @@ def getLatestBinariesTag(String version) {
 // Takes a jdk major version, a tag, and an array of platform names (standard platform format).
 def getBuildIDsByPlatform(String trssUrl, String jdkVersion, String srcTag, Map platformsList) {
     // First we gather a list of the latest pipelines for this jdkVersion.
+    echo "Gathering Build IDs by platform."
     def pipelineName = "openjdk${jdkVersion}-pipeline"
     def pipelines = sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getBuildHistory?buildName=${pipelineName}")
     def pipelineJson = new JsonSlurper().parseText(pipelines)
@@ -206,6 +207,7 @@ def getBuildIDsByPlatform(String trssUrl, String jdkVersion, String srcTag, Map 
                     if (onePipelinePlatformsMap.containsKey(onePlatformKey)) {
                         platformsList[onePipelinePlatformKey] = onePipelinePlatformsMap[onePlatformKey]
                         platformsWithAValue++
+                        echo "Found new build ID for platform ${onePlatformKey}."
                     }
                 } else {
                     platformsWithAValue++
@@ -218,6 +220,7 @@ def getBuildIDsByPlatform(String trssUrl, String jdkVersion, String srcTag, Map 
             }
         }
     }
+    echo "Finished getting build IDs by platform."
 }
 
 // Return our best guess at the url for the first pipeline that generated builds from a specific tag.

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -218,13 +218,11 @@ echo "D7"
                     }
                 }
 
+echo "D7.1"
                 // Also, check if the pipeline published any successful builds overall.
                 if (onePipelineBuild.buildName.contains("refactor_openjdk_release_tool") && onePipelineBuild.status.contains("Done")) {
-                    def publishOutput = sh(returnStdout: true, script: "wget -q -O - ${onePipelineBuild.url}/job/refactor_openjdk_release_tool/${onePipelineBuild.buildNum}/consoleText")
-                    if (publishOutput.contains("Finished: SUCCESS")) {
-                        pipelinePublishBool = true
+                    pipelinePublishBool = true
 echo "D8"
-                    }
                 }
             }
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -971,8 +971,9 @@ node('worker') {
                             echo "This pipeline has testing enabled: ${reproBuildUrl}"
 
                             getReproducibilityPercentage(featureRelease, reproBuildTrss, trssUrl, releaseName, reproducibleBuilds)
-
-                            if ( reproducibleBuilds[featureRelease][0].startsWith("100") ) {
+echo "debug A5"
+                            if ( ! reproducibleBuilds[featureRelease][0].startsWith("100") ) {
+echo "debug A5.1"
                                 if (!slackColor.equals('danger')) {
                                     slackColor = 'warning'
                                 }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -550,7 +550,7 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
     }
 }
 
-node('worker') {
+node('test-osuosl-ubuntu1804-ppc64le-2') {
   try{
     def variant = "${params.VARIANT}"
     def trssUrl    = "${params.TRSS_URL}"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -172,8 +172,8 @@ echo "D3"
         def pipelineBuilds = sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getChildBuilds?parentId=${onePipeline._id}")
         def pipelineBuildsJson = new JsonSlurper().parseText(pipelineBuilds)
         if ((pipelineBuildsJson.size() == 0) || (!onePipeline.toString().contains(srcTag))) {
+echo "D4: ${srcTag}"
             return
-echo "D4"
         }
 
         boolean pipelinePublishBool = false

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -541,22 +541,22 @@ echo "Debug, hard-coding srcTag to jdk-21.0.6+2-ea-beta for testing."
                         wgetCommand = "wget -q -O - ${testJob.buildUrl}/consoleText"
                     }
 
-                    def testOutput = sh(returnStatus : true, script: "${wgetCommand}")
+                    def testOutputRC = sh(returnStatus : true, script: "${wgetCommand}")
 
                     // If we can find it, then we look for the anticipated percentage.
-                    if ( testOutput != 0 ) {
+                    if ( testOutputRC != 0 ) {
                         echo "Warning: This job's output could not be found in trss or jenkins, and is likely expired: ${testJob.buildUrl}"
                         echo "Skipping this test and moving on to the next one."
                         continue
                     }
 
-                    testOutput = sh(returnStdout: true, script: "${wgetCommand}")
-
+                    def testOutput = sh(returnStdout: true, script: "${wgetCommand}")
+echo "debug A1"
                     // If we can find it, then we look for the anticipated percentage.
                     if ( !testOutput.contains("Running test "+reproTestName) ) {
                         continue
                     }
-
+echo "debug A2"
                     results[jdkVersion][1][onePlatform] = "???% - ${reproTestName} ran but failed to produce a percentage. Test Link: " + testJob.buildUrl
                     // Now we know the test ran, 
                     def matcherObject = testOutput =~ /ReproduciblePercent = (100|[0-9][0-9]?\.?[0-9]?[0-9]?) %/

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -209,7 +209,11 @@ echo "D6.3"
                     // - Does the build job for one of our listed platforms contain a successful build job?
                     if (onePipelineBuild.status.equals("Done") && (onePipelineBuild.buildResult.equals("UNSTABLE") || onePipelineBuild.buildResult.equals("SUCCESS"))) {
 echo "D6.4"
-                        onePipelinePlatformsMap[onePlatformKey] = onePipelineBuild._id
+                        if (onePipelineBuild.buildParams.toString() ==~ /ENABLE_TESTS..?\:.?true/)
+echo "D6.5"
+                            onePipelinePlatformsMap[onePlatformKey] = onePipelineBuild._id
+                        }
+                        
 echo "D7"
                     }
                 }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -167,7 +167,9 @@ echo "D1"
     def platformConversionMap = getPlatformConversionMap()
 
     // Then we iterate over the list of pipelines, seeking a pipeline that contains one of our platforms.
-    for (def onePipeline : pipelineJson) {
+    assert pipelineJson instanceof List
+
+    for (Map onePipeline : pipelineJson) {
 echo "D3"
         if (!onePipeline.toString().contains(srcTag.replaceAll("-beta",""))) {
 echo "D4: ${srcTag}"
@@ -186,7 +188,8 @@ echo "D4.6"
         def onePipelinePlatformsMap = [:]
 
         // For each build within a given pipeline:
-        for (def onePipelineBuild : pipelineBuildsJson) {
+        assert pipelineBuildsJson instanceof List
+        for (Map onePipelineBuild : pipelineBuildsJson) {
 echo "D5"
             // - Is this platform in our platform list?
             Set platformKeys = platformsList.keySet()

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -551,7 +551,7 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
     }
 }
 
-node('build-linux-x64-ee1bc0') {
+node('x64&&linux') {
   try{
     def variant = "${params.VARIANT}"
     def trssUrl    = "${params.TRSS_URL}"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -503,6 +503,7 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
                 echo "New link: ${trssURL}/api/getData?_id=${mapOfMoreRecentBuildIDs[onePlatform]}"
                 pipelineLink = "${trssURL}/api/getData?_id=${mapOfMoreRecentBuildIDs[onePlatform]}"
             }
+
             def trssBuildJobNames = callWgetSafely("${pipelineLink}")
             results[jdkVersion][1][onePlatform] = "???% - Build not found. Pipeline link: " + pipelineLink
 
@@ -562,28 +563,22 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
         // Ignoring the platforms where the test is not available yet.
         def naCount = 0
         for (String key in results[jdkVersion][1].keySet()) {
-
             def value = results[jdkVersion][1][key]
             if (value.equals("NA")) {
                 naCount++
             } else if ( value ==~ /^[0-9]+\.?[0-9]* %/ ) {
-
                 overallAverage += (value =~ /^[0-9]+\.?[0-9]*/)[0] as BigDecimal
             }
             // else do nothing, as we presume non-integer and non-NA values are 0.
         }
 
         if (overallAverage != 0) {
-
             overallAverage = overallAverage / (results[jdkVersion][1].size() - naCount)
-
         }
+
         // This reduces the output to 2 decimal places.
-
         results[jdkVersion][0] = ((overallAverage.toString()) =~ /[0-9]+\.?[0-9]?[0-9]?/)[0]+" %"
-
     }
-
 }
 
 node('worker') {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -898,16 +898,21 @@ node('worker') {
                         }
                     }
 
+echo "DEBUG: expectedReleaseName - ${status['expectedReleaseName']}"
+echo "DEBUG: upstreamTag - ${status['upstreamTag']}"
+echo "DEBUG: releaseName - ${releaseName}"
+
+                    def (reproBuildUrl, reproBuildTrss, ignorethisvariable) = getBuildUrl(trssUrl, variant, featureRelease, status['expectedReleaseName'].replaceAll("-beta", ""), status['upstreamTag']+"_adopt")
                     def testsShouldHaveRun = false
-                    if ( probableBuildUrl != "" && sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getBuildHistory?buildUrl=${probableBuildUrl}") ==~ /.*name.:.enableTests.,.value.:true.*/ ) {
+                    if ( probableBuildUrl != "" && sh(returnStdout: true, script: "wget -q -O - ${trssUrl}/api/getBuildHistory?buildUrl=${reproBuildUrl}") ==~ /.*name.:.enableTests.,.value.:true.*/ ) {
                         testsShouldHaveRun = true
-                        echo "This pipeline has testing enabled: ${probableBuildUrl}"
+                        echo "This pipeline has testing enabled: ${reproBuildUrl}"
                     } else {
-                        echo "This pipeline is either a blank string, or does not have testing enabled: ${probableBuildUrl}"
+                        echo "This pipeline is either a blank string, or does not have testing enabled: ${reproBuildUrl}"
                     }
                     if (reproducibleBuilds.containsKey(featureRelease)) {
                         if (testsShouldHaveRun) {
-                            getReproducibilityPercentage(featureRelease, probableBuildIdForTRSS, trssUrl, releaseName, reproducibleBuilds)
+                            getReproducibilityPercentage(featureRelease, reproBuildTrss, trssUrl, releaseName, reproducibleBuilds)
                             if ( reproducibleBuilds[featureRelease][0] != "100%") {
                                 if (!slackColor.equals('danger')) {
                                     slackColor = 'warning'

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -191,10 +191,10 @@ echo "D6.1"
                 }
 echo "D6.2"
                 if (onePipelineBuild.buildName.contains(platformConversionMap[onePlatformKey][0])) {
-echo "D6.2"
+echo "D6.3"
                     // - Does the build job for one of our listed platforms contain a successful build job?
                     if (onePipelineBuild.status.equals("Done") && (onePipelineBuild.buildResult.equals("UNSTABLE") || onePipelineBuild.buildResult.equals("SUCCESS"))) {
-echo "D6.1"
+echo "D6.4"
                         onePipelinePlatformsMap[onePlatformKey] = onePipelineBuild._id
 echo "D7"
                     }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -484,8 +484,8 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
         results[jdkVersion][1].each { onePlatform, valueNotUsed ->
             mapOfMoreRecentBuildIDs[onePlatform] = ""
         }
-echo "Debug, hard-coding srcTag to jdk-21.0.5+9-ea-beta for testing."
-        getBuildIDsByPlatform(trssURL, jdkVersion, "jdk-21.0.5+2-ea-beta", mapOfMoreRecentBuildIDs)
+echo "Debug, hard-coding srcTag to jdk-21.0.6+2-ea-beta for testing."
+        getBuildIDsByPlatform(trssURL, jdkVersion, "jdk-21.0.6+2-ea-beta", mapOfMoreRecentBuildIDs)
 
         def jdkVersionInt = jdkVersion.replaceAll("[a-z]", "")
 
@@ -540,7 +540,17 @@ echo "Debug, hard-coding srcTag to jdk-21.0.5+9-ea-beta for testing."
                     if (testJob.buildOutputId == null) {
                         wgetCommand = "wget -q -O - ${testJob.buildUrl}/consoleText"
                     }
-                    def testOutput = sh(returnStdout: true, script: "${wgetCommand}")
+
+                    def testOutput = sh(returnStatus : true, script: "${wgetCommand}")
+
+                    // If we can find it, then we look for the anticipated percentage.
+                    if ( testOutput != 1 ) {
+                        echo "Warning: This job's output could not be found in trss or jenkins, and is likely expired: ${testJob.buildUrl}"
+                        echo "Skipping this test and moving on to the next one."
+                        continue
+                    }
+
+                    testOutput = sh(returnStdout: true, script: "${wgetCommand}")
 
                     // If we can find it, then we look for the anticipated percentage.
                     if ( !testOutput.contains("Running test "+reproTestName) ) {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -542,16 +542,6 @@ echo "Debug, hard-coding srcTag to jdk-21.0.5+9-ea-beta for testing."
                     }
                     def testOutput = sh(returnStdout: true, script: "wget -q -O - ${wgetCommand}")
 
-                    def commandString = "wget -q -O - https://trss.adoptium.net/api/getOutputById?id=null \& " +
-                    "abc=$!; " +
-                    "sleep 3; " +
-                    "ps -p $abc; " +
-                    "if [[ $! == 1 ]]; then " +
-                    "  echo \"Warning: TRSS id \$\{abc\} could not be found, and wget hung. Killing process and returning empty string.\";" +
-                    "  kill -9 \$\{abc\}; " +
-                    "fi;"
-                    def testOutput = sh(returnStdout: true, script: "wget -q -O - ${commandString}")
-
                     // If we can find it, then we look for the anticipated percentage.
                     if ( !testOutput.contains("Running test "+reproTestName) ) {
                         continue


### PR DESCRIPTION
This change allows us to identify the latest build of a specific tagged jdk source version per platform.

Previously, we would gather results from the oldest build pipeline using a specific tagged source version.

This change allows us to re-run specific platforms, and have the latest build override the first one, while still using the builds from the original pipeline for other platforms.

This change also includes making all of our wget calls more robust, in case we use invalid key parameters for the trss api and become hung.

Resolves https://github.com/adoptium/ci-jenkins-pipelines/issues/1132