### PR TITLE
Remove burstable tag requirement from non-release testing

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -616,8 +616,10 @@ class Build {
         /*
         Here we limit the win32 testing to the burstable nodes (a subset of the available windows nodes).
         This prevents win32 tests from occupying all the Windows nodes before we can test core platform win64.
+        However, we will not add this tag during non-release builds, as overall throughput will be more 
+        important than priority order.
         */
-        if ("${platform}" == 'x86-32_windows') {
+        if ("${platform}" == 'x86-32_windows' && Boolean.valueOf(buildConfig.RELEASE)) {
             context.println "Windows 32bit JCK tests need the extra label hw.cpu.burstable"
             if (additionalTestLabel == '') {
                 additionalTestLabel = 'hw.cpu.burstable'


### PR DESCRIPTION
...because priority order is important during releases, but overall throughput matters more for routine beta builds.

This is being tested here: https://ci.adoptium.net/job/build-scripts/job/openjdk11-pipeline/2754/