### PR TITLE
Update release tuesday calculation to be 3rd teusday of month

### DIFF
--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -73,6 +73,8 @@ def isDuringReleasePeriod() {
         echo "No releases this month"
     }
 
+    echo "Is within release period? "+releasePeriod
+
     return releasePeriod
 }
 

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -50,6 +50,7 @@ def publishJobTag
 
 // Is the current day within the release period of from the previous Saturday to the following Sunday
 // from the release Tuesday ?
+// Release Tuesday is now the 3rd Tuesday of the month
 def isDuringReleasePeriod() {
     def releasePeriod = false
     def now = ZonedDateTime.now(ZoneId.of('UTC'))
@@ -58,21 +59,18 @@ def isDuringReleasePeriod() {
     // Is it a release month? CPU updates in Jan, Apr, Jul, Oct
     // New major versions are released in Mar and Sept
     if (month == Month.JANUARY || month == Month.MARCH || month == Month.APRIL || month == Month.JULY || month == Month.SEPTEMBER || month == Month.OCTOBER) {
-        // Yes, calculate release Tuesday, which is the closest Tuesday to the 17th
-        def day17th = now.withDayOfMonth(17)
-        def dayOfWeek17th = day17th.getDayOfWeek()
-        def releaseTuesday
-        if (dayOfWeek17th == DayOfWeek.SATURDAY || dayOfWeek17th == DayOfWeek.SUNDAY || dayOfWeek17th == DayOfWeek.MONDAY || dayOfWeek17th == DayOfWeek.TUESDAY) {
-            releaseTuesday = day17th.with(TemporalAdjusters.nextOrSame(DayOfWeek.TUESDAY))
-        } else {
-            releaseTuesday = day17th.with(TemporalAdjusters.previous(DayOfWeek.TUESDAY))
-        }
+        // Yes, calculate release Tuesday, which is the 3rd Tuesday of the month
+        def day1st = now.withDayOfMonth(1)
+        def releaseTuesday = day1st.with(TemporalAdjusters.dayOfWeekInMonth(3, DayOfWeek.TUESDAY))
+        echo "Release Tuesday for this month is: "+releaseTuesday 
 
         // Release period no trigger from prior week previous Saturday to following Sunday
         def days = ChronoUnit.DAYS.between(releaseTuesday, now)
         if (days >= -10 && days <= 5) {
             releasePeriod = true
         }
+    } else {
+        echo "No releases this month"
     }
 
     return releasePeriod

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -187,7 +187,7 @@ node('worker') {
     def binariesRepoTag = publishJobTag + "-beta"
 
     if (isDuringReleasePeriod()) {
-        echo "We are within a release period (previous Saturday to the following Sunday around the release Tuesday), so testing is disabled."
+        echo "We are within a release period (prior week previous Saturday to the following Sunday around the release Tuesday), so testing is disabled."
         enableTesting = false
     }
 


### PR DESCRIPTION
Oracle have changed the release Tuesday day to be the "3rd Tuesday" of a release month: https://www.oracle.com/security-alerts/

Automatic EA build trigger disabling of tests needs updating with this logic.

Test run: https://ci.adoptium.net/job/build-scripts/job/utils/job/betaTrigger_21ea/197/console
