### PR TITLE
For jdk8u aarch32|alpine beta triggers check for existance of a specific asset

### DIFF
--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -115,10 +115,10 @@ def loadTargetConfigurations(String javaVersion, String variant, String configSe
 }
 
 // Verify the given published release tag contains the given asset architecture
-def checkJDKAssetExistsForArch(String version, String release, String variant, String arch) {
+def checkJDKAssetExistsForArch(String binariesRepo, String version, String releaseTag, String variant, String arch) {
     def assetExists = false
 
-    echo "Verifying ${version} assets in release: ${release}"
+    echo "Verifying ${version} JDK asset for ${arch} in release: ${releaseTag}"
 
     def publishVersion = version
     // aarch32-jdk8u and alpine-jdk8u published as "jdk8u" tags
@@ -126,7 +126,7 @@ def checkJDKAssetExistsForArch(String version, String release, String variant, S
         publishVersion = "jdk8u"
     }
 
-    def escRelease = release.replaceAll("\\+", "%2B")
+    def escRelease = releaseTag.replaceAll("\\+", "%2B")
     def releaseAssetsUrl = "${binariesRepo}/releases/tags/${escRelease}".replaceAll("_NN_", publishVersion.replaceAll("[a-z]",""))
 
     // Get list of assets, concatenate into a single string
@@ -228,7 +228,7 @@ node('worker') {
         }
 
         echo "Checking if ${binariesRepoTag} is already published for JDK asset ${jdkAssetToCheck} ?"
-        def assetExists = checkJDKAssetExistsForArch(versionStr, binariesRepoTag, variant, jdkAssetToCheck)
+        def assetExists = checkJDKAssetExistsForArch(binariesRepo, versionStr, binariesRepoTag, variant, jdkAssetToCheck)
 
         if (assetExists) {
             echo "Build tag ${binariesRepoTag} is already published - nothing to do"

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -277,13 +277,13 @@ if (triggerMainBuild || triggerEvaluationBuild) {
     def jobs = [:]
     def pipelines = [:]
 
-    // Trigger Main pipeline as long as we have a target configuration
+    // Trigger Main pipeline as long as we have a non-empty target configuration
     if (triggerMainBuild && mainTargetConfigurations != "{}") {
         pipelines["main"] = "build-scripts/openjdk${version}-pipeline"
         echo "main build targetConfigurations:"
         echo JsonOutput.prettyPrint(mainTargetConfigurations)
     }
-    // Trigger Evaluation as long as we have a target configuration
+    // Trigger Evaluation as long as we have a non-empty target configuration
     if (triggerEvaluationBuild && evaluationTargetConfigurations != "{}") {
         pipelines["evaluation"] = "build-scripts/evaluation-openjdk${version}-pipeline"
         echo "evaluation build targetConfigurations:"

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -127,7 +127,7 @@ def checkJDKAssetExistsForArch(String binariesRepo, String version, String relea
     }
 
     def escRelease = releaseTag.replaceAll("\\+", "%2B")
-    def releaseAssetsUrl = "${binariesRepo}/releases/tags/${escRelease}".replaceAll("_NN_", publishVersion.replaceAll("[a-z]",""))
+    def releaseAssetsUrl = binariesRepo.replaceAll("github.com","api.github.com/repos") + "/releases/tags/${escRelease}"
 
     // Get list of assets, concatenate into a single string
     def rc = sh(script: 'rm -f releaseAssets.json && curl -L -o releaseAssets.json '+releaseAssetsUrl, returnStatus: true)

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -141,7 +141,7 @@ def checkJDKAssetExistsForArch(String binariesRepo, String version, String relea
     } else {
         // Work out the JDK artifact filetype
         def filetype
-        if (osarch.contains("Windows")) {
+        if (arch.contains("windows")) {
             filetype = "\\.zip"
         } else {
             filetype = "\\.tar\\.gz"

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -120,12 +120,6 @@ def checkJDKAssetExistsForArch(String binariesRepo, String version, String relea
 
     echo "Verifying ${version} JDK asset for ${arch} in release: ${releaseTag}"
 
-    def publishVersion = version
-    // aarch32-jdk8u and alpine-jdk8u published as "jdk8u" tags
-    if (version == "aarch32-jdk8u" || version == "alpine-jdk8u") {
-        publishVersion = "jdk8u"
-    }
-
     def escRelease = releaseTag.replaceAll("\\+", "%2B")
     def releaseAssetsUrl = binariesRepo.replaceAll("github.com","api.github.com/repos") + "/releases/tags/${escRelease}"
 

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -115,7 +115,7 @@ def loadTargetConfigurations(String javaVersion, String variant, String configSe
 }
 
 // Verify the given published release tag contains the given asset architecture
-def checkJDKAssetExistsForArch(String binariesRepo, String version, String releaseTag, String variant, String arch) {
+def checkJDKAssetExistsForArch(String binariesRepo, String version, String releaseTag, String arch) {
     def assetExists = false
 
     echo "Verifying ${version} JDK asset for ${arch} in release: ${releaseTag}"
@@ -222,7 +222,7 @@ node('worker') {
         }
 
         echo "Checking if ${binariesRepoTag} is already published for JDK asset ${jdkAssetToCheck} ?"
-        def assetExists = checkJDKAssetExistsForArch(binariesRepo, versionStr, binariesRepoTag, variant, jdkAssetToCheck)
+        def assetExists = checkJDKAssetExistsForArch(binariesRepo, versionStr, binariesRepoTag, jdkAssetToCheck)
 
         if (assetExists) {
             echo "Build tag ${binariesRepoTag} is already published - nothing to do"

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -283,12 +283,14 @@ if (triggerMainBuild || triggerEvaluationBuild) {
     def jobs = [:]
     def pipelines = [:]
 
-    if (triggerMainBuild) {
+    // Trigger Main pipeline as long as we have a target configuration
+    if (triggerMainBuild && mainTargetConfigurations != "{}") {
         pipelines["main"] = "build-scripts/openjdk${version}-pipeline"
         echo "main build targetConfigurations:"
         echo JsonOutput.prettyPrint(mainTargetConfigurations)
     }
-    if (triggerEvaluationBuild) {
+    // Trigger Evaluation as long as we have a target configuration
+    if (triggerEvaluationBuild && evaluationTargetConfigurations != "{}") {
         pipelines["evaluation"] = "build-scripts/evaluation-openjdk${version}-pipeline"
         echo "evaluation build targetConfigurations:"
         echo JsonOutput.prettyPrint(evaluationTargetConfigurations)

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -154,9 +154,9 @@ def checkJDKAssetExistsForArch(String binariesRepo, String version, String relea
     }
 
     if (assetExists) {
-        echo "${arch} JDK asset for version ${version} tag ${release} exists"
+        echo "${arch} JDK asset for version ${version} tag ${releaseTag} exists"
     } else {
-        echo "${arch} JDK asset for version ${version} tag ${release} NOT FOUND"
+        echo "${arch} JDK asset for version ${version} tag ${releaseTag} NOT FOUND"
     }
     return assetExists
 }

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -275,11 +275,6 @@ node('worker') {
     }
 } // End: node('worker')
 
-echo "STATUS: triggerMainBuild: ${triggerMainBuild}"
-echo "STATUS: triggerEvaluationBuild: ${triggerEvaluationBuild}"
-triggerMainBuild=false
-triggerEvaluationBuild=false
-
 if (triggerMainBuild || triggerEvaluationBuild) {
     // Set version suffix, jdk8 has different mechanism to jdk11+
     def additionalConfigureArgs = (version > 8) ? "--with-version-opt=ea" : ""


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1152

Update trigger_beta_build.groovy to check for the existence of a specific asset rather than rely purely on the release tag existing.
- x64_linux : Main versions
- arm_linux : jdk8u_aarch32
- x64_alpine-linux : jdk8u_x64_alpine

Also prevent evaluation pipelines incorrectly triggering for jdk8u_aarch32 and jdk8u_alpine.

Note: This change will imply that if the given "arch" above is failing to build, then repeat triggers can occur in that scenario, but then there's obviously a build problem anyway...