### PR TITLE
Prevent multiple Windows exe/dll signing and verify

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1571,7 +1571,10 @@ class Build {
                                                             success=true
                                                         fi
                                                     else
-                                                        if ! curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign; then
+                                                        if [ "$file" =~ api-ms-win.* ] || [ "$file" =~ msvcp.* ] || [ "$file" =~ ucrtbase.* ] || [ "$file" =~ vcruntime.* ]; then
+                                                            echo "Skipping Microsoft file $file"
+                                                            success=true
+                                                        elif ! curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign; then
                                                             echo "curl command failed, sign of $f failed"
                                                         else
                                                             success=true

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1560,7 +1560,6 @@ class Build {
                                                 fi
                                                 for f in $FILES
                                                 do
-                                                    echo "Signing $f using Eclipse Foundation codesign service"
                                                     dir=$(dirname "$f")
                                                     file=$(basename "$f")
                                                     ms_file_skipped=false
@@ -1572,6 +1571,7 @@ class Build {
                                                         fi
                                                     fi
                                                     if [ $ms_file_skipped == false ]; then
+                                                        echo "Signing $f using Eclipse Foundation codesign service"
                                                         mv "$f" "${dir}/unsigned_${file}"
                                                         success=false
                                                         if [ "${base_os}" == "mac" ]; then

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -748,13 +748,11 @@ class Build {
     /*
     Run the Sign downstream job. We run this job on windows and jdk8 hotspot & jdk13 mac builds.
     The job code signs and notarizes the binaries so they can run on these operating systems without encountering issues.
-    Tarball signing only required for jdk8u, as jdk11+ is signed dynamically during the build.
     */
     def sign(VersionInfo versionInfo) {
         // Sign and archive jobs if needed
         if (
-            (buildConfig.TARGET_OS == 'windows' || buildConfig.TARGET_OS == 'mac') &&
-            buildConfig.JAVA_TO_BUILD == 'jdk8u'
+            buildConfig.TARGET_OS == 'windows' || (buildConfig.TARGET_OS == 'mac')
         ) {
             context.stage('sign zip/tgz') {
                 def filter = ''
@@ -1551,8 +1549,6 @@ class Build {
                                                 #!/bin/bash
                                                 set -eu
                                                 echo "Signing JMOD files under build path ${base_path} for base_os ${base_os}"
-                                                echo "FINDING libjli.dylib ..."
-                                                find "${base_path}" -name "libjli.dylib"
                                                 TMP_DIR="${base_path}/"
                                                 if [ "${base_os}" == "mac" ]; then
                                                     ENTITLEMENTS="$WORKSPACE/entitlements.plist"

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -748,7 +748,7 @@ class Build {
     /*
     Run the Sign downstream job. We run this job on windows and jdk8 hotspot & jdk13 mac builds.
     The job code signs and notarizes the binaries so they can run on these operating systems without encountering issues.
-    tarball signing only required for jdk8u, as jdk11+ is signed dynamically during the build.
+    Tarball signing only required for jdk8u, as jdk11+ is signed dynamically during the build.
     */
     def sign(VersionInfo versionInfo) {
         // Sign and archive jobs if needed

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -748,11 +748,12 @@ class Build {
     /*
     Run the Sign downstream job. We run this job on windows and jdk8 hotspot & jdk13 mac builds.
     The job code signs and notarizes the binaries so they can run on these operating systems without encountering issues.
+    tarball signing only required for jdk8u, as jdk11+ is signed dynamically during the build.
     */
     def sign(VersionInfo versionInfo) {
         // Sign and archive jobs if needed
         if (
-            buildConfig.TARGET_OS == 'windows' || (buildConfig.TARGET_OS == 'mac')
+            (buildConfig.TARGET_OS == 'windows' || (buildConfig.TARGET_OS == 'mac') && buildConfig.JAVA_TO_BUILD == 'jdk8u')
         ) {
             context.stage('sign zip/tgz') {
                 def filter = ''

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1563,57 +1563,64 @@ class Build {
                                                     echo "Signing $f using Eclipse Foundation codesign service"
                                                     dir=$(dirname "$f")
                                                     file=$(basename "$f")
-                                                    mv "$f" "${dir}/unsigned_${file}"
-                                                    success=false
-                                                    if [ "${base_os}" == "mac" ]; then
-                                                        if ! curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign; then
-                                                            echo "curl command failed, sign of $f failed"
-                                                        else
-                                                            success=true
-                                                        fi
-                                                    else
+                                                    ms_file_skipped=false
+                                                    if [ "${base_os}" == "windows" ]; then
+                                                        # Check if file is a Microsoft supplied file that is already signed
                                                         if [[ "$file" =~ api-ms-win.* ]] || [[ "$file" =~ msvcp.* ]] || [[ "$file" =~ ucrtbase.* ]] || [[ "$file" =~ vcruntime.* ]]; then
                                                             echo "Skipping Microsoft file $file"
-                                                            success=true
-                                                        elif ! curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign; then
-                                                            echo "curl command failed, sign of $f failed"
-                                                        else
-                                                            success=true
+                                                            ms_file_skipped=true
                                                         fi
                                                     fi
-                                                    if [ $success == false ]; then
-                                                        # Retry up to 20 times
-                                                        max_iterations=20
-                                                        iteration=1
-                                                        echo "Code Not Signed For File $f"
-                                                        while [ $iteration -le $max_iterations ] && [ $success = false ]; do
-                                                            echo $iteration Of $max_iterations
-                                                            sleep 1
-                                                            if [ "${base_os}" == "mac" ]; then
-                                                                if curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign; then
-                                                                    success=true
-                                                                fi
+                                                    if [ $ms_file_skipped == false ]; then
+                                                        mv "$f" "${dir}/unsigned_${file}"
+                                                        success=false
+                                                        if [ "${base_os}" == "mac" ]; then
+                                                            if ! curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign; then
+                                                                echo "curl command failed, sign of $f failed"
                                                             else
-                                                                if curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign; then
-                                                                    success=true
-                                                                fi
+                                                                success=true
                                                             fi
+                                                        else
+                                                            if ! curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign; then
+                                                                echo "curl command failed, sign of $f failed"
+                                                            else
+                                                                success=true
+                                                            fi
+                                                        fi
+                                                        if [ $success == false ]; then
+                                                            # Retry up to 20 times
+                                                            max_iterations=20
+                                                            iteration=1
+                                                            echo "Code Not Signed For File $f"
+                                                            while [ $iteration -le $max_iterations ] && [ $success = false ]; do
+                                                                echo $iteration Of $max_iterations
+                                                                sleep 1
+                                                                if [ "${base_os}" == "mac" ]; then
+                                                                    if curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign; then
+                                                                        success=true
+                                                                    fi
+                                                                else
+                                                                    if curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign; then
+                                                                        success=true
+                                                                    fi
+                                                                fi
 
-                                                            if [ $success = false ]; then
-                                                                echo "curl command failed, $f Failed Signing On Attempt $iteration"
-                                                                iteration=$((iteration+1))
-                                                                if [ $iteration -gt $max_iterations ]
-                                                                then
-                                                                    echo "Errors Encountered During Signing"
-                                                                    exit 1
+                                                                if [ $success = false ]; then
+                                                                    echo "curl command failed, $f Failed Signing On Attempt $iteration"
+                                                                    iteration=$((iteration+1))
+                                                                    if [ $iteration -gt $max_iterations ]
+                                                                    then
+                                                                        echo "Errors Encountered During Signing"
+                                                                        exit 1
+                                                                    fi
+                                                                else
+                                                                    echo "$f Signed OK On Attempt $iteration"
                                                                 fi
-                                                            else
-                                                                echo "$f Signed OK On Attempt $iteration"
-                                                            fi
-                                                        done
-                                                    fi
-                                                    chmod --reference="${dir}/unsigned_${file}" "$f"
-                                                    rm -rf "${dir}/unsigned_${file}"
+                                                            done
+                                                        fi
+                                                        chmod --reference="${dir}/unsigned_${file}" "$f"
+                                                        rm -rf "${dir}/unsigned_${file}"
+                                                    fi # ms_file_skipped == false
                                                 done
                                             '''
                                             // groovylint-enable

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -753,7 +753,7 @@ class Build {
     def sign(VersionInfo versionInfo) {
         // Sign and archive jobs if needed
         if (
-            (buildConfig.TARGET_OS == 'windows' || (buildConfig.TARGET_OS == 'mac') && buildConfig.JAVA_TO_BUILD == 'jdk8u')
+            (buildConfig.TARGET_OS == 'windows' || buildConfig.TARGET_OS == 'mac') && buildConfig.JAVA_TO_BUILD == 'jdk8u')
         ) {
             context.stage('sign zip/tgz') {
                 def filter = ''

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -753,7 +753,8 @@ class Build {
     def sign(VersionInfo versionInfo) {
         // Sign and archive jobs if needed
         if (
-            (buildConfig.TARGET_OS == 'windows' || buildConfig.TARGET_OS == 'mac') && buildConfig.JAVA_TO_BUILD == 'jdk8u')
+            (buildConfig.TARGET_OS == 'windows' || buildConfig.TARGET_OS == 'mac') &&
+            buildConfig.JAVA_TO_BUILD == 'jdk8u'
         ) {
             context.stage('sign zip/tgz') {
                 def filter = ''

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1572,7 +1572,7 @@ class Build {
                                                             success=true
                                                         fi
                                                     else
-                                                        if [ "$file" =~ api-ms-win.* ] || [ "$file" =~ msvcp.* ] || [ "$file" =~ ucrtbase.* ] || [ "$file" =~ vcruntime.* ]; then
+                                                        if [[ "$file" =~ api-ms-win.* ]] || [[ "$file" =~ msvcp.* ]] || [[ "$file" =~ ucrtbase.* ]] || [[ "$file" =~ vcruntime.* ]]; then
                                                             echo "Skipping Microsoft file $file"
                                                             success=true
                                                         elif ! curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign; then

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1551,6 +1551,8 @@ class Build {
                                                 #!/bin/bash
                                                 set -eu
                                                 echo "Signing JMOD files under build path ${base_path} for base_os ${base_os}"
+                                                echo "FINDING libjli.dylib ..."
+                                                find "${base_path}" -name "libjli.dylib"
                                                 TMP_DIR="${base_path}/"
                                                 if [ "${base_os}" == "mac" ]; then
                                                     ENTITLEMENTS="$WORKSPACE/entitlements.plist"

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -185,8 +185,15 @@ void verifyExecutables(String unpack_dir) {
                         unsigned="$unsigned $f"
                         cc_unsigned=$((cc_unsigned+1))
                     else
-                        echo "Signed correctly: ${f}"
-                        cc_signed=$((cc_signed+1))
+                        num_sigs=$("${signtool}" verify /all /pa ${f} | grep -E '^[0-9][[:space:]]+sha256' | wc -l)
+                        if [[ "$num_sigs" -ne 1 ]]; then
+                            echo "Error: ${f} has ${num_sigs} Signatures, it must only have one."
+                            unsigned="$unsigned $f"
+                            cc_unsigned=$((cc_unsigned+1))
+                        else
+                            echo "Signed correctly: ${f}"
+                            cc_signed=$((cc_signed+1))
+                        fi
                     fi
                   done
 

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -168,7 +168,7 @@ void verifyExecutables(String unpack_dir, String issueToOrg) {
 
         // Find all exe/dll's that must be Signed
 
-        withEnv(['unpack_dir='+unpack_dir, 'signtool='+signtool]) {
+        withEnv(['unpack_dir='+unpack_dir, 'signtool='+signtool, 'issueToOrg='+issueToOrg]) {
             // groovylint-disable
             sh '''
                 #!/bin/bash

--- a/pipelines/build/common/verify_signing.groovy
+++ b/pipelines/build/common/verify_signing.groovy
@@ -200,7 +200,7 @@ void verifyExecutables(String unpack_dir, String issueToOrg) {
                             echo "Error: ${f} is NOT signed by ${issueToOrg}."
                             unsigned="$unsigned $f"
                             cc_unsigned=$((cc_unsigned+1))
-                        elif
+                        else
                             echo "Signed correctly: ${f}"
                             cc_signed=$((cc_signed+1))
                         fi

--- a/tt.sh
+++ b/tt.sh
@@ -1,0 +1,6 @@
+
+file="api-ms-winsdfsdfsf.dll"
+if [[ "$file" =~ api-ms-win.* ]] || [[ "$file" =~ msvcp.* ]] || [[ "$file" =~ ucrtbase.* ]] || [[ "$file" =~ vcruntime.* ]]; then
+                                                            echo "Skipping Microsoft file $file"
+fi
+

--- a/tt.sh
+++ b/tt.sh
@@ -1,6 +1,0 @@
-
-file="api-ms-winsdfsdfsf.dll"
-if [[ "$file" =~ api-ms-win.* ]] || [[ "$file" =~ msvcp.* ]] || [[ "$file" =~ ucrtbase.* ]] || [[ "$file" =~ vcruntime.* ]]; then
-                                                            echo "Skipping Microsoft file $file"
-fi
-


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3997

- Update verify_signing.groovy to check Windows exes only have one Eclipse signature and Microsoft DLLs are not signed by Eclipse
- Update inline build Windows signing to skip Windows supplied DLLs


