### PR TITLE
Add jdk24u weekly build schedule

### DIFF
--- a/pipelines/jobs/configurations/jdk24u.groovy
+++ b/pipelines/jobs/configurations/jdk24u.groovy
@@ -38,6 +38,9 @@ targetConfigurations = [
         ]
 ]
 
+// 12:05 Sat - Weekend schedule for Oracle managed jdk24u.groovy version that has no published tags
+triggerSchedule_weekly  = 'TZ=UTC\n05 12 * * 6'
+
 // scmReferences to use for weekly release build
 weekly_release_scmReferences = [
         'hotspot'        : '',


### PR DESCRIPTION
jdk24u weekly builds should be been scheduled as Oracle managed with no published tags
