### PR TITLE
Prevent build_job_generator regeneration from blowing up if no targetConfigurations

### DIFF
--- a/pipelines/build/regeneration/build_job_generator.groovy
+++ b/pipelines/build/regeneration/build_job_generator.groovy
@@ -211,7 +211,10 @@ node('worker') {
             checkoutUserPipelines()
         }
 
-        if (jenkinsCreds != '') {
+        if (targetConfigurations.size() == 0) {
+            println "[WARNING] No targetConfigurations to be generated for this version"
+        } else {
+          if (jenkinsCreds != '') {
             withCredentials([usernamePassword(
                 credentialsId: "${JENKINS_AUTH}",
                 usernameVariable: 'jenkinsUsername',
@@ -240,7 +243,7 @@ node('worker') {
                     jobType
                 ).regenerate()
             }
-        } else {
+          } else {
             println '[WARNING] No Jenkins API Credentials have been provided! If your server does not have anonymous read enabled, you may encounter 403 api request error code.'
             regenerationScript(
                 javaVersion,
@@ -263,6 +266,7 @@ node('worker') {
                 checkoutCreds,
                 jobType
             ).regenerate()
+          }
         }
         println '[SUCCESS] All done!'
     } finally {


### PR DESCRIPTION
If there are no targetConfigurations for a given pipeline configuration and job type,
for example jdk21u_evaluation.groovy.
The the job throws exception due to trying to process an empty array...
```
Also:   org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: 5a685aff-ddc8-4482-ab2d-399fe8d9d0cc
java.lang.SecurityException: Unable to find constructor: new Regeneration java.lang.String java.util.LinkedHashMap java.util.ArrayList groovy.json.internal.LazyMap groovy.json.internal.LazyMap java.util.LinkedHashMap java.lang.Integer org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper WorkflowScript java.lang.String groovy.json.internal.LazyMap java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String
	at PluginClassLoader for script-security//org.kohsuke.groovy.sandbox.impl.GroovyCallSiteSelector.findConstructor(GroovyCallSiteSelector.java:47)
	at PluginClassLoader for script-security//org.kohsuke.groovy.sandbox.impl.Checker.checkedConstructor(Checker.java:223)
	at PluginClassLoader for workflow-cps//com.cloudbees.groovy.cps.sandbox.SandboxInvoker.constructorCall(SandboxInvoker.java:21)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.LoggingInvoker.constructorCall(LoggingInvoker.java:122)
	at Script3.run(Script3.groovy:790)
	at WorkflowScript.run(WorkflowScript:221)
	at ___cps.transform___(Native Method)
	at PluginClassLoader for workflow-cps//com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.dispatchOrArg(FunctionCallBlock.java:100)
```

No jobs should be generated if there is no targetConfigurations!

Tested on this evaluation job generation: https://ci.adoptium.net/job/build-scripts/job/utils/job/evaluation-pipeline_jobs_generator_jdk/619/console

