### PR TITLE
Update trigger_beta_build.groovy for Solaris to pass ENABLE_TESTS and DRY_RUN

### DIFF
--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -319,6 +319,8 @@ if (triggerMainBuild || triggerEvaluationBuild) {
                         jobParams = [
                             booleanParam(name: 'RELEASE',           value: false),
                             string(name: 'SCM_REF',                 value: "$latestAdoptTag"),
+                            booleanParam(name: 'ENABLE_TESTS',      value: enableTesting),
+                            booleanParam(name: 'DRY_RUN',           value: false)
                         ]
                     } else {
                         jobParams = [


### PR DESCRIPTION
jdk8u Solaris EA trigger needs to pass ENABLE_TESTS and DRY_RUN parms to the
jdk8u-solaris-arch-temurin-simplepipe jobs