### PR TITLE
windows: switch to running builds in docker containers

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -70,6 +70,7 @@ class Config11 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
+                dockerImage         : 'win2022_notrhel_image',
                 additionalNodeLabels: [
                         temurin:    'win2022&&vs2022',
                         openj9:     'win2012&&vs2017',
@@ -87,6 +88,7 @@ class Config11 {
         x32Windows: [
                 os                  : 'windows',
                 arch                : 'x86-32',
+                dockerImage         : 'win2022_notrhel_image',
                 additionalNodeLabels: 'win2022&&vs2022',
                 configureArgs       : [
                         'temurin'   : '--disable-ccache'
@@ -246,6 +248,7 @@ class Config11 {
         aarch64Windows: [
                 os                  : 'windows',
                 arch                : 'aarch64',
+                dockerImage         : 'win2022_notrhel_image',
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test                : 'default',

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -68,6 +68,7 @@ class Config17 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
+                dockerImage         : 'win2022_notrhel_image',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test                : 'default',
                 buildArgs           : [
@@ -78,6 +79,7 @@ class Config17 {
         x32Windows: [
                 os                  : 'windows',
                 arch                : 'x86-32',
+                dockerImage         : 'win2022_notrhel_image',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test                : 'default',
                 buildArgs           : [
@@ -176,6 +178,7 @@ class Config17 {
         aarch64Windows: [
                 os                  : 'windows',
                 arch                : 'aarch64',
+                dockerImage         : 'win2022_notrhel_image',
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test                : 'default',

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -66,6 +66,7 @@ class Config21 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
+                dockerImage         : 'win2022_notrhel_image',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
@@ -161,6 +162,7 @@ class Config21 {
         aarch64Windows: [
                 os                  : 'windows',
                 arch                : 'aarch64',
+                dockerImage         : 'win2022_notrhel_image',
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test                : 'default',

--- a/pipelines/jobs/configurations/jdk23u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk23u_pipeline_config.groovy
@@ -67,6 +67,7 @@ class Config23 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
+                dockerImage         : 'win2022_notrhel_image',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
@@ -162,6 +163,7 @@ class Config23 {
         aarch64Windows: [
                 os                  : 'windows',
                 arch                : 'aarch64',
+                dockerImage         : 'win2022_notrhel_image',
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test                : 'default',

--- a/pipelines/jobs/configurations/jdk24_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk24_pipeline_config.groovy
@@ -67,6 +67,7 @@ class Config24 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
+                dockerImage         : 'win2022_notrhel_image',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
@@ -162,6 +163,7 @@ class Config24 {
         aarch64Windows: [
                 os                  : 'windows',
                 arch                : 'aarch64',
+                dockerImage         : 'win2022_notrhel_image',
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test                : 'default',

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -68,6 +68,7 @@ class Config8 {
         x64Windows    : [
                 os                  : 'windows',
                 arch                : 'x64',
+                dockerImage         : 'win2022_notrhel_image',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test                 : 'default',
                 configureArgs       : [
@@ -81,6 +82,7 @@ class Config8 {
         x32Windows    : [
                 os                  : 'windows',
                 arch                : 'x86-32',
+                dockerImage         : 'win2022_notrhel_image',
                 additionalNodeLabels: 'win2022',
                 configureArgs       : [
                         'temurin'   : '--disable-ccache'


### PR DESCRIPTION
We now have systems which are able to run builds in containers on Windows, similar to what we do for Linux.

Like s390x, these images cannot be publicly available so as a stop-gap until https://github.com/adoptium/infrastructure/issues/3217 I'm using container images pre-created on the machine called `win2022_notrhel_image` specifically (the name including `rhel` is to [block it from trying to issue a `docker pull`](https://github.com/adoptium/ci-jenkins-pipelines/pull/611) but going forward [an option would be good](https://github.com/adoptium/ci-jenkins-pipelines/issues/1096)). 

Builds on the earlier work in:
- https://github.com/adoptium/ci-jenkins-pipelines/pull/1117
- https://github.com/adoptium/ci-jenkins-pipelines/pull/1151

Part of https://github.com/adoptium/infrastructure/issues/3286

