### PR TITLE
Update daily Slack status to handle multiple head repo versions jdk24 and jdk25

### DIFF
--- a/pipelines/build/regeneration/build_job_generator.groovy
+++ b/pipelines/build/regeneration/build_job_generator.groovy
@@ -211,7 +211,10 @@ node('worker') {
             checkoutUserPipelines()
         }
 
-        if (jenkinsCreds != '') {
+        if (targetConfigurations.size() == 0) {
+            println "[WARNING] No targetConfigurations to be generated for this version"
+        } else {
+          if (jenkinsCreds != '') {
             withCredentials([usernamePassword(
                 credentialsId: "${JENKINS_AUTH}",
                 usernameVariable: 'jenkinsUsername',
@@ -240,7 +243,7 @@ node('worker') {
                     jobType
                 ).regenerate()
             }
-        } else {
+          } else {
             println '[WARNING] No Jenkins API Credentials have been provided! If your server does not have anonymous read enabled, you may encounter 403 api request error code.'
             regenerationScript(
                 javaVersion,
@@ -263,6 +266,7 @@ node('worker') {
                 checkoutCreds,
                 jobType
             ).regenerate()
+          }
         }
         println '[SUCCESS] All done!'
     } finally {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -893,7 +893,7 @@ node('worker') {
         }
 
         // Slack message:
-////        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
         echo 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }
@@ -1050,7 +1050,7 @@ node('worker') {
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
                 def fullMessage = "${featureRelease} latest 'EA Build' publish status: *${health}*.${reproducibilityText} Build: ${releaseLink}.${lastPublishedMsg}${errorMsg}${missingMsg}"
                 echo "===> ${fullMessage}"
-////                slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
+                slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }
             echo '----------------------------------------------------------------'
         }


### PR DESCRIPTION
Daily Slack status tool assumed only 1 jdk(head) repo versions, but with stabilization branches we now have 2, eg.jdk-24 and jdk-25
