### PR TITLE
Improve build pipeline summary publish link text with build failure warning

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -784,7 +784,7 @@ class Builder implements Serializable {
         def releaseWarning = ''
         if ( jobResult != "SUCCESS" && jobResult != "UNSTABLE" ) {
             // Build was not successful, add warning and link to build job
-            releaseWarning = '<a href=' + jobUrl + '><span style="color:red;">WARNING: build result(<b>' + jobResult + '</b>)</span></a> : '
+            releaseWarning = '<a href=' + jobUrl + '><span style="color:red;">WARNING: pipeline status was <b>' + jobResult + '</b></span></a> : '
         }
         
         def tag = "${javaToBuild}-${timestamp}"

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -783,7 +783,7 @@ class Builder implements Serializable {
         def releaseComment = 'BETA publish'
         def prefixLinkComment = ''
         if ( jobResult != "SUCCESS" && jobResult != "UNSTABLE" ) {
-            prefixLinkComment = '<span style="color:red;">WARNING: job result(<b>' + jobResult + '</b>)</span> : '
+            prefixLinkComment = '<span style="color:red;">WARNING: build result(<b>' + jobResult + '</b>)</span> : '
         }
         
         def tag = "${javaToBuild}-${timestamp}"

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -1026,7 +1026,7 @@ class Builder implements Serializable {
                     // Archive tap files as a single tar file if we have any
                     context.sh """
                         cd ${tarDir}/
-                        if [[ $(ls -l *.tap) ]]; then
+                        if [[ `ls -l *.tap` ]]; then
                           tar -czf ${tarTap} *.tap
                         fi
                     """

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -986,7 +986,7 @@ class Builder implements Serializable {
 
                                         copyArtifactSuccess = true
                                         if (release) {
-                                            def (String releaseToolUrl, String releaseComment) = publishBinary(config, downstreamJob.getResult(), downstreamJob.getUrl())
+                                            def (String releaseToolUrl, String releaseComment) = publishBinary(config, downstreamJob.getResult(), downstreamJob.getAbsoluteUrl())
                                             releaseSummary.appendText("<li><a href=${releaseToolUrl}> ${releaseComment} ${config.VARIANT} ${publishName} ${config.TARGET_OS} ${config.ARCHITECTURE}</a></li>")
                                         }
                                     }

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -1023,14 +1023,19 @@ class Builder implements Serializable {
                         flatten: true,
                         optional: true
                     )
-                    // Archive tap files as a single tar file
+                    // Archive tap files as a single tar file if we have any
                     context.sh """
                         cd ${tarDir}/
-                        tar -czf ${tarTap} *.tap
+                        if [[ $(ls -l *.tap) ]]; then
+                          tar -czf ${tarTap} *.tap
+                        fi
                     """
                     try {
-                        context.timeout(time: pipelineTimeouts.ARCHIVE_ARTIFACTS_TIMEOUT, unit: 'HOURS') {
-                            context.archiveArtifacts artifacts: "${tarDir}/${tarTap}"
+                        def tarTapExists = context.sh(script: "ls -l ${tarDir}/${tarTap}", returnStatus:true)
+                        if (tarTapExists == 0) {
+                            context.timeout(time: pipelineTimeouts.ARCHIVE_ARTIFACTS_TIMEOUT, unit: 'HOURS') {
+                                context.archiveArtifacts artifacts: "${tarDir}/${tarTap}"
+                            }
                         }
                     } catch (FlowInterruptedException e) {
                         throw new Exception("[ERROR] Archive AQAvitTapFiles.tar.gz timeout Exiting...")

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -784,8 +784,7 @@ class Builder implements Serializable {
         def releaseWarning = ''
         if ( jobResult != "SUCCESS" && jobResult != "UNSTABLE" ) {
             // Build was not successful, add warning and link to build job
-            def buildUrl = "${context.JENKINS_URL}${jobUrl}"
-            releaseWarning = '<a href=' + buildUrl + '><span style="color:red;">WARNING: build result(<b>' + jobResult + '</b>)</span></a> : '
+            releaseWarning = '<a href=' + jobUrl + '><span style="color:red;">WARNING: build result(<b>' + jobResult + '</b>)</span></a> : '
         }
         
         def tag = "${javaToBuild}-${timestamp}"

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -781,9 +781,11 @@ class Builder implements Serializable {
         def javaVersion=determineReleaseToolRepoVersion()
         def stageName = 'BETA publish'
         def releaseComment = 'BETA publish'
-        def extendedLinkComment = ''
+        def extendedLinkCommentPre = ''
+        def extendedLinkCommentPost = ''
         if ( jobResult != "SUCCESS" && jobResult != "UNSTABLE" ) {
-            extendedLinkComment = '<p style="color:red;">WARNING: job result(<b>' + jobResult + '</b>)</p> : '
+            extendedLinkCommentPre  = '<p style="color:red;">WARNING: job result(<b>' + jobResult + '</b>) : '
+            extendedLinkCommentPost = '</p>'
         }
         
         def tag = "${javaToBuild}-${timestamp}"
@@ -827,8 +829,8 @@ class Builder implements Serializable {
             }
         }
 
-        // Prefix with any extended comment
-        releaseComment = extendedLinkComment + releaseComment
+        // Prefix/Postfix with any extended comment
+        releaseComment = extendedLinkCommentPre + releaseComment + extendedLinkCommentPost
 
         releaseToolUrl += "VERSION=${javaVersion}&RELEASE=${release}&UPSTREAM_JOB_NUMBER=${currentBuild.getNumber()}"
         tag = URLEncoder.encode(tag, 'UTF-8')

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -1063,7 +1063,7 @@ class Builder implements Serializable {
                 } else {
                     try {
                         context.timeout(time: pipelineTimeouts.PUBLISH_ARTIFACTS_TIMEOUT, unit: 'HOURS') {
-                            def (String releaseToolUrl, String releaseComment, String releaseWarning) = publishBinary(null, currentBuild.result, "${context.JOB_URL}")
+                            def (String releaseToolUrl, String releaseComment, String releaseWarning) = publishBinary(null, currentBuild.result, "${context.BUILD_URL}")
                             releaseSummary.appendText("<li>${releaseWarning}<a href=${releaseToolUrl}> ${releaseComment} Rerun Link</a></li>")
                         }
                     } catch (FlowInterruptedException e) {

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -827,7 +827,6 @@ class Builder implements Serializable {
                 }
             }
         }
-
         releaseToolUrl += "VERSION=${javaVersion}&RELEASE=${release}&UPSTREAM_JOB_NUMBER=${currentBuild.getNumber()}"
         tag = URLEncoder.encode(tag, 'UTF-8')
         artifactsToCopy = URLEncoder.encode(artifactsToCopy, 'UTF-8')

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -781,11 +781,9 @@ class Builder implements Serializable {
         def javaVersion=determineReleaseToolRepoVersion()
         def stageName = 'BETA publish'
         def releaseComment = 'BETA publish'
-        def extendedLinkCommentPre = ''
-        def extendedLinkCommentPost = ''
+        def prefixLinkComment = ''
         if ( jobResult != "SUCCESS" && jobResult != "UNSTABLE" ) {
-            extendedLinkCommentPre  = '<p style="color:red;">WARNING: job result(<b>' + jobResult + '</b>) : '
-            extendedLinkCommentPost = '</p>'
+            prefixLinkComment = '<span style="color:red;">WARNING: job result(<b>' + jobResult + '</b>)</span> : '
         }
         
         def tag = "${javaToBuild}-${timestamp}"
@@ -829,8 +827,8 @@ class Builder implements Serializable {
             }
         }
 
-        // Prefix/Postfix with any extended comment
-        releaseComment = extendedLinkCommentPre + releaseComment + extendedLinkCommentPost
+        // Add any prefix comment
+        releaseComment = prefixLinkComment + releaseComment
 
         releaseToolUrl += "VERSION=${javaVersion}&RELEASE=${release}&UPSTREAM_JOB_NUMBER=${currentBuild.getNumber()}"
         tag = URLEncoder.encode(tag, 'UTF-8')

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -49,7 +49,7 @@ class Config11 {
                         'temurin'   : '--enable-headless-only=yes --disable-ccache'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-sbom --enable-sbom-strace'
+                        'temurin'   : '--create-sbom'
                 ]
         ],
 

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -193,14 +193,14 @@ class Config11 {
                         dragonwell: 'armv8.2'
                 ],
                 configureArgs       : [
-                        'temurin'   : '--enable-dtrace=auto --disable-ccache --with-jobs=4',
+                        'temurin'   : '--enable-dtrace=auto --disable-ccache',
                         'openj9'    : '--enable-dtrace=auto',
                         'corretto'  : '--enable-dtrace=auto',
                         'dragonwell': "--enable-dtrace=auto --with-extra-cflags=\"-march=armv8.2-a+crypto\" --with-extra-cxxflags=\"-march=armv8.2-a+crypto\"",
                         'bisheng'   : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-sbom --enable-sbom-strace'
+                        'temurin'   : '--create-sbom'
                 ]
         ],
 

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -49,7 +49,7 @@ class Config11 {
                         'temurin'   : '--enable-headless-only=yes --disable-ccache'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom --enable-sbom-strace'
                 ]
         ],
 
@@ -193,14 +193,14 @@ class Config11 {
                         dragonwell: 'armv8.2'
                 ],
                 configureArgs       : [
-                        'temurin'   : '--enable-dtrace=auto --disable-ccache',
+                        'temurin'   : '--enable-dtrace=auto --disable-ccache --with-jobs=4',
                         'openj9'    : '--enable-dtrace=auto',
                         'corretto'  : '--enable-dtrace=auto',
                         'dragonwell': "--enable-dtrace=auto --with-extra-cflags=\"-march=armv8.2-a+crypto\" --with-extra-cxxflags=\"-march=armv8.2-a+crypto\"",
                         'bisheng'   : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom --enable-sbom-strace'
                 ]
         ],
 


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1149

- Provide a "WARNING build result(FAILURE)" type message next to Publish binary link, to warn user the build job was not successful, and provide link to build job to check...
- Also fixed groovy script from bombing out if no .tap files exist

eg.https://ci.adoptium.net/job/build-scripts/job/release-openjdk17-pipeline/80/
![image](https://github.com/user-attachments/assets/a0addc0e-edc5-45ea-80cc-a9582ffb53bb)

