### PR TITLE
switch `rhel6||centos6` labels for `sw.tool.glibc.2_12`

### DIFF
--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -29,7 +29,7 @@ class Config17 {
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'sanity.external', 'dev.openjdk', 'dev.functional']
                 ],
                 additionalTestLabels: [
-                        openj9      : '!(centos6||rhel6)'
+                        openj9      : '!sw.tool.glibc.2_12'
                 ],
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -28,8 +28,8 @@ class Config21 {
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'sanity.external', 'dev.openjdk', 'dev.functional', 'dev.system', 'special.system']
                 ],
                 additionalTestLabels: [
-                        openj9      : '!(centos6||rhel6)',
-                        temurin     : '!(centos6||rhel6)'
+                        openj9      : '!sw.tool.glibc.2_12',
+                        temurin     : '!sw.tool.glibc.2_12'
                 ],
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',

--- a/pipelines/jobs/configurations/jdk23u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk23u_pipeline_config.groovy
@@ -29,8 +29,8 @@ class Config23 {
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'dev.openjdk', 'dev.functional', 'dev.system', 'special.system']
                 ],
                 additionalTestLabels: [
-                        openj9      : '!(centos6||rhel6)',
-                        temurin     : '!(centos6||rhel6)'
+                        openj9      : '!sw.tool.glibc.2_12',
+                        temurin     : '!sw.tool.glibc.2_12'
                 ],
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',

--- a/pipelines/jobs/configurations/jdk24_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk24_pipeline_config.groovy
@@ -29,8 +29,8 @@ class Config24 {
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'dev.openjdk', 'dev.functional', 'dev.system', 'special.system']
                 ],
                 additionalTestLabels: [
-                        openj9      : '!(centos6||rhel6)',
-                        temurin     : '!(centos6||rhel6)'
+                        openj9      : '!sw.tool.glibc.2_12',
+                        temurin     : '!sw.tool.glibc.2_12'
                 ],
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',

--- a/pipelines/jobs/configurations/jdk25_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk25_pipeline_config.groovy
@@ -29,8 +29,8 @@ class Config25 {
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'dev.openjdk', 'dev.functional', 'dev.system', 'special.system']
                 ],
                 additionalTestLabels: [
-                        openj9      : '!(centos6||rhel6)',
-                        temurin     : '!(centos6||rhel6)'
+                        openj9      : '!sw.tool.glibc.2_12',
+                        temurin     : '!sw.tool.glibc.2_12'
                 ],
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',


### PR DESCRIPTION
Fixes https://github.com/adoptium/aqa-tests/issues/5754 - this is a more explicit/generic way of determining which machines that tests should be run on.

(Having said that, one of the two machines we have at Adoptium which matches this is offline and the other is going to be decommissioned so this may not serve too much use in the future :-) )

I've added the "new" label to the machines.

@AdamBrousseau would be good to have your approval on this in case your systems will be impacted by this change - I can revert the openj9 label change if required.