### PR TITLE
Fix Windows sha256 retrieval

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1436,11 +1436,12 @@ class Build {
                                             """.stripIndent(), returnStdout: true, returnStatus: false).replaceAll('\n', '')
             } else {
                 context.println "Windows detected - running bat to generate SHA256 sums in writeMetadata"
-                String hash_stdout = context.bat(script: "sha256sum ${file}", returnStdout: true, returnStatus: false)
-                // Windows batch returns stdout of <command invoked>\r\n<sha256sum output>\r\n
-                hash = hash_stdout.split('\r').last().replaceAll('\n', '').split(' ').first()
+                //String hash_stdout = context.bat(script: "sha256sum ${file}", returnStdout: true, returnStatus: false)
+                //// Windows batch returns stdout of <command invoked>\r\n<sha256sum output>\r\n
+                //hash = hash_stdout.split('\r').last().replaceAll('\n', '').split(' ').first()
+                hash = context.bat(script: "@sha256sum ${file}", returnStdout: true, returnStatus: false)
             }
-            context.println "archive sha256 = ${hash}"
+            context.println "archive sha256 = /${hash}/"
 
             data.binary_type = type
             data.sha256 = hash

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1436,8 +1436,9 @@ class Build {
                                             """.stripIndent(), returnStdout: true, returnStatus: false).replaceAll('\n', '')
             } else {
                 context.println "Windows detected - running bat to generate SHA256 sums in writeMetadata"
-                hash = context.bat(script: "sha256sum ${file} | cut -f1 -d' '") // .replaceAll('\n', '')
+                hash = context.bat(script: "sha256sum ${file} | cut -f1 -d' '", returnStdout: true, returnStatus: false).replaceAll('\n', '')
             }
+            context.println "archive sha256 = ${hash}"
 
             data.binary_type = type
             data.sha256 = hash

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1436,10 +1436,7 @@ class Build {
                                             """.stripIndent(), returnStdout: true, returnStatus: false).replaceAll('\n', '')
             } else {
                 context.println "Windows detected - running bat to generate SHA256 sums in writeMetadata"
-                //String hash_stdout = context.bat(script: "sha256sum ${file}", returnStdout: true, returnStatus: false)
-                //// Windows batch returns stdout of <command invoked>\r\n<sha256sum output>\r\n
-                //hash = hash_stdout.split('\r').last().replaceAll('\n', '').split(' ').first()
-                hash = context.bat(script: "@sha256sum ${file}", returnStdout: true, returnStatus: false)
+                hash = context.bat(script: "@sha256sum ${file}", returnStdout: true, returnStatus: false).split(' ').first()
             }
             context.println "archive sha256 = /${hash}/"
 

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1437,7 +1437,8 @@ class Build {
             } else {
                 context.println "Windows detected - running bat to generate SHA256 sums in writeMetadata"
                 String hash_stdout = context.bat(script: "sha256sum ${file}", returnStdout: true, returnStatus: false)
-                hash = hash_stdout.split('\r').last()
+                // Windows batch returns stdout of <command invoked>\r\n<sha256sum output>\r\n
+                hash = hash_stdout.split('\r').last().replaceAll('\n', '').split(' ').first()
             }
             context.println "archive sha256 = ${hash}"
 

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1436,11 +1436,9 @@ class Build {
                                             """.stripIndent(), returnStdout: true, returnStatus: false).replaceAll('\n', '')
             } else {
                 context.println "Windows detected - running bat to generate SHA256 sums in writeMetadata"
-                //String hash_stdout = context.bat(script: "sha256sum ${file}", returnStdout: true, returnStatus: false)
-                //// Windows batch returns stdout of <command invoked>\r\n<sha256sum output>\r\n
-                //hash = hash_stdout.split('\r').last().replaceAll('\n', '').split(' ').first()
-
-       hash = context.bat(script: "sha256sum ${file} | cut -f1 -d' '") // .replaceAll('\n', '')
+                String hash_stdout = context.bat(script: "sha256sum ${file}", returnStdout: true, returnStatus: false)
+                // Windows batch returns stdout of <command invoked>\r\n<sha256sum output>\r\n
+                hash = hash_stdout.split('\r').last().replaceAll('\n', '').split(' ').first()
             }
             context.println "archive sha256 = ${hash}"
 

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1436,7 +1436,8 @@ class Build {
                                             """.stripIndent(), returnStdout: true, returnStatus: false).replaceAll('\n', '')
             } else {
                 context.println "Windows detected - running bat to generate SHA256 sums in writeMetadata"
-                hash = context.bat(script: "sha256sum ${file} | cut -f2 -d'\r'", returnStdout: true, returnStatus: false).replaceAll('\n', '')
+                String hash_stdout = context.bat(script: "sha256sum ${file}", returnStdout: true, returnStatus: false)
+                hash = hash_stdout.split('\r').last()
             }
             context.println "archive sha256 = ${hash}"
 

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1446,12 +1446,12 @@ class Build {
             data.sha256 = hash
 
             // To save on spam, only print out the metadata the first time
-            //if (!metaWrittenOut && initialWrite) {
+            if (!metaWrittenOut && initialWrite) {
                 context.println '===METADATA OUTPUT==='
                 context.println JsonOutput.prettyPrint(JsonOutput.toJson(data.asMap()))
                 context.println '=/=METADATA OUTPUT=/='
                 metaWrittenOut = true
-            //}
+            }
 
             // Special handling for sbom metadata file (to be backwards compatible for api service)
             // from "*sbom<XXX>.json" to "*sbom<XXX>-metadata.json"

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1438,7 +1438,7 @@ class Build {
                 context.println "Windows detected - running bat to generate SHA256 sums in writeMetadata"
                 hash = context.bat(script: "@sha256sum ${file}", returnStdout: true, returnStatus: false).split(' ').first()
             }
-            context.println "archive sha256 = /${hash}/"
+            context.println "archive sha256 = ${hash}"
 
             data.binary_type = type
             data.sha256 = hash

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1436,9 +1436,11 @@ class Build {
                                             """.stripIndent(), returnStdout: true, returnStatus: false).replaceAll('\n', '')
             } else {
                 context.println "Windows detected - running bat to generate SHA256 sums in writeMetadata"
-                String hash_stdout = context.bat(script: "sha256sum ${file}", returnStdout: true, returnStatus: false)
-                // Windows batch returns stdout of <command invoked>\r\n<sha256sum output>\r\n
-                hash = hash_stdout.split('\r').last().replaceAll('\n', '').split(' ').first()
+                //String hash_stdout = context.bat(script: "sha256sum ${file}", returnStdout: true, returnStatus: false)
+                //// Windows batch returns stdout of <command invoked>\r\n<sha256sum output>\r\n
+                //hash = hash_stdout.split('\r').last().replaceAll('\n', '').split(' ').first()
+
+       hash = context.bat(script: "sha256sum ${file} | cut -f1 -d' '") // .replaceAll('\n', '')
             }
             context.println "archive sha256 = ${hash}"
 
@@ -1446,12 +1448,12 @@ class Build {
             data.sha256 = hash
 
             // To save on spam, only print out the metadata the first time
-            if (!metaWrittenOut && initialWrite) {
+            //if (!metaWrittenOut && initialWrite) {
                 context.println '===METADATA OUTPUT==='
                 context.println JsonOutput.prettyPrint(JsonOutput.toJson(data.asMap()))
                 context.println '=/=METADATA OUTPUT=/='
                 metaWrittenOut = true
-            }
+            //}
 
             // Special handling for sbom metadata file (to be backwards compatible for api service)
             // from "*sbom<XXX>.json" to "*sbom<XXX>-metadata.json"

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1436,7 +1436,7 @@ class Build {
                                             """.stripIndent(), returnStdout: true, returnStatus: false).replaceAll('\n', '')
             } else {
                 context.println "Windows detected - running bat to generate SHA256 sums in writeMetadata"
-                hash = context.bat(script: "sha256sum ${file} | cut -f1 -d' '", returnStdout: true, returnStatus: false).replaceAll('\n', '')
+                hash = context.bat(script: "sha256sum ${file} | cut -f2 -d'\r'", returnStdout: true, returnStatus: false).replaceAll('\n', '')
             }
             context.println "archive sha256 = ${hash}"
 


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/4139

Windows metadata sha256 context.bat() was missing returnStdOut options and needs processing for bat output.

Test build: https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-windows-x64-temurin/271/ -
```
...
```
