### PR TITLE
x86 Redist API-MS-Win DLLs not being skipped during Eclipse signing

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1562,7 +1562,7 @@ class Build {
                                                     ms_file_skipped=false
                                                     if [ "${base_os}" == "windows" ]; then
                                                         # Check if file is a Microsoft supplied file that is already signed
-                                                        if [[ "$file" =~ api-ms-win.* ]] || [[ "$file" =~ msvcp.* ]] || [[ "$file" =~ ucrtbase.* ]] || [[ "$file" =~ vcruntime.* ]]; then
+                                                        if [[ "$file" =~ api-ms-win.* ]] || [[ "$file" =~ API-MS-Win.* ]] || [[ "$file" =~ msvcp.* ]] || [[ "$file" =~ ucrtbase.* ]] || [[ "$file" =~ vcruntime.* ]]; then
                                                             echo "Skipping Microsoft file $file"
                                                             ms_file_skipped=true
                                                         fi


### PR DESCRIPTION
x86 Redist DLLs have an upper case file with "API-MS-Win" :

https://ci.adoptium.net/job/build-scripts/job/release/job/sign_verification/2234/console
```
FAILURE: The following 3 executables are not signed correctly:
    unpacked/jdk/expanded_java.base.jmod/lib/API-MS-Win-core-xstate-l2-1-0.dll
    unpacked/jdk/jdk-17.0.14+6/bin/API-MS-Win-core-xstate-l2-1-0.dll
    unpacked/jre/jdk-17.0.14+6-jre/bin/API-MS-Win-core-xstate-l2-1-0.dll
```