### PR TITLE
jtreg.sh - use jdk11 instead of jdk-11

### DIFF
--- a/tools/code-tools/jtreg.sh
+++ b/tools/code-tools/jtreg.sh
@@ -57,50 +57,50 @@ buildJTReg()
     if [ "$1" == "$JTREG_5" ]; then
       export BUILD_NUMBER="b01"
       export BUILD_VERSION="5.1"
-      export JAVA_HOME=/usr/lib/jvm/java-1.8.0
+      export JAVA_HOME=/usr/lib/jvm/jdk8
     elif [ "$1" == "$JTREG_6" ]; then
       export JTREG_BUILD_NUMBER="1"
       export BUILD_VERSION="6"
-      export JAVA_HOME=/usr/lib/jvm/java-1.8.0
+      export JAVA_HOME=/usr/lib/jvm/jdk8
     elif [ "$1" == "$JTREG_6_1" ]; then
       export JTREG_BUILD_NUMBER="1"
       export BUILD_VERSION="6.1"
-      export JAVA_HOME=/usr/lib/jvm/java-1.8.0
+      export JAVA_HOME=/usr/lib/jvm/jdk8
     elif [ "$1" == "$JTREG_7" ]; then
       export JTREG_BUILD_NUMBER="1"
       export BUILD_VERSION="7"
-      export JAVA_HOME=/usr/lib/jvm/jdk-11
+      export JAVA_HOME=/usr/lib/jvm/jdk11
     elif [ "$1" == "$JTREG_7_1" ]; then
       export JTREG_BUILD_NUMBER="1"
       export BUILD_VERSION="7.1.1"
-      export JAVA_HOME=/usr/lib/jvm/jdk-11
+      export JAVA_HOME=/usr/lib/jvm/jdk11
     elif [ "$1" == "$JTREG_7_2" ]; then
       export JTREG_BUILD_NUMBER="1"
       export BUILD_VERSION="7.2"
-      export JAVA_HOME=/usr/lib/jvm/jdk-11
+      export JAVA_HOME=/usr/lib/jvm/jdk11
     elif [ "$1" == "$JTREG_7_3" ]; then
       export JTREG_BUILD_NUMBER="1"
       export BUILD_VERSION="7.3"
-      export JAVA_HOME=/usr/lib/jvm/jdk-11
+      export JAVA_HOME=/usr/lib/jvm/jdk11
     elif [ "$1" == "$JTREG_7_3_1" ]; then
       export JTREG_BUILD_NUMBER="1"
       export BUILD_VERSION="7.3.1"
-      export JAVA_HOME=/usr/lib/jvm/jdk-11
+      export JAVA_HOME=/usr/lib/jvm/jdk11
     elif [ "$1" == "$JTREG_7_4" ]; then
       export JTREG_BUILD_NUMBER="1"
       export BUILD_VERSION="7.4"
-      export JAVA_HOME=/usr/lib/jvm/jdk-11
+      export JAVA_HOME=/usr/lib/jvm/jdk11
     elif [ "$1" == "$JTREG_7_5" ]; then
       export JTREG_BUILD_NUMBER="1"
       export BUILD_VERSION="7.5"
-      export JAVA_HOME=/usr/lib/jvm/jdk-11
+      export JAVA_HOME=/usr/lib/jvm/jdk11
     fi
     git checkout $version
   else
     unset BUILD_NUMBER
     unset BUILD_VERSION
     unset JTREG_BUILD_NUMBER
-    export JAVA_HOME=/usr/lib/jvm/jdk-17
+    export JAVA_HOME=/usr/lib/jvm/jdk17
     git checkout master
   fi
 

--- a/tools/code-tools/temurin-sbom.sh
+++ b/tools/code-tools/temurin-sbom.sh
@@ -4,7 +4,7 @@ set -eu
 echo 'Starting build process...'
 export WORKSPACE="$WORKSPACE/temurin-sbom/cyclonedx-lib"
 cd "$WORKSPACE"
-export JAVA_HOME=/usr/lib/jvm/jdk-17
+export JAVA_HOME=/usr/lib/jvm/jdk17
 ant -f build.xml clean
 ant -f build.xml build-sign-sbom
 ant -f build.xml build


### PR DESCRIPTION
The dependencyPipeline job has been failing since November e.g. https://ci.adoptium.net/job/dependency_pipeline/1464/execution/node/161/log/?consoleFull
```
***********************************************
Building JTREG jtreg-7+1...
***********************************************
PATH: /usr/lib/jvm/jdk-11/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
JAVA_HOME: /usr/lib/jvm/jdk-11
Changing into /home/adoptopenjdk/workspace/dependency_pipeline/jtreg
Currently in /home/adoptopenjdk/workspace/dependency_pipeline/jtreg
Removing contents of build folder
[build.sh][INFO] CYGWIN_OR_MSYS=0
[build.sh][ERROR] '/usr/lib/jvm/jdk-11' is not a directory
```
This has resulted in the PR to [update to jtreg 7.1+1](https://github.com/adoptium/ci-jenkins-pipelines/pull/1186) to fail to go live.
The underlying reason for this appears to be because that job is utilising the adoptium build_image docker containers (which I wasn't aware of) and they were changed to use `jdkXX` instead of `jdk-XX` for the name of the JDK directory under `/usr/lib/jvm` for better compatibility with the upstream openjdk builds.

This PR adjusts the jtreg.sh script so that it uses the `jdkXX` paths without the hyphen.

Temporary test job with the fix: https://ci.adoptium.net/job/sxa-deppipe/1/execution/node/148/log/