### PR TITLE
Update Daily Slack EA status to report published EA Test job failure & testcase stats

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -692,7 +692,7 @@ def getFailedTestSummary(String trssUrl, String variant, String featureRelease, 
     def failedTestJobNum  = 0
     def failedTestCaseNum = 0 
 
-    // Find all pipeline jobs for this release EA tag
+    // Find all "Done" pipeline jobs for this release EA tag
     def buildUrls
     if (tag == "") {
         // Non-tag release builds, just find the last build
@@ -704,9 +704,11 @@ def getFailedTestSummary(String trssUrl, String variant, String featureRelease, 
     if (buildUrls.size() > 0) {
         buildUrls.each { buildUrlTuple ->
             (probableBuildUrl, probableBuildIdForTRSS, probableBuildStatus) = buildUrlTuple
-            def testResults = getPipelineTestResults(trssUrl, featureRelease+"-pipeline", probableBuildUrl, probableBuildIdForTRSS, buildVariant, testVariant)
-            failedTestJobNum  += testResults.testJobFailure
-            failedTestCaseNum += testResults.testCaseFailed
+            if (probableBuildStatus == "Done") {
+                def testResults = getPipelineTestResults(trssUrl, featureRelease+"-pipeline", probableBuildUrl, probableBuildIdForTRSS, buildVariant, testVariant)
+                failedTestJobNum  += testResults.testJobFailure
+                failedTestCaseNum += testResults.testCaseFailed
+            }
         }
     }
 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -826,6 +826,10 @@ node('worker') {
                                     // Release build tag triggered build
                                     pipeline_id = job._id
                                     pipelineUrl = job.buildUrl
+                                } else if (job.startBy.startsWith("upstream project \"build-scripts/weekly-")) {
+                                    // Scheduled "weekly" job for Oracle managed versions
+                                    pipeline_id = job._id
+                                    pipelineUrl = job.buildUrl
                                 }
                             }
                             // Was job a "match"?

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -573,10 +573,16 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
                 // For each test job (including testList subjobs), we now search for the reproducibility test.
                 assert testJobNamesJson instanceof List
                 for ( Map testJob in testJobNamesJson ) {
-echo "TRSS_TEST_JOB: "+testJob
+                    // Default to Jenkins console
                     def wgetUrl = "${testJob.buildUrl}/consoleText"
-                    if (testJob.buildOutputId != null) {
-                        wgetUrl = "${trssURL}/api/getOutputById?id=${testJob.buildOutputId}"
+
+                    // See if we can find the test in the tests list, to get the output from
+                    def tests = testJob.tests
+                    tests.each { testTarget ->
+                        if (testTarget.testName.startsWith(reproTestName)) {
+                            wgetUrl = "${trssURL}/api/getOutputById?id=${testTarget.testOutputId}"
+                            break
+                        }
                     }
 
                     def testOutput = callWgetSafely(wgetUrl)

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -581,7 +581,6 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
                     tests.each { testTarget ->
                         if (testTarget.testName.startsWith(reproTestName)) {
                             wgetUrl = "${trssURL}/api/getOutputById?id=${testTarget.testOutputId}"
-                            break
                         }
                     }
 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -972,7 +972,7 @@ node('worker') {
                     }
                 } else {
                     // Check if build in-progress
-                    def (probableBuildUrl, probableBuildIdForTRSS, probableBuildStatus) = ["", "", ""]
+                    (probableBuildUrl, probableBuildIdForTRSS, probableBuildStatus) = ["", "", ""]
                     def buildUrls = getBuildUrls(trssUrl, variant, featureRelease, status['expectedReleaseName'].replaceAll("-beta", ""), status['upstreamTag']+"_adopt", true)
                     if (buildUrls.size() > 0) {
                         (probableBuildUrl, probableBuildIdForTRSS, probableBuildStatus) = buildUrls[0]

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -710,7 +710,7 @@ def getFailedTestSummary(String trssUrl, String variant, String featureRelease, 
         }
     }
 
-    return "FailedTestJobs: "+failedTestJobNum+" FailedTestCases: "+failedTestCaseNum
+    return " FailedTestJobs: "+failedTestJobNum+" FailedTestCases: "+failedTestCaseNum
 }
 
 
@@ -1136,7 +1136,7 @@ node('worker') {
                 }
 
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
-                def fullMessage = "${featureRelease} latest 'EA Build' publish status: *${health}*.${reproducibilityText} Build: ${releaseLink}.${lastPublishedMsg}${errorMsg}${missingMsg}"
+                def fullMessage = "${featureRelease} 'EA Build' status: *${health}*.${reproducibilityText} Build: ${releaseLink}.${failedTestSummary}${lastPublishedMsg}${errorMsg}${missingMsg}"
                 echo "===> ${fullMessage}"
                 //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -812,7 +812,7 @@ node('worker') {
 
                             // Was job "Done"?
                             // Report pipelines built within the last week
-                            if (job.status != null && job.status.equals('Done') && job.startBy != null && days <= 7) {
+                            if (job.status != null && job.status.equals('Done') && job.startBy != null && days <= 27) {
                                 if (job.startBy.startsWith('timer')) {
                                     // Timer scheduled job
                                     pipeline_id = job._id

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -562,7 +562,6 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
                 def reproTestBucket=platformReproTestMap[onePlatform][0]
                 def testJobTitle="Test_openjdk${jdkVersionInt}_hs_${reproTestBucket}_${testPlatform}.*"
                 def trssTestJobNames = callWgetSafely("${trssURL}/api/getAllChildBuilds?parentId=${buildJob._id}\\&buildNameRegex=^${testJobTitle}\$")
-echo "TRSS test jobs: "+trssTestJobNames
                 // Did this build have tests? If not, skip to next build job.
                 if ( trssTestJobNames.length() <= 2 ) {
                     continue
@@ -574,6 +573,7 @@ echo "TRSS test jobs: "+trssTestJobNames
                 // For each test job (including testList subjobs), we now search for the reproducibility test.
                 assert testJobNamesJson instanceof List
                 for ( Map testJob in testJobNamesJson ) {
+echo "TRSS_TEST_JOB: "+testJob
                     def wgetUrl = "${testJob.buildUrl}/consoleText"
                     if (testJob.buildOutputId != null) {
                         wgetUrl = "${trssURL}/api/getOutputById?id=${testJob.buildOutputId}"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -597,7 +597,7 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
 }
 
 // Get the Pipeline Test job results...
-def getPipelineTestResults(String trssUrl, String pipeline_id, String buildVariant, String testVariant) {
+def getPipelineTestResults(String trssUrl, String pipelineName, String pipelineUrl, String pipeline_id, String buildVariant, String testVariant) {
 	def buildJobComplete = 0
 	def buildJobFailure = 0
 	def testJobSuccess = 0
@@ -830,7 +830,7 @@ node('worker') {
                             }
                             // Was job a "match"?
                             if (pipeline_id != null) {
-                                def testResults = getPipelineTestResults(trssUrl, pipeline_id, buildVariant, testVariant)
+                                def testResults = getPipelineTestResults(trssUrl, pipelineName, pipelineUrl, pipeline_id, buildVariant, testVariant)
                                 testStats.add(testResults)
                             }
                     }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -1004,7 +1004,7 @@ node('worker') {
         }
 
         // Slack message:
-        //slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
         echo 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }
@@ -1173,7 +1173,7 @@ node('worker') {
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
                 def fullMessage = "${featureRelease} EA: *${health}*. Build: ${releaseLink}.${failedTestSummary}${lastPublishedMsg}${reproducibilityText}${errorMsg}${missingMsg}"
                 echo "===> ${fullMessage}"
-                //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
+                slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }
             echo '----------------------------------------------------------------'
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -560,7 +560,7 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
             for ( Map buildJob in buildJobNamesJson ) {
                 reproResult = "???% - Build found, but no reproducibility tests. Build link: " + buildJob.buildUrl
                 def testPlatform = platformConversionMap[onePlatform][1]
-                def reproTestName=platformReproTestMap[onePlatform][1]
+                def reproTestName=platformReproTestMap[onePlatform][1]+"_0"
                 def reproTestBucket=platformReproTestMap[onePlatform][0]
                 def testJobTitle="Test_openjdk${jdkVersionInt}_hs_${reproTestBucket}_${testPlatform}.*"
                 def trssTestJobNames = callWgetSafely("${trssURL}/api/getAllChildBuilds?parentId=${buildJob._id}\\&buildNameRegex=^${testJobTitle}\$")
@@ -581,7 +581,7 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
                     // See if we can find the test in the tests list, to get the output from
                     def tests = testJob.tests
                     tests.each { testTarget ->
-                        if (testTarget.testName.startsWith(reproTestName)) {
+                        if (testTarget.testName == reproTestName) {
                             wgetUrl = "${trssURL}/api/getOutputById?id=${testTarget.testOutputId}"
                         }
                     }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -562,7 +562,7 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
                 def reproTestBucket=platformReproTestMap[onePlatform][0]
                 def testJobTitle="Test_openjdk${jdkVersionInt}_hs_${reproTestBucket}_${testPlatform}.*"
                 def trssTestJobNames = callWgetSafely("${trssURL}/api/getAllChildBuilds?parentId=${buildJob._id}\\&buildNameRegex=^${testJobTitle}\$")
-
+echo "TRSS test jobs: "+trssTestJobNames
                 // Did this build have tests? If not, skip to next build job.
                 if ( trssTestJobNames.length() <= 2 ) {
                     continue

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -715,11 +715,11 @@ def getFailedTestSummary(String trssUrl, String variant, String featureRelease, 
     }
 
     if (testJobTotal == 0) {
-        return "_No AQA tests run._"
+        return " _No AQA tests run._"
     } else if ((failedTestJobNum + failedTestTargetNum) == 0) {
         return "\n_AQA tests successful: "+testJobTotal+" jobs & "+testTargetTotal+" targets run._"
     } else {
-        def summary = "\n_Failed:"
+        def summary = "\n_AQA test failures:"
         if (failedTestJobNum > 0) {
             summary += " TestJobs="+failedTestJobNum+"/"+testJobTotal
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -968,7 +968,7 @@ node('worker') {
         }
 
         // Slack message:
-        //slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
         echo 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }
@@ -1138,7 +1138,7 @@ node('worker') {
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
                 def fullMessage = "${featureRelease} EA: *${health}*.${reproducibilityText} Build: ${releaseLink}.${failedTestSummary}${lastPublishedMsg}${errorMsg}${missingMsg}"
                 echo "===> ${fullMessage}"
-                //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
+                slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }
             echo '----------------------------------------------------------------'
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -596,7 +596,8 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
     }
 }
 
-def getPipelineTestResults(String trssUrl, String pipeline_id, String testVariant) {
+// Get the Pipeline Test job results...
+def getPipelineTestResults(String trssUrl, String pipeline_id, String buildVariant, String testVariant) {
 	def buildJobComplete = 0
 	def buildJobFailure = 0
 	def testJobSuccess = 0
@@ -829,7 +830,7 @@ node('worker') {
                             }
                             // Was job a "match"?
                             if (pipeline_id != null) {
-                                def testResults = getPipelineTestResults(trssUrl, pipeline_id, testVariant)
+                                def testResults = getPipelineTestResults(trssUrl, pipeline_id, buildVariant, testVariant)
                                 testStats.add(testResults)
                             }
                     }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -522,6 +522,8 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
         def platformsForOneJDKVersion = results[jdkVersion][1]
         assert platformsForOneJDKVersion instanceof Map
         for ( String onePlatform in platformsForOneJDKVersion.keySet() ) {
+            echo "Searching for "+onePlatform+" reproducibility %"
+
             // Check if we already have a result from previous pipeline
             if (results[jdkVersion][1][onePlatform] != "?" && !results[jdkVersion][1][onePlatform].startsWith("???")) {
                 // We have a result already...

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -710,7 +710,7 @@ def getFailedTestSummary(String trssUrl, String variant, String featureRelease, 
         }
     }
 
-    return " FailedTestJobs: "+failedTestJobNum+" FailedTestCases: "+failedTestCaseNum
+    return " _Failed: TestJobs="+failedTestJobNum+" TestCases="+failedTestCaseNum+"_"
 }
 
 
@@ -1136,7 +1136,7 @@ node('worker') {
                 }
 
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
-                def fullMessage = "${featureRelease} 'EA Build' status: *${health}*.${reproducibilityText} Build: ${releaseLink}.${failedTestSummary}${lastPublishedMsg}${errorMsg}${missingMsg}"
+                def fullMessage = "${featureRelease} EA: *${health}*.${reproducibilityText} Build: ${releaseLink}.${failedTestSummary}${lastPublishedMsg}${errorMsg}${missingMsg}"
                 echo "===> ${fullMessage}"
                 //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -710,7 +710,7 @@ def getFailedTestSummary(String trssUrl, String variant, String featureRelease, 
         }
     }
 
-    return "FailedTestJobs: "+testResults+" FailedTestCases: "+failedTestCaseNum
+    return "FailedTestJobs: "+failedTestJobNum+" FailedTestCases: "+failedTestCaseNum
 }
 
 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -997,7 +997,7 @@ node('worker') {
         }
 
         // Slack message:
-        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        //slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
         echo 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }
@@ -1166,7 +1166,7 @@ node('worker') {
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
                 def fullMessage = "${featureRelease} EA: *${health}*. Build: ${releaseLink}.${failedTestSummary}${lastPublishedMsg}${reproducibilityText}${errorMsg}${missingMsg}"
                 echo "===> ${fullMessage}"
-                slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
+                //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }
             echo '----------------------------------------------------------------'
         }


### PR DESCRIPTION
- Make the published EA build status also report "AQA test failures: TestJobs=N/Tot TestTargets=N/Tot."
To highlight need to fix/exclude to failures.
- Also correct reproducibility% status which is currently incorrectly reporting and not finding the relevant reproducible build test

Example output: https://adoptium.slack.com/archives/C09NW3L2J/p1738669436392289

 