### PR TITLE
Windows TCK tests for JDK24 and up must run in headful mode

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -648,6 +648,10 @@ class Build {
                         extra_app_options += " customJvmOpts=-Djava.net.preferIPv4Stack=true"
                     }
 
+                    if (platform.contains("windows") && jdkVersion >= 24) {
+                        extra_app_options += " customJvmOpts=-Djava.awt.headless=false"
+                    }
+
                     def additionalTestLabel_param = additionalTestLabel
                     if ("${platform}" == 'aarch64_mac') {
                         // extended java_awt tests won't all run on the osx12 node, split extended from sanity/special across nodes


### PR DESCRIPTION
Explicitly.

Reasons detailed here: https://github.com/temurin-compliance/temurin-compliance/issues/717