### PR TITLE
devkit patch for riscv64 Fedora 27/28

### DIFF
--- a/pipelines/build/devkit/Tools.gmk.patch
+++ b/pipelines/build/devkit/Tools.gmk.patch
@@ -30,7 +30,7 @@ index 249eaa66247..56e348b29b6 100644
          ifeq ($(wildcard $(DOWNLOAD_RPMS)/*.rpm), )
  	  cd $(DOWNLOAD_RPMS) && \
 -	      wget -r -np -nd $(patsubst %, -A "*%*.rpm", $(RPM_LIST)) $(BASE_URL)
-+	      tar xvpf /home/jenkins/download-rpmsF2728.tar
++	      curl https://ci.adoptium.net/userContent/devkit/download-rpmsF2728.riscv64.tar | tar xpvf -
          endif
  
  ################################################################################

--- a/pipelines/build/devkit/Tools.gmk.patch
+++ b/pipelines/build/devkit/Tools.gmk.patch
@@ -25,3 +25,12 @@ index 249eaa66247..56e348b29b6 100644
    binutils_ver := binutils-2.41
    ccache_ver := ccache-3.7.12
    mpfr_ver := mpfr-4.2.0
+@@ -251,7 +252,7 @@
+         # Only run this if rpm dir is empty.
+         ifeq ($(wildcard $(DOWNLOAD_RPMS)/*.rpm), )
+ 	  cd $(DOWNLOAD_RPMS) && \
+-	      wget -r -np -nd $(patsubst %, -A "*%*.rpm", $(RPM_LIST)) $(BASE_URL)
++	      tar xvpf /home/jenkins/download-rpmsF2728.tar
+         endif
+ 
+ ################################################################################

--- a/pipelines/build/devkit/Tools.gmk.patch
+++ b/pipelines/build/devkit/Tools.gmk.patch
@@ -1,142 +1,27 @@
-diff --git a/make/devkit/Tools.gmk b/make/devkit/Tools.gmk
-index 187320ca2..9f1454d5e 100644
+iff --git a/make/devkit/Tools.gmk b/make/devkit/Tools.gmk
+index 249eaa66247..56e348b29b6 100644
 --- a/make/devkit/Tools.gmk
 +++ b/make/devkit/Tools.gmk
-@@ -62,6 +62,19 @@ ifeq ($(BASE_OS), OL)
-     BASE_URL := http://yum.oracle.com/repo/OracleLinux/OL6/4/base/$(ARCH)/
-     LINUX_VERSION := OL6.4
+@@ -68,7 +68,8 @@ else ifeq ($(BASE_OS), Fedora)
+     BASE_OS_VERSION := $(DEFAULT_OS_VERSION)
    endif
-+else ifeq ($(BASE_OS), Centos)
-+  DEFAULT_OS_VERSION := 7
-+  ifeq ($(BASE_OS_VERSION), )
-+    BASE_OS_VERSION := $(DEFAULT_OS_VERSION)
-+  endif
-+  BASE_OS_MAJOR_VERSION := $(shell echo $(BASE_OS_VERSION) | cut -d'.' -f1)
-+  CENTOS_MIRROR := vault.centos.org
-+  ifeq ($(ARCH), x86_64)
-+    BASE_URL := http://$(CENTOS_MIRROR)/centos/$(BASE_OS_VERSION)/os/$(ARCH)/Packages/
-+  else
-+    BASE_URL := http://$(CENTOS_MIRROR)/altarch/$(BASE_OS_VERSION)/os/$(ARCH)/Packages/
-+  endif
-+  LINUX_VERSION := Centos$(BASE_OS_VERSION)
- else ifeq ($(BASE_OS), Fedora)
    ifeq ($(ARCH), riscv64)
-     DEFAULT_OS_VERSION := rawhide/68692
-@@ -87,6 +104,7 @@ else ifeq ($(BASE_OS), Fedora)
-       BASE_URL := https://archives.fedoraproject.org/pub/archive/$(FEDORA_TYPE)/releases/$(BASE_OS_VERSION)/Everything/$(ARCH)/os/Packages/
-     endif
-   endif
-+  BASE_OS_MAJOR_VERSION := $(shell echo $(BASE_OS_VERSION) | cut -d'.' -f1)
-   LINUX_VERSION := Fedora_$(BASE_OS_VERSION)
- else
-   $(error Unknown base OS $(BASE_OS))
-@@ -95,16 +113,39 @@ endif
- ##########################################################################################
+-    BASE_URL := http://fedora.riscv.rocks/repos-dist/f$(BASE_OS_VERSION)/latest/$(ARCH)/Packages/
++#    BASE_URL := http://fedora.riscv.rocks/repos-dist/f$(BASE_OS_VERSION)/latest/$(ARCH)/Packages/
++    BASE_URL := https://secondary.fedoraproject.org/pub/alt/risc-v/archive/RPMS/riscv64
+   else
+     LATEST_ARCHIVED_OS_VERSION := 35
+     ifeq ($(filter x86_64 armhfp, $(ARCH)), )
+@@ -92,9 +93,9 @@ endif
  # Define external dependencies
  
-+# Centos GPG KEYS
-+Centos_7_GPG_KEY_noarch := 6341AB2753D78A78A7C27BB124C6A8A7F4A80EB5  #gitleaks:allow
-+Centos_7_GPG_KEY_aarch64 := EF8F3CA66EFDF32B36CDADF76C7CB6EF305D49D6 #gitleaks:allow
-+Centos_7_GPG_KEY_x86_64 := 6341AB2753D78A78A7C27BB124C6A8A7F4A80EB5  #gitleaks:allow
-+Centos_7_GPG_KEY_ppc64le := BAFA3436FC50768E3C3C2E4EA963BBDBF533F4FA #gitleaks:allow
-+# Fedora GPG KEYS
-+Fedora_19_GPG_KEY_s390x := CA81B2C85E4F4D4A1A3F723407477E65FB4B18E6   #gitleaks:allow
-+
-+# PGP Signature file extensions
-+GCC_SIG := sig
-+BINUTILS_SIG := sig
-+CCACHE_SIG := asc
-+GMP_SIG := sig
-+MPC_SIG := sig
-+GDB_SIG := sig
-+
  # Latest that could be made to work.
- GCC_VER := 11.3.0
- ifeq ($(GCC_VER), 11.3.0)
-   gcc_ver := gcc-11.3.0
-+  GCC_GPG_KEY := 7F74F97C103468EE5D750B583AB00996FC26A641 #gitleaks:allow
-   binutils_ver := binutils-2.39
-+  BINUTILS_GPG_KEY := 3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F #gitleaks:allow
+-GCC_VER := 13.2.0
+-ifeq ($(GCC_VER), 13.2.0)
+-  gcc_ver := gcc-13.2.0
++GCC_VER := 14.2.0
++ifeq ($(GCC_VER), 14.2.0)
++  gcc_ver := gcc-14.2.0
+   binutils_ver := binutils-2.41
    ccache_ver := ccache-3.7.12
-+  CCACHE_GPG_KEY := 5A939A71A46792CF57866A51996DDA075594ADB8 #gitleaks:allow
-   mpfr_ver := mpfr-4.1.1
-+  MPFR_SHA256 := 85fdf11614cc08e3545386d6b9c8c9035e3db1e506211a45f4e108117fe3c951 #gitleaks:allow
-   gmp_ver := gmp-6.2.1
-+  GMP_GPG_KEY := 343C2FF0FBEE5EC2EDBEF399F3599FF828C67298 #gitleaks:allow
-   mpc_ver := mpc-1.2.1
-+  MPC_GPG_KEY := AD17A21EF8AED8F1CC02DBD9F7D5C9BF765C61E3 #gitleaks:allow
-   gdb_ver := gdb-11.2
-+  GDB_GPG_KEY := F40ADB902B24264AA42E50BF92EDB04BFF325CF3 #gitleaks:allow
-   REQUIRED_MIN_MAKE_MAJOR_VERSION := 4
- else ifeq ($(GCC_VER), 11.2.0)
-   gcc_ver := gcc-11.2.0
-@@ -246,7 +287,17 @@ download-rpms:
-         # Only run this if rpm dir is empty.
-         ifeq ($(wildcard $(DOWNLOAD_RPMS)/*.rpm), )
- 	  cd $(DOWNLOAD_RPMS) && \
--	      wget -r -np -nd $(patsubst %, -A "*%*.rpm", $(RPM_LIST)) $(BASE_URL)
-+	    wget -e robots=off -r -np -nd $(patsubst %, -A "*%*.rpm", $(RPM_LIST)) $(BASE_URL)
-+	  gpg --keyserver keyserver.ubuntu.com --recv-keys \
-+	    $($(BASE_OS)_$(BASE_OS_MAJOR_VERSION)_GPG_KEY_$(ARCH))
-+	  gpg --keyserver keyserver.ubuntu.com --recv-keys \
-+	    $($(BASE_OS)_$(BASE_OS_MAJOR_VERSION)_GPG_KEY_noarch)
-+	  rm -f $(DOWNLOAD_RPMS)/rpm.sig && gpg --armor --export \
-+	    $($(BASE_OS)_$(BASE_OS_MAJOR_VERSION)_GPG_KEY_$(ARCH)) > $(DOWNLOAD_RPMS)/rpm.sig
-+	  gpg --armor --export \
-+	    $($(BASE_OS)_$(BASE_OS_MAJOR_VERSION)_GPG_KEY_noarch) >> $(DOWNLOAD_RPMS)/rpm.sig
-+	  rpm --import $(DOWNLOAD_RPMS)/rpm.sig || true
-+	  rpm -K $(DOWNLOAD_RPMS)/*.rpm
-         endif
- 
- ##########################################################################################
-@@ -271,6 +322,14 @@ define Download
- 
-   $$($(1)_FILE) :
- 	wget -P $(DOWNLOAD) $$($(1))
-+        ifeq ($(1),MPFR)
-+	  echo $($(1)_SHA256) $$@ | sha256sum -c
-+        else
-+	  wget -P $(DOWNLOAD) $$($(1)).$($(1)_SIG)
-+	  gpg --keyserver keyserver.ubuntu.com --recv-keys $($(1)_GPG_KEY)
-+	  echo -e "5\ny\n" | gpg --batch --command-fd 0 --expert --edit-key $($(1)_GPG_KEY) trust;
-+	  gpg --verify $$@.$($(1)_SIG) $$@
-+        endif
- endef
- 
- # Download and unpack all source packages
-@@ -323,6 +382,9 @@ $(foreach p,$(RPM_FILE_LIST),$(eval $(call unrpm,$(p))))
- # have it anyway, but just to make sure...
- # Patch libc.so and libpthread.so to force linking against libraries in sysroot
- # and not the ones installed on the build machine.
-+# Remove comment sections from static libraries and C runtime objects
-+# to prevent leaking RHEL-specific package versions into
-+# devkit-produced binaries.
- $(libs) : $(rpms)
- 	@echo Patching libc and pthreads
- 	@(for f in `find $(SYSROOT) -name libc.so -o -name libpthread.so`; do \
-@@ -332,6 +394,7 @@ $(libs) : $(rpms)
- 	      -e 's|/lib/||g' ) > $$f.tmp ; \
- 	  mv $$f.tmp $$f ; \
- 	done)
-+	@find $(SYSROOT) -name '*.[ao]' -exec objcopy --remove-section .comment '{}' ';'
- 	@mkdir -p $(SYSROOT)/usr/lib
- 	@touch $@
- 
-@@ -440,6 +503,9 @@ endif
- 
- # Makefile creation. Simply run configure in build dir.
- # Setting CFLAGS to -O2 generates a much faster ld.
-+# Use --enable-deterministic-archives so that make targets that
-+# generate "ar" archives, such as "static-libs-image", produce
-+# deterministic .a files.
- $(bfdmakes) \
- $(BUILDDIR)/$(binutils_ver)/Makefile \
-     : $(BINUTILS_CFG)
-@@ -454,6 +520,7 @@ $(BUILDDIR)/$(binutils_ver)/Makefile \
- 	      --with-sysroot=$(SYSROOT) \
- 	      --disable-nls \
- 	      --program-prefix=$(TARGET)- \
-+	      --enable-deterministic-archives \
- 	      --enable-multilib \
- 	      --enable-threads \
- 	      --enable-plugins \
+   mpfr_ver := mpfr-4.2.0

--- a/pipelines/build/devkit/build_devkit.groovy
+++ b/pipelines/build/devkit/build_devkit.groovy
@@ -30,6 +30,7 @@ def build_devkit() {
     stage('Build DevKit') {
         // Make DevKit
         sh("cd pipelines/build/devkit && ./make_devkit.sh ${params.VERSION} ${params.ARCH} ${params.BASE_OS} ${params.BASE_OS_VERSION}")
+        sh("find pipelines/build/devkit -name log.build -type f -print | while read F; do echo ===== SXAEC: $F; cat $F; done")
 
         def devkit_target="${params.ARCH}-linux-gnu"
 

--- a/pipelines/build/devkit/build_devkit.groovy
+++ b/pipelines/build/devkit/build_devkit.groovy
@@ -114,7 +114,7 @@ def build() {
 }
 
 node(params.DEVKIT_BUILD_NODE) {
-  try {
+//  try {
     cleanWs notFailBuild: true, disableDeferredWipeout: true, deleteDirs: true
 
     if (params.DOCKER_IMAGE != "") { 
@@ -133,9 +133,9 @@ node(params.DEVKIT_BUILD_NODE) {
     } else {
         // Build directly on host
         build()
-    }
-  } finally { 
-    cleanWs notFailBuild: true
-  } 
+    } 
+//  } finally { 
+//    cleanWs notFailBuild: true
+//  } 
 }
 

--- a/pipelines/build/devkit/build_devkit.groovy
+++ b/pipelines/build/devkit/build_devkit.groovy
@@ -30,7 +30,8 @@ def build_devkit() {
     stage('Build DevKit') {
         // Make DevKit
         sh("cd pipelines/build/devkit && ./make_devkit.sh ${params.VERSION} ${params.ARCH} ${params.BASE_OS} ${params.BASE_OS_VERSION}")
-        sh("find pipelines/build/devkit -name log.build -type f -print | while read F; do echo ===== SXAEC: $F; cat $F; done")
+        // This needs to be single quotes (or backslash-escaped $) to work
+        sh('find pipelines/build/devkit -name log.build -type f -print | while read F; do echo ===== SXAEC: $F; cat $F; done')
 
         def devkit_target="${params.ARCH}-linux-gnu"
 

--- a/pipelines/build/devkit/make_devkit.sh
+++ b/pipelines/build/devkit/make_devkit.sh
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+# For Fedora see https://mirrormanager.fedoraproject.org/ for a lsit of versions/architectures
+
 
 set -e
 

--- a/pipelines/build/devkit/make_devkit.sh
+++ b/pipelines/build/devkit/make_devkit.sh
@@ -15,6 +15,7 @@
 # For Fedora see https://mirrormanager.fedoraproject.org/ for a lsit of versions/architectures
 
 
+set -x
 set -e
 
 if [ $# -lt 4 ]; then
@@ -58,7 +59,7 @@ if [ "${BASE_OS}" = "rhel" ] && [ "${ARCH}" = "s390x" ]; then
     fi
   done
   # Temporary fudge to use Centos logic until we adjust Tools.gmk
-  BASE_OS=Centos
+  # BASE_OS=Centos
 fi
 
 # Perform "bootstrap" devkit build
@@ -71,14 +72,14 @@ BOOTSTRAP_DEVKIT="$(pwd)/build/bootstrap_${devkit_target}-to-${devkit_target}"
 BOOTSTRAP_DOWNLOADED_RPMS="$(pwd)/build/bootstrap_rpms_${devkit_target}-to-${devkit_target}"
 
 mv build/devkit/result/${devkit_target}-to-${devkit_target} "${BOOTSTRAP_DEVKIT}"
-mv build/devkit/download/rpms/${ARCH}-linux-gnu-Centos${BASE_OS_VERSION} "${BOOTSTRAP_DOWNLOADED_RPMS}"
+mv build/devkit/download/rpms/${ARCH}-linux-gnu-Fedora-${BASE_OS_VERSION} "${BOOTSTRAP_DOWNLOADED_RPMS}"
 
 # Make final "DevKit" using the bootstrap devkit
 rm -rf build/devkit
 
 # Move saved bootstrap rpm downloads to final build folder
 mkdir -p build/devkit/download/rpms
-mv ${BOOTSTRAP_DOWNLOADED_RPMS} build/devkit/download/rpms/${ARCH}-linux-gnu-Centos${BASE_OS_VERSION}
+mv ${BOOTSTRAP_DOWNLOADED_RPMS} build/devkit/download/rpms/${ARCH}-linux-gnu-${BASE_OS}_${BASE_OS_VERSION}
 
 echo "Building 'final' DevKit toolchain, using 'bootstrap' toolchain in ${BOOTSTRAP_DEVKIT}"
 cd make/devkit && pwd && \

--- a/pipelines/build/devkit/make_devkit.sh
+++ b/pipelines/build/devkit/make_devkit.sh
@@ -71,15 +71,18 @@ cd ../..
 BOOTSTRAP_DEVKIT="$(pwd)/build/bootstrap_${devkit_target}-to-${devkit_target}"
 BOOTSTRAP_DOWNLOADED_RPMS="$(pwd)/build/bootstrap_rpms_${devkit_target}-to-${devkit_target}"
 
-mv build/devkit/result/${devkit_target}-to-${devkit_target} "${BOOTSTRAP_DEVKIT}"
-mv build/devkit/download/rpms/${ARCH}-linux-gnu-Fedora-${BASE_OS_VERSION} "${BOOTSTRAP_DOWNLOADED_RPMS}"
+echo SXAEC1ls -l 
+ls -l build/devkit/result
+ls -l build/devkit/download/rpms/
+mv -v build/devkit/result/${devkit_target}-to-${devkit_target} "${BOOTSTRAP_DEVKIT}"
+mv -v build/devkit/download/rpms/${ARCH}-linux-gnu-Fedora_${BASE_OS_VERSION} "${BOOTSTRAP_DOWNLOADED_RPMS}" || true
 
 # Make final "DevKit" using the bootstrap devkit
 rm -rf build/devkit
 
 # Move saved bootstrap rpm downloads to final build folder
 mkdir -p build/devkit/download/rpms
-echo SXAWC: PWD = $PWD
+echo SXAEC2: PWD = $PWD
 ls -ld build/devkit/download/rpms/${ARCH}-linux-gnu-${BASE_OS}_${BASE_OS_VERSION} || true
 ls -l ${BOOTSTRAP_DOWNLOADED_RPMS}  || true
 ls -l build/devkit/download/rpms || true

--- a/pipelines/build/devkit/make_devkit.sh
+++ b/pipelines/build/devkit/make_devkit.sh
@@ -79,7 +79,11 @@ rm -rf build/devkit
 
 # Move saved bootstrap rpm downloads to final build folder
 mkdir -p build/devkit/download/rpms
-mv ${BOOTSTRAP_DOWNLOADED_RPMS} build/devkit/download/rpms/${ARCH}-linux-gnu-${BASE_OS}_${BASE_OS_VERSION}
+echo SXAWC: PWD = $PWD
+ls -ld build/devkit/download/rpms/${ARCH}-linux-gnu-${BASE_OS}_${BASE_OS_VERSION} || true
+ls -l ${BOOTSTRAP_DOWNLOADED_RPMS}  || true
+ls -l build/devkit/download/rpms || true
+mv ${BOOTSTRAP_DOWNLOADED_RPMS} build/devkit/download/rpms/${ARCH}-linux-gnu-${BASE_OS}_${BASE_OS_VERSION} || true
 
 echo "Building 'final' DevKit toolchain, using 'bootstrap' toolchain in ${BOOTSTRAP_DEVKIT}"
 cd make/devkit && pwd && \


### PR DESCRIPTION
Draft as this MUST NOT BE MERGED AS-IS for now.

It's a patch on top of the jdk head release instead of jdk21 and is not compatible with the existing code being used for the CentOS devkits, but I'm creating this PR as a placeholder to demonstrate where we're looking to get to.

The job at https://ci.adoptium.net/job/build-scripts/job/utils/job/devkit/job/devkit-gcc-linux-riscv64 is running from this branch.