### PR TITLE
(v2025.01.01) RERUN_FAILURE for AQA test builds (#1178)

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -516,6 +516,7 @@ class Build {
                         context.string(name: 'VENDOR_TEST_REPOS', value: vendorTestRepos),
                         context.string(name: 'VENDOR_TEST_BRANCHES', value: vendorTestBranches),
                         context.string(name: 'VENDOR_TEST_DIRS', value: vendorTestDirs),
+                        context.booleanParam(name: 'RERUN_FAILURE', value: true),
                         context.string(name: 'RERUN_ITERATIONS', value: "${rerunIterations}")
                         ]
 


### PR DESCRIPTION
cherry-pick: https://github.com/adoptium/ci-jenkins-pipelines/pull/1178
resolves: https://github.com/adoptium/ci-jenkins-pipelines/issues/1177