### PR TITLE
Windows docker build ensure cleanWorkspace cleans build tmp workspace

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2217,7 +2217,7 @@ def buildScriptsAssemble(
                                                     context.println "Windows build cleaning" + context.WORKSPACE
                                                     context.cleanWs notFailBuild: true
                                                 } catch (e) {
-                                                    context.println "Failed to clean ${e}"
+                                                    context.println "ERROR: Failed to clean ${e}"
                                                 }
                                             }
                                         }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1659,7 +1659,7 @@ def postBuildWSclean(
                                       context.println 'Cleaning workspace build output files under ' + context.WORKSPACE
                                       batOrSh('rm -rf ' + context.WORKSPACE + '/workspace/build/src/build ' + context.WORKSPACE + '/workspace/target ' + context.WORKSPACE + '/workspace/build/devkit ' + context.WORKSPACE + '/workspace/build/straceOutput')
                                     } catch (e) {
-                                        context.println "Failed to clean workspace build output files ${e}"
+                                        context.println "ERROR: Failed to clean workspace build output files ${e}"
                                     }
                                 }
                             } else {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1644,7 +1644,7 @@ def postBuildWSclean(
                                         context.println 'Cleaning workspace non-hidden files: ' + context.WORKSPACE + '/*'
                                         context.sh(script: 'rm -rf ' + context.WORKSPACE + '/*')
                                     } catch (e) {
-                                        context.println "Failed to clean workspace non-hidden files ${e}"
+                                        context.println "ERROR: Failed to clean workspace non-hidden files ${e}"
                                     }
 
                                     // Clean remaining hidden files using cleanWs

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1644,7 +1644,7 @@ def postBuildWSclean(
                                         context.println 'Cleaning workspace non-hidden files: ' + context.WORKSPACE + '/*'
                                         context.sh(script: 'rm -rf ' + context.WORKSPACE + '/*')
                                     } catch (e) {
-                                        context.println "ERROR: Failed to clean workspace non-hidden files ${e}"
+                                        context.println "Warning: Failed to clean workspace non-hidden files ${e}"
                                     }
 
                                     // Clean remaining hidden files using cleanWs
@@ -1652,14 +1652,14 @@ def postBuildWSclean(
                                         context.println 'Cleaning workspace hidden files using cleanWs: ' + context.WORKSPACE
                                         context.cleanWs notFailBuild: true, disableDeferredWipeout: true, deleteDirs: true
                                     } catch (e) {
-                                        context.println "Failed to clean ${e}"
+                                        context.println "Warning: Failed to clean ${e}"
                                     }
                                 } else if (cleanWorkspaceBuildOutputAfter) {
                                     try {
                                       context.println 'Cleaning workspace build output files under ' + context.WORKSPACE
                                       batOrSh('rm -rf ' + context.WORKSPACE + '/workspace/build/src/build ' + context.WORKSPACE + '/workspace/target ' + context.WORKSPACE + '/workspace/build/devkit ' + context.WORKSPACE + '/workspace/build/straceOutput')
                                     } catch (e) {
-                                        context.println "ERROR: Failed to clean workspace build output files ${e}"
+                                        context.println "Warning: Failed to clean workspace build output files ${e}"
                                     }
                                 }
                             } else {
@@ -2206,7 +2206,7 @@ def buildScriptsAssemble(
                                             try {
                                                 context.cleanWs notFailBuild: true
                                             } catch (e) {
-                                                context.println "Failed to clean ${e}"
+                                                context.println "Warning: Failed to clean ${e}"
                                             }
                                             cleanWorkspace = false
                                         }
@@ -2217,7 +2217,7 @@ def buildScriptsAssemble(
                                                     context.println "Windows build cleaning" + context.WORKSPACE
                                                     context.cleanWs notFailBuild: true
                                                 } catch (e) {
-                                                    context.println "ERROR: Failed to clean ${e}"
+                                                    context.println "Warning: Failed to clean ${e}"
                                                 }
                                             }
                                         }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2199,11 +2199,11 @@ def buildScriptsAssemble(
                                             }
                                             cleanWorkspace = false
                                         }
-                                        // For Windows docker build also clean alternative workspace
-                                        if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE ) {
+                                        // For Windows build also clean alternative workspace
+                                        if ( buildConfig.TARGET_OS == 'windows' ) {
                                             context.ws(workspace) {
                                                 try {
-                                                    context.println "Windows docker build cleaning" + context.WORKSPACE
+                                                    context.println "Windows build cleaning" + context.WORKSPACE
                                                     context.cleanWs notFailBuild: true
                                                 } catch (e) {
                                                     context.println "Failed to clean ${e}"

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2199,6 +2199,17 @@ def buildScriptsAssemble(
                                             }
                                             cleanWorkspace = false
                                         }
+                                        // For Windows docker build also clean alternative workspace
+                                        if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE ) {
+                                            context.ws(workspace) {
+                                                try {
+                                                    context.println "Windows docker build cleaning" + context.WORKSPACE
+                                                    context.cleanWs notFailBuild: true
+                                                } catch (e) {
+                                                    context.println "Failed to clean ${e}"
+                                                }
+                                            }
+                                        }
                                     }
                                 } catch (FlowInterruptedException e) {
                                     throw new Exception("[ERROR] Controller clean workspace timeout (${buildTimeouts.CONTROLLER_CLEAN_TIMEOUT} HOURS) has been reached. Exiting...")

--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -163,7 +163,7 @@ class PullRequestTestPipeline implements Serializable {
                                     context.booleanParam(name: 'enableInstallers', value: false), // never need this enabled in pr-test
                                     context.booleanParam(name: 'useAdoptBashScripts', value: false), // should not use defaultsJson but adoptDefaultsJson
                                     context.booleanParam(name: 'keepReleaseLogs', value: false), // never need this enabled in pr-tester
-                                    context.booleanParam(name: 'cleanWorkspace', value: true) // always clean prtester workspace before the build
+                                    context.booleanParam(name: 'cleanWorkspace', value: true), // always clean prtester workspace before the build
                                     context.booleanParam(name: 'cleanWorkspaceAfterBuild', value: true) // always clean prtester workspace after the build
                                 ]
                         } catch (err) {

--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -163,6 +163,7 @@ class PullRequestTestPipeline implements Serializable {
                                     context.booleanParam(name: 'enableInstallers', value: false), // never need this enabled in pr-test
                                     context.booleanParam(name: 'useAdoptBashScripts', value: false), // should not use defaultsJson but adoptDefaultsJson
                                     context.booleanParam(name: 'keepReleaseLogs', value: false), // never need this enabled in pr-tester
+                                    context.booleanParam(name: 'cleanWorkspace', value: true) // always clean prtester workspace before the build
                                     context.booleanParam(name: 'cleanWorkspaceAfterBuild', value: true) // always clean prtester workspace after the build
                                 ]
                         } catch (err) {


### PR DESCRIPTION
For Windows which builds within a tmp workspace, ensure when CLEAN_WORKSPACE is specified it is honoured.
https://github.com/adoptium/ci-jenkins-pipelines/blob/207bcc88ad4ca1b6cedc72b64092e2541637cccd/pipelines/build/common/openjdk_build_pipeline.groovy#L2190

Also, changed pr-tester default setting to cleanWorkspace prior to tester builds, which should now ensure windows host cleans workspace before container build

Some test builds:
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-windows-x64-temurin/241/
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-windows-aarch64-temurin/34/