### PR TITLE
Additional options for Temurin jck trigger

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -650,6 +650,7 @@ class Build {
                                                                     context.MapParameter(name: 'AUTO_AQA_GEN', value: "${aqaAutoGen}"),
                                                                     context.MapParameter(name: 'RERUN_ITERATIONS', value: "1"),
                                                                     context.MapParameter(name: 'RERUN_FAILURE', value: "true"),
+                                                                    context.MapParameter(name: 'EXTRA_OPTIONS', value: "-Djava.awt.headless=true"),
                                                                     context.MapParameter(name: 'SETUP_JCK_RUN', value: "${setupJCKRun}")]),
                             remoteJenkinsName: 'temurin-compliance',
                             shouldNotFailBuild: true,

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -642,16 +642,6 @@ class Build {
                         extra_app_options += " customJvmOpts=-Djava.net.preferIPv4Stack=true"
                     }
 
-                    def add_test_label = additionalTestLabel
-                    if ("${platform}" == 'aarch64_mac' && targetTests.contains('special.jck')) {
-                        // Workaround for https://github.com/adoptium/ci-jenkins-pipelines/issues/1195 aarch64 Mac until "label added" or fix found
-                        if (add_test_label == '') {
-                            add_test_label = 'esmv4-macos11-arm64'
-                        } else {
-                            add_test_label += '&&esmv4-macos11-arm64'
-                        }
-                    }
-
                     context.catchError {
                         remoteTriggeredBuilds["${targetTests}"] = context.triggerRemoteJob abortTriggeredJob: true,
                             blockBuildUntilComplete: false,
@@ -666,7 +656,7 @@ class Build {
                                                                     context.MapParameter(name: 'PLATFORMS', value: "${platform}"),
                                                                     context.MapParameter(name: 'PIPELINE_DISPLAY_NAME', value: "${displayName}"),
                                                                     context.MapParameter(name: 'APPLICATION_OPTIONS', value: "${appOptions} ${extra_app_options}"),
-                                                                    context.MapParameter(name: 'LABEL_ADDITION', value: add_test_label),
+                                                                    context.MapParameter(name: 'LABEL_ADDITION', value: additionalTestLabel),
                                                                     context.MapParameter(name: 'cause', value: "Remote triggered by job ${env.BUILD_URL}"), // Label is lowercase on purpose to map to the Jenkins target reporting system
                                                                     context.MapParameter(name: 'AUTO_AQA_GEN', value: "${aqaAutoGen}"),
                                                                     context.MapParameter(name: 'RERUN_ITERATIONS', value: "1"),

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -631,6 +631,27 @@ class Build {
                         parallel = 'Dynamic'
                         num_machines = '2'
                     }
+
+                    def extra_options = ""
+                    if ("${platform}" == 's390x_linux' && targetTests.contains('extended.jck')) {
+                        extra_options += " -Xss4m"
+                    }
+
+                    def extra_app_options = ""
+                    if ("${platform}" == 'ppc64_aix' && targetTests.contains('special.jck')) {
+                        extra_app_options += " customJvmOpts=-Djava.net.preferIPv4Stack=true"
+                    }
+
+                    def add_test_label = additionalTestLabel
+                    if ("${platform}" == 'aarch64_mac' && targetTests.contains('special.jck')) {
+                        // Workaround for https://github.com/adoptium/ci-jenkins-pipelines/issues/1195 aarch64 Mac until "label added" or fix found
+                        if (add_test_label == '') {
+                            add_test_label = 'esmv4-macos11-arm64'
+                        } else {
+                            add_test_label += '&&esmv4-macos11-arm64'
+                        }
+                    }
+
                     context.catchError {
                         remoteTriggeredBuilds["${targetTests}"] = context.triggerRemoteJob abortTriggeredJob: true,
                             blockBuildUntilComplete: false,
@@ -644,13 +665,13 @@ class Build {
                                                                     context.MapParameter(name: 'NUM_MACHINES', value: "${num_machines}"),
                                                                     context.MapParameter(name: 'PLATFORMS', value: "${platform}"),
                                                                     context.MapParameter(name: 'PIPELINE_DISPLAY_NAME', value: "${displayName}"),
-                                                                    context.MapParameter(name: 'APPLICATION_OPTIONS', value: "${appOptions}"),
-                                                                    context.MapParameter(name: 'LABEL_ADDITION', value: additionalTestLabel),
+                                                                    context.MapParameter(name: 'APPLICATION_OPTIONS', value: "${appOptions} ${extra_app_options}"),
+                                                                    context.MapParameter(name: 'LABEL_ADDITION', value: add_test_label),
                                                                     context.MapParameter(name: 'cause', value: "Remote triggered by job ${env.BUILD_URL}"), // Label is lowercase on purpose to map to the Jenkins target reporting system
                                                                     context.MapParameter(name: 'AUTO_AQA_GEN', value: "${aqaAutoGen}"),
                                                                     context.MapParameter(name: 'RERUN_ITERATIONS', value: "1"),
                                                                     context.MapParameter(name: 'RERUN_FAILURE', value: "true"),
-                                                                    context.MapParameter(name: 'EXTRA_OPTIONS', value: "-Djava.awt.headless=true"),
+                                                                    context.MapParameter(name: 'EXTRA_OPTIONS', value: "${extra_options}"),
                                                                     context.MapParameter(name: 'SETUP_JCK_RUN', value: "${setupJCKRun}")]),
                             remoteJenkinsName: 'temurin-compliance',
                             shouldNotFailBuild: true,


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1195

Add various extra options to resolve removal of temurin-compliance automanuals

Test builds:
- x64Linux : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-linux-x64-temurin/317/ - SUCCESS
- AIX : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-aix-ppc64-temurin/101/
  - TC build (with no excludes): temurin-compliance/job/AQA_Test_Pipeline/8051/  - SUCCESS (except for expected AWT)
- s390xLinux : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-linux-s390x-temurin/117/
  - TC build (with no excludes): temurin-compliance/job/AQA_Test_Pipeline/8053/ - SUCCESS

