### PR TITLE
Prevent aarch64Mac extended tests running on osx12 node

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -649,12 +649,13 @@ class Build {
                     }
 
                     def additionalTestLabel_param = additionalTestLabel
-                    if ("${platform}" == 'aarch64_mac' && targetTests.contains('extended.jck')) {
-                        // extended java_awt tests won't all run on the osx12 node
+                    if ("${platform}" == 'aarch64_mac') {
+                        // extended java_awt tests won't all run on the osx12 node, split extended from sanity/special across nodes
+                        def osxLabel = (targetTests.contains('extended.jck')) ? '!sw.os.osx.12' : 'sw.os.osx.12'
                         if (additionalTestLabel_param == '') {
-                            additionalTestLabel_param = '!sw.os.osx.12'
+                            additionalTestLabel_param = "${osxLabel}"
                         } else {
-                            additionalTestLabel_param += '&&!sw.os.osx.12'
+                            additionalTestLabel_param += "&&${osxLabel}"
                         }
                     }
 

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -642,6 +642,16 @@ class Build {
                         extra_app_options += " customJvmOpts=-Djava.net.preferIPv4Stack=true"
                     }
 
+                    def additionalTestLabel_param = additionalTestLabel
+                    if ("${platform}" == 'aarch64_mac' && targetTests.contains('extended.jck')) {
+                        // extended java_awt tests won't all run on the osx12 node
+                        if (additionalTestLabel_param == '') {
+                            additionalTestLabel_param = '!sw.os.osx.12'
+                        } else {
+                            additionalTestLabel_param += '&&!sw.os.osx.12'
+                        }
+                    }
+
                     context.catchError {
                         remoteTriggeredBuilds["${targetTests}"] = context.triggerRemoteJob abortTriggeredJob: true,
                             blockBuildUntilComplete: false,
@@ -656,7 +666,7 @@ class Build {
                                                                     context.MapParameter(name: 'PLATFORMS', value: "${platform}"),
                                                                     context.MapParameter(name: 'PIPELINE_DISPLAY_NAME', value: "${displayName}"),
                                                                     context.MapParameter(name: 'APPLICATION_OPTIONS', value: "${appOptions} ${extra_app_options}"),
-                                                                    context.MapParameter(name: 'LABEL_ADDITION', value: additionalTestLabel),
+                                                                    context.MapParameter(name: 'LABEL_ADDITION', value: additionalTestLabel_param),
                                                                     context.MapParameter(name: 'cause', value: "Remote triggered by job ${env.BUILD_URL}"), // Label is lowercase on purpose to map to the Jenkins target reporting system
                                                                     context.MapParameter(name: 'AUTO_AQA_GEN', value: "${aqaAutoGen}"),
                                                                     context.MapParameter(name: 'RERUN_ITERATIONS', value: "1"),

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -607,6 +607,12 @@ class Build {
             targets['parallel'] = 'extended.jck'
         }
 
+        if ("${platform}" == 'aarch64_mac') {
+            // aarch64_mac runs extended.jck on !osx12, allow sanity&special to run on any
+            targets['serial']   = 'sanity.jck,special.jck'
+            targets['serial_extended'] = 'extended.jck' 
+        }
+
         /*
         Here we limit the win32 testing to the burstable nodes (a subset of the available windows nodes).
         This prevents win32 tests from occupying all the Windows nodes before we can test core platform win64.


### PR DESCRIPTION
TC aarch64Mac extended some java_awt tests will not run on the TC osx12 node, so prevent from running on that node.

Test build: https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-mac-aarch64-temurin/182/
