### PR TITLE
Add jdk25 pipeline configurations

### DIFF
--- a/pipelines/jobs/configurations/jdk25.groovy
+++ b/pipelines/jobs/configurations/jdk25.groovy
@@ -1,0 +1,50 @@
+targetConfigurations = [
+        'x64Mac'      : [
+                'temurin'
+        ],
+        'x64Linux'    : [
+                'temurin'
+        ],
+        'x64AlpineLinux' : [
+                'temurin'
+        ],
+        'aarch64AlpineLinux' : [
+                'temurin'
+        ],
+        'x64Windows'  : [
+                'temurin'
+        ],
+        'aarch64Windows' : [
+                'temurin'
+        ],
+        'ppc64Aix'    : [
+                'temurin'
+        ],
+        'ppc64leLinux': [
+                'temurin'
+        ],
+        's390xLinux'  : [
+                'temurin'
+        ],
+        'aarch64Linux': [
+                'hotspot',
+                'temurin'
+        ],
+        'aarch64Mac': [
+                'temurin'
+        ],
+        'riscv64Linux': [
+                'temurin'
+        ]
+]
+
+// scmReferences to use for weekly release build
+weekly_release_scmReferences = [
+        'hotspot'        : '',
+        'temurin'        : '',
+        'openj9'         : '',
+        'corretto'       : '',
+        'dragonwell'     : ''
+]
+
+return this

--- a/pipelines/jobs/configurations/jdk25_evaluation.groovy
+++ b/pipelines/jobs/configurations/jdk25_evaluation.groovy
@@ -1,0 +1,9 @@
+targetConfigurations = []
+
+// scmReferences to use for weekly evaluation release build
+weekly_evaluation_scmReferences = [
+        'hotspot'        : '',
+        'temurin'        : ''
+]
+
+return this

--- a/pipelines/jobs/configurations/jdk25_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk25_pipeline_config.groovy
@@ -1,0 +1,181 @@
+class Config25 {
+
+    final Map<String, Map<String, ?>> buildConfigurations = [
+        x64Mac    : [
+                os                  : 'mac',
+                arch                : 'x64',
+                additionalNodeLabels: 'xcode15.0.1',
+                additionalTestLabels: [
+                        openj9      : '!sw.os.osx.10_11',
+                        temurin     : '!sw.os.osx.10_14'
+                ],
+                test: [
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
+                ],
+                configureArgs       : '--enable-dtrace',
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom'
+                ]
+        ],
+
+        x64Linux  : [
+                os                  : 'linux',
+                arch                : 'x64',
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                dockerFile: [
+                        openj9      : 'pipelines/build/dockerFiles/cuda.dockerfile'
+                ],
+                test: [
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'dev.openjdk', 'dev.functional', 'dev.system', 'special.system']
+                ],
+                additionalTestLabels: [
+                        openj9      : '!(centos6||rhel6)',
+                        temurin     : '!(centos6||rhel6)'
+                ],
+                configureArgs       : [
+                        'openj9'    : '--enable-dtrace',
+                        'temurin'   : '--enable-dtrace'
+                ],
+                buildArgs           : [
+                        'temurin'   : '--create-source-archive --create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
+                ]
+        ],
+
+        x64AlpineLinux  : [
+                os                  : 'alpine-linux',
+                arch                : 'x64',
+                dockerImage         : 'adoptopenjdk/alpine3_build_image',
+                test                : 'default',
+                configureArgs       : '--enable-headless-only=yes',
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
+                ]
+        ],
+
+        aarch64AlpineLinux  : [
+                os                  : 'alpine-linux',
+                arch                : 'aarch64',
+                dockerImage         : 'adoptopenjdk/alpine3_build_image',
+                test                : 'default',
+                configureArgs       : [
+                        'openj9'    : '--enable-headless-only=yes',
+                        'temurin'   : '--enable-headless-only=yes --with-jobs=4'
+                ],
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
+                ]
+        ],
+
+        x64Windows: [
+                os                  : 'windows',
+                arch                : 'x64',
+                dockerImage         : 'win2022_notrhel_image',
+                additionalNodeLabels: 'win2022&&vs2022',
+                test: [
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
+                ],
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit vs2022_redist_14.40.33807_10.0.26100.0'
+                ]
+        ],
+
+        ppc64Aix    : [
+                os                  : 'aix',
+                arch                : 'ppc64',
+                additionalNodeLabels: [
+                        temurin: 'openxl17&&aix720',
+                        openj9:  'xlc16&&aix715'
+                ],
+                test                : 'default',
+                additionalTestLabels: [
+                        temurin      : 'sw.os.aix.7_2TL5'
+                ],
+                cleanWorkspaceAfterBuild: true,
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom'
+                ]
+        ],
+
+        s390xLinux    : [
+                os                  : 'linux',
+                arch                : 's390x',
+                dockerImage         : 'rhel7_build_image',
+                test                : 'default',
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
+                ]
+        ],
+
+        ppc64leLinux    : [
+                os                  : 'linux',
+                arch                : 'ppc64le',
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                test: [
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'special.system']
+                ],
+                configureArgs       : [
+                        'openj9'      : '--enable-dtrace'
+                ],
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
+                ]
+        ],
+
+        aarch64Linux    : [
+                os                  : 'linux',
+                arch                : 'aarch64',
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                test: [
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'special.system']
+                ],
+                configureArgs       : [
+                        'openj9'    : '--enable-dtrace',
+                        'temurin'   : '--enable-dtrace --with-jobs=4'
+                ],
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'
+                ]
+        ],
+
+        aarch64Mac: [
+                os                  : 'mac',
+                arch                : 'aarch64',
+                additionalNodeLabels: 'xcode15.0.1',
+                test: [
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
+                ],
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom'
+                ]
+        ],
+
+        riscv64Linux      :  [
+                os                  : 'linux',
+                arch                : 'riscv64',
+                crossCompile        : 'qemustatic',
+                dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
+                dockerArgs          : '--platform linux/riscv64',
+                test                : 'default',
+                configureArgs       : '--enable-headless-only=yes --enable-dtrace',
+                buildArgs           : [
+                        'temurin'   : '--create-jre-image --create-sbom'
+                ]
+        ],
+
+        aarch64Windows: [
+                os                  : 'windows',
+                arch                : 'aarch64',
+                dockerImage         : 'win2022_notrhel_image',
+                crossCompile        : 'x64',
+                additionalNodeLabels: 'win2022&&vs2022',
+                test                : 'default',
+                buildArgs       : [
+                        'temurin'   : '--create-jre-image --create-sbom --cross-compile --use-adoptium-devkit vs2022_redist_14.40.33807_10.0.26100.0'
+                ]
+        ]
+  ]
+
+}
+
+Config25 config = new Config25()
+return config.buildConfigurations

--- a/pipelines/jobs/configurations/jdk25_release.groovy
+++ b/pipelines/jobs/configurations/jdk25_release.groovy
@@ -1,0 +1,40 @@
+targetConfigurations = [
+        'x64Mac'      : [
+                'temurin'
+        ],
+        'x64Linux'    : [
+                'temurin'
+        ],
+        'x64AlpineLinux' : [
+                'temurin'
+        ],
+        'aarch64AlpineLinux' : [
+                'temurin'
+        ],
+        'x64Windows'  : [
+                'temurin'
+        ],
+        'aarch64Windows' : [
+                'temurin'
+        ],
+        'ppc64Aix'    : [
+                'temurin'
+        ],
+        'ppc64leLinux': [
+                'temurin'
+        ],
+        's390xLinux'  : [
+                'temurin'
+        ],
+        'aarch64Linux': [
+                'temurin'
+        ],
+        'aarch64Mac': [
+                'temurin'
+        ],
+        'riscv64Linux': [
+                'temurin'
+        ]
+]
+
+return this


### PR DESCRIPTION
openjdk/jdk HEAD has branch and new head version is now jdk-25

Created jdk25 config based on jdk24 config files.
 