### PR TITLE
Correct publish job url

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -222,9 +222,9 @@ def getBuildIDsByPlatform(String trssUrl, String jdkVersion, String srcTag, Map 
 
                 // Also, check if the pipeline published any successful builds overall.
                 if (onePipelineBuild.buildName.contains("refactor_openjdk_release_tool") && onePipelineBuild.status.contains("Done")) {
-                    def wgetUrlForReleaseTool = "${onePipelineBuild.buildUrl}/consoleText"
+                    def wgetUrlForReleaseTool = "${onePipelineBuild.url}/job/${onePipelineBuild.buildName}/${onePipelineBuild.buildNum}/consoleText"
                     if (onePipelineBuild.buildOutputId != null) {
-                        wgetUrlForReleaseTool = "${onePipelineBuild.url}/job/${onePipelineBuild.buildName}/${onePipelineBuild.buildNum}/consoleText"
+                        wgetUrlForReleaseTool = "${trssURL}/api/getOutputById?id=${onePipelineBuild.buildOutputId}"
                     }
 
                     def releaseToolOutput = callWgetSafely(wgetUrlForReleaseTool)

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -224,7 +224,7 @@ def getBuildIDsByPlatform(String trssUrl, String jdkVersion, String srcTag, Map 
                 if (onePipelineBuild.buildName.contains("refactor_openjdk_release_tool") && onePipelineBuild.status.contains("Done")) {
                     def wgetUrlForReleaseTool = "${onePipelineBuild.buildUrl}/consoleText"
                     if (onePipelineBuild.buildOutputId != null) {
-                        wgetUrlForReleaseTool = "${trssURL}/api/getOutputById?id=${onePipelineBuild.buildOutputId}"
+                        wgetUrlForReleaseTool = "${onePipelineBuild.url}/job/${onePipelineBuild.buildName}/${onePipelineBuild.buildNum}/consoleText"
                     }
 
                     def releaseToolOutput = callWgetSafely(wgetUrlForReleaseTool)

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -677,7 +677,7 @@ node('worker') {
             }
 
             // Check tip_releases status, by querying binaries repo as API does not server the "tip" dev releases
-            if (tipReleases.size() > 0) {
+            if ("${params.TIP_RELEASES}".trim() != "") {
              tipReleases.each { tipRelease ->
               def latestOpenjdkBuild = getLatestOpenjdkBuildTag(tipRelease)
               def tipVersion = tipRelease.replaceAll("[a-z]","").toInteger()
@@ -708,7 +708,7 @@ node('worker') {
         def pipelinesOfInterest = ""
         def allReleases = []
         allReleases.addAll(featureReleases)
-        if (tipReleases.size() > 0) {
+        if ("${params.TIP_RELEASES}".trim() != "") {
             allReleases.addAll(tipReleases)
         }
         if ("${params.NON_TAG_BUILD_RELEASES}".trim() != "") {
@@ -911,7 +911,7 @@ node('worker') {
             echo '-------------- Latest pipeline health report ------------------'
             def allReleases = []
             allReleases.addAll(featureReleases)
-            if (tipReleases.size() > 0) {
+            if ("${params.TIP_RELEASES}".trim() != "") {
                 allReleases.addAll(tipReleases)
             }
             if (("${params.NON_TAG_BUILD_RELEASES}".trim() != "")) {


### PR DESCRIPTION
This change includes correcting the url for the refactor_openjdk_release_tool job, as well as correcting the check for empty tip release parameter.