### PR TITLE
use GCC14/Fedora 28 devkit for riscv64 JDK25 builds

### DIFF
--- a/pipelines/jobs/configurations/jdk25_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk25_pipeline_config.groovy
@@ -160,7 +160,7 @@ class Config25 {
                 test                : 'default',
                 configureArgs       : '--enable-headless-only=yes --enable-dtrace',
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom'
+                        'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit gcc-14.2.0-Fedora_28-b00'
                 ]
         ],
 


### PR DESCRIPTION
The build images now have a devkit for RISC-V based on a GCC14 compiler and the Fedora 27/28 RPMs. This enables it for JDK25 as an initial test with the intention of using it for earlier versions afterwards.

Fixes https://github.com/adoptium/infrastructure/issues/3637 