### PR TITLE
Add special.system for JDK21+ mac64 and reset variables inside the parallel job

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -389,10 +389,6 @@ class Build {
         def jdkBranch = getJDKBranch()
         def jdkRepo = getJDKRepo()
         def openj9Branch = (buildConfig.SCM_REF && buildConfig.VARIANT == 'openj9') ? buildConfig.SCM_REF : 'master'
-
-        def vendorTestRepos = ''
-        def vendorTestBranches = ''
-        def vendorTestDirs = ''
         List testList = buildConfig.TEST_LIST
         def enableTestDynamicParallel = Boolean.valueOf(buildConfig.ENABLE_TESTDYNAMICPARALLEL)
         def aqaBranch = 'master'
@@ -411,7 +407,6 @@ class Build {
             testTime = '120'
             parallel = 'Dynamic'
         }
-        def testLabel = ''
 
         testList.each { testType ->
             // For each requested test, i.e 'sanity.openjdk', 'sanity.system', 'sanity.perf', 'sanity.external', call test job
@@ -446,10 +441,14 @@ class Build {
                             }
                         }
 
+                        def testLabel = ''
                         // Eclipse Adoptium Temurin reproducible comparing on x64 mac required to run on aarch64 mac
                         if (testType  == 'special.system' && jobName.contains('x86-64_mac') && buildConfig.VARIANT == 'temurin') {
                             testLabel = 'ci.role.test&&hw.arch.aarch64&&(sw.os.osx||sw.os.mac)'
                         }
+                        def vendorTestRepos = ''
+                        def vendorTestBranches = ''
+                        def vendorTestDirs = ''
                         if (testType  == 'special.system' || testType  == 'dev.system') {
                             def useAdoptShellScripts = Boolean.valueOf(buildConfig.USE_ADOPT_SHELL_SCRIPTS)
                             vendorTestBranches = useAdoptShellScripts ? ADOPT_DEFAULTS_JSON['repository']['build_branch'] : DEFAULTS_JSON['repository']['build_branch']
@@ -2478,6 +2477,7 @@ def buildScriptsAssemble(
             } catch (Exception e) {
                 currentBuild.result = 'FAILURE'
                 context.println "Execution error: ${e}"
+
                 def sw = new StringWriter()
                 def pw = new PrintWriter(sw)
                 e.printStackTrace(pw)

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -8,7 +8,9 @@ class Config21 {
                 additionalTestLabels: [
                         openj9      : '!sw.os.osx.10_11'
                 ],
-                test                : 'default',
+                test: [
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
+                ],
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'

--- a/pipelines/jobs/configurations/jdk23u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk23u_pipeline_config.groovy
@@ -9,7 +9,9 @@ class Config23 {
                         openj9      : '!sw.os.osx.10_11',
                         temurin     : '!sw.os.osx.10_14'
                 ],
-                test                : 'default',
+                test: [
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
+                ],
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'

--- a/pipelines/jobs/configurations/jdk24_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk24_pipeline_config.groovy
@@ -9,7 +9,9 @@ class Config24 {
                         openj9      : '!sw.os.osx.10_11',
                         temurin     : '!sw.os.osx.10_14'
                 ],
-                test                : 'default',
+                test: [
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
+                ],
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'


### PR DESCRIPTION
- Add special.system for JDK21+ mac64
- Define variable per parallel job to avoid interference issues.

related https://github.com/adoptium/temurin-build/pull/3844