### PR TITLE
Add riscv64Linux to regular weekly EA build config

### DIFF
--- a/pipelines/jobs/configurations/jdk17u.groovy
+++ b/pipelines/jobs/configurations/jdk17u.groovy
@@ -40,6 +40,9 @@ targetConfigurations = [
         ],
         'arm32Linux'  : [
                 'temurin'
+        ],
+        'riscv64Linux': [
+                'temurin'
         ]
 ]
 


### PR DESCRIPTION
riscv64Linux has been missing from jdk17u EA beta weekly builds as isn't in the jdk17u.groovy
