### PR TITLE
Pull cuda image from NVCR and change to ubi8 base

### DIFF
--- a/pipelines/build/dockerFiles/cuda.dockerfile
+++ b/pipelines/build/dockerFiles/cuda.dockerfile
@@ -2,7 +2,7 @@ ARG image
 ARG cuda_ver=12.2.0
 ARG cuda_distro=ubi8
 
-FROM nvidia/cuda:${cuda_ver}-devel-${cuda_distro} as cuda
+FROM nvcr.io/nvidia/cuda:${cuda_ver}-devel-${cuda_distro} as cuda
 FROM $image
 
 # Install cuda headers https://github.com/eclipse/openj9/blob/master/buildenv/docker/mkdocker.sh#L586-L593

--- a/pipelines/build/dockerFiles/cuda.dockerfile
+++ b/pipelines/build/dockerFiles/cuda.dockerfile
@@ -1,6 +1,6 @@
 ARG image
 ARG cuda_ver=12.2.0
-ARG cuda_distro=ubuntu20.04
+ARG cuda_distro=ubi8
 
 FROM nvidia/cuda:${cuda_ver}-devel-${cuda_distro} as cuda
 FROM $image


### PR DESCRIPTION
**Switch to ubi8 base cuda image**
The ubuntu image does not support ppc64le arch. We are now building (Semeru)
on ppc64le in the cent7 container and require the cuda libs.

Related https://github.com/ibmruntimes/ci-jenkins-pipelines/pull/228

**Pull cuda image from nvcr Nvidia**
Sometimes pulls fail because DockerHub is rate limited. We are
also facing pull restrictions from DockerHub for Semeru.

Related https://github.com/eclipse-openj9/openj9/pull/20622
Signed-off-by: Adam Brousseau <adam.brousseau@ca.ibm.com>