### PR TITLE
Returns remote job URL including job number

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2577,6 +2577,7 @@ def buildScriptsAssemble(
                                                 sleep 3600
                                                 jobHandle.updateBuildStatus()
                                             }
+                                            context.println "Remote build URL " + jobHandle.getBuildUrl();
                                             setStageResult("${testTargets}", jobHandle.getBuildResult().toString());
                                         }
                                     }


### PR DESCRIPTION
Make it easy to track the remote triggered  jobs

