### PR TITLE
Correct EA build status in daily Slack build status when recent builds are GA ones

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -64,7 +64,12 @@ def isGaTag(String version, String tag) {
 echo "TAG: "+tag
     def openjdkRepo = getUpstreamRepo(version) 
 
+    def annotatedTag = true
+    
     def tagCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep '\\^{}' | grep \"${tag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
+    if (tagCommitSHA == "") {
+       tagCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep -v '\\^{}' | grep \"${tag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
+    }
 
 echo "tagSHA:"+tagCommitSHA
     def gaCheckTag = "unknown"
@@ -82,6 +87,9 @@ echo "tagSHA:"+tagCommitSHA
         }
     }
     def gaCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep '\\^{}' | grep \"${gaCheckTag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
+    if (gaCommitSHA == "") {
+        gaCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep -v '\\^{}' | grep \"${gaCheckTag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
+    }
 echo "gaSHA:"+gaCommitSHA
     if (gaCommitSHA != "" && tagCommitSHA == gaCommitSHA) {
 echo "ISGA"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -824,10 +824,8 @@ node('worker') {
 
               def status = []
               // Get latest published EA build (ie.not including GA builds)
-              // Ignore rogue published jdk8u solaris tag!
               def asset_index = 0
-              while(asset_index < assetsJson.size() && (isGaTag(featureRelease, assetsJson[asset_index].release_name.replaceAll("-ea-beta", "")) ||
-                                                        assetsJson[asset_index].release_name.contains("solaris")) ) {
+              while(asset_index < assetsJson.size() && isGaTag(featureRelease, assetsJson[asset_index].release_name.replaceAll("-ea-beta", "")) ) {
                 asset_index += 1
               }
               if (asset_index < assetsJson.size()) {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -64,8 +64,6 @@ def isGaTag(String version, String tag) {
 
     def openjdkRepo = getUpstreamRepo(version) 
 
-    def annotatedTag = true
-    
     def tagCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep '\\^{}' | grep \"${tag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
     if (tagCommitSHA == "") {
        // Some repos eg.jkd8u-aarch32-port use Lightweight tagging...

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -314,7 +314,6 @@ def getBuildUrls(String trssUrl, String variant, String featureRelease, String p
 
     if (pipelineJson.size() > 0) {
         def foundBuildTimestamp = 0
-echo "BUILDURLS: "+pipelineJson
         pipelineJson.each { job ->
             def overridePublishName = ""
             def buildScmRef = ""
@@ -334,22 +333,12 @@ echo "BUILDURLS: "+pipelineJson
                     releaseType = buildParam.value
                 }
             }
-echo "B: "+job
-echo "BB:"+releaseType
-echo "BB:"+containsVariant
-echo "BB:"+overridePublishName
-echo "BB:"+buildScmRef
-echo "BB:"+job.status
-echo "BB RS:"+requiredStatus+"BB"
-echo "BB:"+featureReleaseInt
-echo "BB:"+containsX64AlpineLinux
-echo "BB:"+featureRelease
+
             // Is there a job for the required tag?
             if (releaseType == "Weekly" && containsVariant && overridePublishName == publishName && buildScmRef == scmRef && job.status != null && (requiredStatus == "" || job.status == requiredStatus)) {
                 if (featureReleaseInt == 8) {
                     // alpine-jdk8u cannot be distinguished from jdk8u by the scmRef alone, so check for "x64AlpineLinux" in the targetConfiguration
                     if ((featureRelease == "alpine-jdk8u" && containsX64AlpineLinux) || (featureRelease != "alpine-jdk8u" && !containsX64AlpineLinux)) {
-echo "AAA"
                         if (job.timestamp > foundBuildTimestamp || !latestOnly) {
                             if (latestOnly) {
                                 functionBuildUrls = [[job.buildUrl, job._id, job.status]]

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -1033,7 +1033,7 @@ node('worker') {
         }
 
         // Slack message:
-        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall EA Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        //slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall EA Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
         echo 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }
@@ -1200,7 +1200,7 @@ node('worker') {
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
                 def fullMessage = "${featureRelease} EA: *${health}*. Build: ${releaseLink}.${failedTestSummary}${lastPublishedMsg}${errorMsg}${reproSummary}${missingMsg}"
                 echo "===> ${fullMessage}"
-                slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
+                //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }
             echo '----------------------------------------------------------------'
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -335,6 +335,15 @@ echo "BUILDURLS: "+pipelineJson
                 }
             }
 echo "B: "+job
+echo "BB:"+releaseType
+echo "BB:"+containsVariant
+echo "BB:"+overridePublishName
+echo "BB:"+buildScmRef
+echo "BB:"+job.status
+echo "BB RS:"+requiredStatus+"BB"
+echo "BB:"+featureReleaseInt
+echo "BB:"+containsX64AlpineLinux
+echo "BB:"+featureRelease
             // Is there a job for the required tag?
             if (releaseType == "Weekly" && containsVariant && overridePublishName == publishName && buildScmRef == scmRef && job.status != null && (requiredStatus == "" || job.status == requiredStatus)) {
                 if (featureReleaseInt == 8) {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -812,7 +812,7 @@ node('worker') {
               def status = []
               // Get latest published EA build (ie.not including GA builds)
               def asset_index = 0
-              while(asset_index < assetsJson.size() && isGaTag(featureRelease, assetsJson[asset_index].release_name.replaceAll("-ea-beta", ""))) {) {
+              while(asset_index < assetsJson.size() && isGaTag(featureRelease, assetsJson[asset_index].release_name.replaceAll("-ea-beta", ""))) {
                 asset_index += 1
               }
               if (asset_index < assetsJson.size()) {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -69,7 +69,11 @@ def isGaTag(String version, String tag) {
     def gaCheckTag = "unknown"
     if (version.contains("jdk8u")) {
         if (tag.indexOf("-") > 0) {
-            gaCheckTag = tag.substring(0, tag.indexOf("-"))+"-ga"
+            if (version == "aarch32-jdk8u") {
+                gaCheckTag = tag.substring(0, tag.indexOf("-"))+"-ga"+tag.substring(tag.indexOf("-", tag.indexOf("-")+1))
+            } else {
+                gaCheckTag = tag.substring(0, tag.indexOf("-"))+"-ga"
+            }
         }
     } else {
         if (tag.indexOf("+") > 0) {
@@ -811,8 +815,10 @@ node('worker') {
 
               def status = []
               // Get latest published EA build (ie.not including GA builds)
+              // Ignore rogue published jdk8u solaris tag!
               def asset_index = 0
-              while(asset_index < assetsJson.size() && isGaTag(featureRelease, assetsJson[asset_index].release_name.replaceAll("-ea-beta", ""))) {
+              while(asset_index < assetsJson.size() && (isGaTag(featureRelease, assetsJson[asset_index].release_name.replaceAll("-ea-beta", "")) ||
+                                                        assetsJson[asset_index].release_name.contains("solaris")) ) {
                 asset_index += 1
               }
               if (asset_index < assetsJson.size()) {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -61,20 +61,20 @@ def isGaTag(String version, String tag) {
         // Tip release has no GA tags
         return false
     }
-echo "TAG: "+tag
     def openjdkRepo = getUpstreamRepo(version) 
 
     def annotatedTag = true
     
     def tagCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep '\\^{}' | grep \"${tag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
     if (tagCommitSHA == "") {
+       // Some repos eg.jkd8u-aarch32-port use Lightweight tagging...
        tagCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep -v '\\^{}' | grep \"${tag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
     }
 
-echo "tagSHA:"+tagCommitSHA
     def gaCheckTag = "unknown"
     if (version.contains("jdk8u")) {
         if (tag.indexOf("-") > 0) {
+            // Is this a jdk8u-aarch32 tag eg.jdk8u442-b06-aarch32-20250125
             if (version == "aarch32-jdk8u"  && tag.indexOf("-", tag.indexOf("-")+1) > 0) {
                 gaCheckTag = tag.substring(0, tag.indexOf("-"))+"-ga"+tag.substring(tag.indexOf("-", tag.indexOf("-")+1))
             } else {
@@ -88,14 +88,12 @@ echo "tagSHA:"+tagCommitSHA
     }
     def gaCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep '\\^{}' | grep \"${gaCheckTag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
     if (gaCommitSHA == "") {
+        // Some repos eg.jkd8u-aarch32-port use Lightweight tagging...
         gaCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep -v '\\^{}' | grep \"${gaCheckTag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
     }
-echo "gaSHA:"+gaCommitSHA
     if (gaCommitSHA != "" && tagCommitSHA == gaCommitSHA) {
-echo "ISGA"
         return true
     } else {
-echo "NOTGA"
         return false
     }
 }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -1033,7 +1033,7 @@ node('worker') {
         }
 
         // Slack message:
-        //slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall EA Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall EA Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
         echo 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }
@@ -1200,7 +1200,7 @@ node('worker') {
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
                 def fullMessage = "${featureRelease} EA: *${health}*. Build: ${releaseLink}.${failedTestSummary}${lastPublishedMsg}${errorMsg}${reproSummary}${missingMsg}"
                 echo "===> ${fullMessage}"
-                //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
+                slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }
             echo '----------------------------------------------------------------'
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -810,8 +810,13 @@ node('worker') {
               def assetsJson = new JsonSlurper().parseText(assets)
 
               def status = []
-              if (assetsJson.size() > 0) {
-                def releaseName = assetsJson[0].release_name
+              // Get latest published EA build (ie.not including GA builds)
+              def asset_index = 0
+              while(asset_index < assetsJson.size() && isGaTag(featureRelease, assetsJson[asset_index].release_name.replaceAll("-ea-beta", ""))) {) {
+                asset_index += 1
+              }
+              if (asset_index < assetsJson.size()) {
+                def releaseName = assetsJson[asset_index].release_name
                 if (nonTagBuildReleases.contains(featureRelease)) {
                   // A non tag build, eg.a scheduled build for Oracle managed STS versions
                   def latestOpenjdkBuild = getLatestOpenjdkEABuildTag(featureRelease)

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -314,6 +314,7 @@ def getBuildUrls(String trssUrl, String variant, String featureRelease, String p
 
     if (pipelineJson.size() > 0) {
         def foundBuildTimestamp = 0
+echo "BUILDURLS: "+pipelineJson
         pipelineJson.each { job ->
             def overridePublishName = ""
             def buildScmRef = ""
@@ -333,12 +334,13 @@ def getBuildUrls(String trssUrl, String variant, String featureRelease, String p
                     releaseType = buildParam.value
                 }
             }
-
+echo "B: "+job
             // Is there a job for the required tag?
             if (releaseType == "Weekly" && containsVariant && overridePublishName == publishName && buildScmRef == scmRef && job.status != null && (requiredStatus == "" || job.status == requiredStatus)) {
                 if (featureReleaseInt == 8) {
                     // alpine-jdk8u cannot be distinguished from jdk8u by the scmRef alone, so check for "x64AlpineLinux" in the targetConfiguration
                     if ((featureRelease == "alpine-jdk8u" && containsX64AlpineLinux) || (featureRelease != "alpine-jdk8u" && !containsX64AlpineLinux)) {
+echo "AAA"
                         if (job.timestamp > foundBuildTimestamp || !latestOnly) {
                             if (latestOnly) {
                                 functionBuildUrls = [[job.buildUrl, job._id, job.status]]
@@ -1033,7 +1035,7 @@ node('worker') {
         }
 
         // Slack message:
-        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall EA Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        //slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall EA Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
         echo 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }
@@ -1091,6 +1093,7 @@ node('worker') {
                         if (buildUrls.size() > 0) {
                             (probableBuildUrl, probableBuildIdForTRSS, probableBuildStatus) = buildUrls[0]
                         }
+                     
 
                         def upstreamTagAge    = getOpenjdkBuildTagAge(featureRelease, status['upstreamTag'])
                         if (upstreamTagAge > 3 && probableBuildStatus == "Done") {
@@ -1200,7 +1203,7 @@ node('worker') {
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
                 def fullMessage = "${featureRelease} EA: *${health}*. Build: ${releaseLink}.${failedTestSummary}${lastPublishedMsg}${errorMsg}${reproSummary}${missingMsg}"
                 echo "===> ${fullMessage}"
-                slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
+                //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }
             echo '----------------------------------------------------------------'
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -61,6 +61,7 @@ def isGaTag(String version, String tag) {
         // Tip release has no GA tags
         return false
     }
+
     def openjdkRepo = getUpstreamRepo(version) 
 
     def annotatedTag = true
@@ -91,6 +92,7 @@ def isGaTag(String version, String tag) {
         // Some repos eg.jkd8u-aarch32-port use Lightweight tagging...
         gaCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep -v '\\^{}' | grep \"${gaCheckTag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
     }
+
     if (gaCommitSHA != "" && tagCommitSHA == gaCommitSHA) {
         return true
     } else {
@@ -1033,7 +1035,7 @@ node('worker') {
         }
 
         // Slack message:
-        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall EA Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
         echo 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -61,7 +61,7 @@ def isGaTag(String version, String tag) {
         // Tip release has no GA tags
         return false
     }
-
+echo "TAG: "+tag
     def openjdkRepo = getUpstreamRepo(version) 
 
     def tagCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep '\\^{}' | grep \"${tag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
@@ -69,7 +69,7 @@ def isGaTag(String version, String tag) {
     def gaCheckTag = "unknown"
     if (version.contains("jdk8u")) {
         if (tag.indexOf("-") > 0) {
-            if (version == "aarch32-jdk8u") {
+            if (version == "aarch32-jdk8u"  && tag.indexOf("-", tag.indexOf("-")+1) > 0) {
                 gaCheckTag = tag.substring(0, tag.indexOf("-"))+"-ga"+tag.substring(tag.indexOf("-", tag.indexOf("-")+1))
             } else {
                 gaCheckTag = tag.substring(0, tag.indexOf("-"))+"-ga"

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -66,7 +66,7 @@ def isGaTag(String version, String tag) {
 
     def tagCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep '\\^{}' | grep \"${tag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
     if (tagCommitSHA == "") {
-       // Some repos eg.jkd8u-aarch32-port use Lightweight tagging...
+       // Some repos eg.jdk8u-aarch32-port use Lightweight tagging...
        tagCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep -v '\\^{}' | grep \"${tag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
     }
 
@@ -87,7 +87,7 @@ def isGaTag(String version, String tag) {
     }
     def gaCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep '\\^{}' | grep \"${gaCheckTag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
     if (gaCommitSHA == "") {
-        // Some repos eg.jkd8u-aarch32-port use Lightweight tagging...
+        // Some repos eg.jdk8u-aarch32-port use Lightweight tagging...
         gaCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep -v '\\^{}' | grep \"${gaCheckTag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
     }
 

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -1018,7 +1018,7 @@ node('worker') {
         }
 
         // Slack message:
-        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        //slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
         echo 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }
@@ -1185,7 +1185,7 @@ node('worker') {
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
                 def fullMessage = "${featureRelease} EA: *${health}*. Build: ${releaseLink}.${failedTestSummary}${lastPublishedMsg}${errorMsg}${reproSummary}${missingMsg}"
                 echo "===> ${fullMessage}"
-                slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
+                //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }
             echo '----------------------------------------------------------------'
         }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -66,6 +66,7 @@ echo "TAG: "+tag
 
     def tagCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep '\\^{}' | grep \"${tag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
 
+echo "tagSHA:"+tagCommitSHA
     def gaCheckTag = "unknown"
     if (version.contains("jdk8u")) {
         if (tag.indexOf("-") > 0) {
@@ -81,10 +82,12 @@ echo "TAG: "+tag
         }
     }
     def gaCommitSHA = sh(returnStdout: true, script:"git ls-remote --tags ${openjdkRepo} | grep '\\^{}' | grep \"${gaCheckTag}\" | tr -s '\\t ' ' ' | cut -d' ' -f1 | tr -d '\\n'")
-
+echo "gaSHA:"+gaCommitSHA
     if (gaCommitSHA != "" && tagCommitSHA == gaCommitSHA) {
+echo "ISGA"
         return true
     } else {
+echo "NOTGA"
         return false
     }
 }

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -1035,7 +1035,7 @@ node('worker') {
         }
 
         // Slack message:
-        //slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
+        slackSend(channel: slackChannel, color: statusColor, message: 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>')
 
         echo 'Adoptium last 7 days Overall Build Success Rating : *' + variant + '* => *' + overallNightlySuccessRating + '* %\n  Build Job Rating: ' + totalBuildJobs + ' jobs (' + nightlyBuildSuccessRating.intValue() + '%)  Test Job Rating: ' + totalTestJobs + ' jobs (' + nightlyTestSuccessRating.intValue() + '%) <' + BUILD_URL + '/console|Detail>'
     }
@@ -1202,7 +1202,7 @@ node('worker') {
                 def releaseLink = "<" + status['assetsUrl'] + "|${releaseName}>"
                 def fullMessage = "${featureRelease} EA: *${health}*. Build: ${releaseLink}.${failedTestSummary}${lastPublishedMsg}${errorMsg}${reproSummary}${missingMsg}"
                 echo "===> ${fullMessage}"
-                //slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
+                slackSend(channel: slackChannel, color: slackColor, message: fullMessage)
             }
             echo '----------------------------------------------------------------'
         }


### PR DESCRIPTION
The daily slack EA build status incorrectly reports EA Build status just after GA releases, and also incorrectly determines
jdk8u-aarch32 EA build tags. The reason being because the recent build tag back search doesn't search past the GA tags...

- Corrected the EA asset search to skip GA builds
- Corrected the jdk8u-aarch32 GA tag comparison to work out the correct jdk8u-aarch32-port GA tags
- Corrected reported "build in-progress" status when current published build is the latest but it is missing assets...
- When reporting AQA test status and build is in-progress(Streaming) the completed AQA tests were not being reported for the in-progress build

Slack status from yesterday used this PR: https://adoptium.slack.com/archives/C09NW3L2J/p1738841633827389
