### PR TITLE
Asmtools 9 now built by jdk21 and added build of asmtools8

### DIFF
--- a/tools/code-tools/asmtools.sh
+++ b/tools/code-tools/asmtools.sh
@@ -94,6 +94,7 @@ function detectJdks() {
   find ${jvm_dir} -maxdepth 1 | sort | grep -e java-17-     -e jdk-17
   jdk08=$(readlink -f $(find ${jvm_dir} -maxdepth 1 | sort | grep -e java-1.8.0-  -e jdk-8   | head -n 1))
   jdk17=$(readlink -f $(find ${jvm_dir} -maxdepth 1 | sort | grep -e java-17-     -e jdk-17  | head -n 1))
+  jdk21=$(readlink -f $(find ${jvm_dir} -maxdepth 1 | sort | grep -e java-21-     -e jdk-21  | head -n 1))
 }
 
 function getProperty() {
@@ -119,17 +120,23 @@ detectJdks
 pushd $REPO_DIR
   RESULTS_DIR="$(pwd)"
   latestRelease=$(git tag -l | tail -n 2 | head -n 1)
-  generateArtifact "master" "$jdk17"
+  generateArtifact "master" "$jdk21"
   masterVersion=$(getVersion)
+  generateArtifact "8.0-b09" "$jdk17"
+  at8Version=$(getVersion)
   generateArtifact "at7" "$jdk08"
   at7Version=$(getVersion)
   renameLegacyCoreArtifacts
   releaseCandidate7=asmtools-core-$at7Version.jar
   releaseName7=asmtools07.jar
+  releaseCandidate8=asmtools-$at8Version.jar
+  releaseName8=asmtools08.jar
   releaseCandidate=asmtools-$masterVersion.jar
   releaseName=asmtools.jar
   echo "Manually renaming  $releaseCandidate7 as $releaseName7 to provide latest-7-stable-recommended file"
   ln -fv $releaseCandidate7 $releaseName7
+  echo "Manually renaming  $releaseCandidate8 as $releaseName8 to provide latest-8-stable-recommended file"
+  ln -fv $releaseCandidate8 $releaseName8
   echo "Manually renaming  $releaseCandidate as $releaseName to provide latest-stable-recommended file"
   ln -fv $releaseCandidate $releaseName
   hashArtifacts

--- a/tools/code-tools/asmtools.sh
+++ b/tools/code-tools/asmtools.sh
@@ -92,6 +92,8 @@ function detectJdks() {
   find ${jvm_dir} -maxdepth 1 | sort | grep -e java-1.8.0-  -e jdk-8
   echo "Available jdks 17 in ${jvm_dir}:"
   find ${jvm_dir} -maxdepth 1 | sort | grep -e java-17-     -e jdk-17
+  echo "Available jdks 21 in ${jvm_dir}:"
+  find ${jvm_dir} -maxdepth 1 | sort | grep -e java-21-     -e jdk-21
   jdk08=$(readlink -f $(find ${jvm_dir} -maxdepth 1 | sort | grep -e java-1.8.0-  -e jdk-8   | head -n 1))
   jdk17=$(readlink -f $(find ${jvm_dir} -maxdepth 1 | sort | grep -e java-17-     -e jdk-17  | head -n 1))
   jdk21=$(readlink -f $(find ${jvm_dir} -maxdepth 1 | sort | grep -e java-21-     -e jdk-21  | head -n 1))


### PR DESCRIPTION
this should fix remaining issue in currently failing dependency pipeline: https://github.com/adoptium/ci-jenkins-pipelines/issues/1231

I think I still can not run dependency pipeline in grinder.