### PR TITLE
Do dont query remote triggered job status if anything wrong

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2573,10 +2573,10 @@ def buildScriptsAssemble(
                                 if (buildConfig.VARIANT == 'temurin' && enableTCK && remoteTriggeredBuilds.asBoolean()) {
                                     remoteTriggeredBuilds.each{ testTargets, jobHandle -> 
                                         context.stage("${testTargets}") {
-                                            // NOT_TRIGGERED is not a valid StageResult value. Map it to NOT_BUILT
-                                            def remoteJobStatus = "NOT_BUILT"
+                                            def remoteJobStatus
                                             if (jobHandle == null || jobHandle.getBuildStatus().toString().equals("NOT_TRIGGERED")) {
                                                 context.println "Failed, remote job ${testTargets} was not triggered"
+                                                remoteJobStatus = "FAILURE"
                                             } else {
                                                 while( !jobHandle.isFinished() ) {
                                                     context.println "Current ${testTargets} Status: " + jobHandle.getBuildStatus().toString();

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2575,7 +2575,9 @@ def buildScriptsAssemble(
                                         context.stage("${testTargets}") {
                                             // NOT_TRIGGERED is not a valid StageResult value. Map it to NOT_BUILT
                                             def remoteJobStatus = "NOT_BUILT"
-                                            if ( !jobHandle.getBuildStatus().toString().equals("NOT_TRIGGERED") ) {
+                                            if (jobHandle == null || jobHandle.getBuildStatus().toString().equals("NOT_TRIGGERED")) {
+                                                context.println "Failed, remote job ${testTargets} was not triggered"
+                                            } else {
                                                 while( !jobHandle.isFinished() ) {
                                                     context.println "Current ${testTargets} Status: " + jobHandle.getBuildStatus().toString();
                                                     sleep 3600000

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2573,6 +2573,7 @@ def buildScriptsAssemble(
                                 if (buildConfig.VARIANT == 'temurin' && enableTCK && remoteTriggeredBuilds.asBoolean()) {
                                     remoteTriggeredBuilds.each{ testTargets, jobHandle -> 
                                         context.stage("${testTargets}") {
+                                            // NOT_TRIGGERED is not a valid StageResult value. Map it to NOT_BUILD
                                             def remoteJobStatus = "NOT_BUILD"
                                             if ( !jobHandle.getBuildStatus().toString().equals("NOT_TRIGGERED") ) {
                                                 while( !jobHandle.isFinished() ) {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2573,8 +2573,8 @@ def buildScriptsAssemble(
                                 if (buildConfig.VARIANT == 'temurin' && enableTCK && remoteTriggeredBuilds.asBoolean()) {
                                     remoteTriggeredBuilds.each{ testTargets, jobHandle -> 
                                         context.stage("${testTargets}") {
-                                            // NOT_TRIGGERED is not a valid StageResult value. Map it to NOT_BUILD
-                                            def remoteJobStatus = "NOT_BUILD"
+                                            // NOT_TRIGGERED is not a valid StageResult value. Map it to NOT_BUILT
+                                            def remoteJobStatus = "NOT_BUILT"
                                             if ( !jobHandle.getBuildStatus().toString().equals("NOT_TRIGGERED") ) {
                                                 while( !jobHandle.isFinished() ) {
                                                     context.println "Current ${testTargets} Status: " + jobHandle.getBuildStatus().toString();


### PR DESCRIPTION
Stop query not triggered remote jobs due to any failures and stop RemoteTrigger for tip_version

Fix #1209 