### PR TITLE
Run the GPG sign job after the SBOM sign

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2484,8 +2484,9 @@ def buildScriptsAssemble(
                 if (!env.JOB_NAME.contains('pr-tester') && context.JENKINS_URL.contains('adopt')) {
                     try {
                         context.println "openjdk_build_pipeline: Running GPG signing process"
-                        gpgSign()
                         jsfSignSBOM()
+                        gpgSign()
+                        
                     } catch (Exception e) {
                         context.println(e.message)
                         currentBuild.result = 'FAILURE'

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1064,7 +1064,7 @@ class Build {
 
     // Kick off the sign_temurin_jsf job to sign the SBOM
     private void jsfSignSBOM() {
-        context.stage('SBOM Sign') {
+        context.stage('SBOM JSF Sign') {
             
             context.println "Running build_sign_sbom_libraries to build the SBOM libraries"
             def buildSBOMLibrariesJob = context.build job: 'build_sign_sbom_libraries',
@@ -2486,7 +2486,7 @@ def buildScriptsAssemble(
                         context.println "openjdk_build_pipeline: Running GPG signing process"
                         jsfSignSBOM()
                         gpgSign()
-                        
+
                     } catch (Exception e) {
                         context.println(e.message)
                         currentBuild.result = 'FAILURE'


### PR DESCRIPTION
If the SBOM jsf sign happens after the SBOM has been signed by the gpg key, the signature will be invalid. Nice catch Stewart