### PR TITLE
Fix metadata for jmods archives

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1433,6 +1433,8 @@ class Build {
                 type = 'sources'
             } else if (file.contains('-sbom')) {
                 type = 'sbom'
+            } else if (file.contains('-jmods')) {
+                type = 'jmods'
             }
             context.println "writeMetaData for " + file
 


### PR DESCRIPTION
https://github.com/adoptium/temurin-build/pull/4157 introduced archiving of the JMDOs image, but missed updating the metadata type for those archives which default to 'jdk'.

Related: https://github.com/adoptium/api.adoptium.net/issues/1480