### PR TITLE
Also build jtreg version 7.5.2+1

### DIFF
--- a/tools/code-tools/jtreg.sh
+++ b/tools/code-tools/jtreg.sh
@@ -19,6 +19,7 @@ readonly JTREG_7_3='jtreg-7.3+1'
 readonly JTREG_7_3_1='jtreg-7.3.1+1'
 readonly JTREG_7_4='jtreg-7.4+1'
 readonly JTREG_7_5_1='jtreg-7.5.1+1'
+readonly JTREG_7_5_2='jtreg-7.5.2+1'
 
 function checkJdks() {
   jvm_dir="/usr/lib/jvm/"
@@ -93,6 +94,10 @@ buildJTReg()
     elif [ "$1" == "$JTREG_7_5_1" ]; then
       export JTREG_BUILD_NUMBER="1"
       export BUILD_VERSION="7.5.1"
+      export JAVA_HOME=/usr/lib/jvm/jdk11
+    elif [ "$1" == "$JTREG_7_5_2" ]; then
+      export JTREG_BUILD_NUMBER="1"
+      export BUILD_VERSION="7.5.2"
       export JAVA_HOME=/usr/lib/jvm/jdk11
     fi
     git checkout $version
@@ -174,5 +179,6 @@ buildJTReg "$JTREG_7_3"
 buildJTReg "$JTREG_7_3_1"
 buildJTReg "$JTREG_7_4"
 buildJTReg "$JTREG_7_5_1"
+buildJTReg "$JTREG_7_5_2"
 buildJTReg
 echo '...finished with build process.'


### PR DESCRIPTION
Necessitated by openjdk change
* [8357141: Update to use jtreg 7.5.2](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/3cba84f2497cab7f450099b25c3418202a5e1972)