### PR TITLE
Build jtreg version 7.5.1+1

### DIFF
--- a/tools/code-tools/jtreg.sh
+++ b/tools/code-tools/jtreg.sh
@@ -2,7 +2,7 @@
 
 ###################################################################
 # Script to build jtreg test suite harness
-# currently builds tip, 5.1, 6, 6.1, 7, 7.1.1, 7.2, 7.3, 7.3.1, 7.4, 7.5
+# currently builds tip, 5.1, 6, 6.1, 7, 7.1.1, 7.2, 7.3, 7.3.1, 7.4, 7.5.1
 ###################################################################
 
 # shellcheck disable=SC2035,SC2116
@@ -18,7 +18,7 @@ readonly JTREG_7_2='jtreg-7.2+1'
 readonly JTREG_7_3='jtreg-7.3+1'
 readonly JTREG_7_3_1='jtreg-7.3.1+1'
 readonly JTREG_7_4='jtreg-7.4+1'
-readonly JTREG_7_5='jtreg-7.5+1'
+readonly JTREG_7_5_1='jtreg-7.5.1+1'
 
 function checkJdks() {
   jvm_dir="/usr/lib/jvm/"
@@ -90,9 +90,9 @@ buildJTReg()
       export JTREG_BUILD_NUMBER="1"
       export BUILD_VERSION="7.4"
       export JAVA_HOME=/usr/lib/jvm/jdk11
-    elif [ "$1" == "$JTREG_7_5" ]; then
+    elif [ "$1" == "$JTREG_7_5_1" ]; then
       export JTREG_BUILD_NUMBER="1"
-      export BUILD_VERSION="7.5"
+      export BUILD_VERSION="7.5.1"
       export JAVA_HOME=/usr/lib/jvm/jdk11
     fi
     git checkout $version
@@ -173,6 +173,6 @@ buildJTReg "$JTREG_7_2"
 buildJTReg "$JTREG_7_3"
 buildJTReg "$JTREG_7_3_1"
 buildJTReg "$JTREG_7_4"
-buildJTReg "$JTREG_7_5"
+buildJTReg "$JTREG_7_5_1"
 buildJTReg
 echo '...finished with build process.'


### PR DESCRIPTION
Corrects #1186, which should have built 7.5.1+1 instead of 7.5+1; see [8339238: Update to use jtreg 7.5.1](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/f644a9511ae32adbbeff77b211f82b8d42bdd62d).