### PR TITLE
Print also jdk21 in asmtools build

### DIFF
--- a/tools/code-tools/asmtools.sh
+++ b/tools/code-tools/asmtools.sh
@@ -92,6 +92,8 @@ function detectJdks() {
   find ${jvm_dir} -maxdepth 1 | sort | grep -e java-1.8.0-  -e jdk-8
   echo "Available jdks 17 in ${jvm_dir}:"
   find ${jvm_dir} -maxdepth 1 | sort | grep -e java-17-     -e jdk-17
+  echo "Available jdks 21 in ${jvm_dir}:"
+  find ${jvm_dir} -maxdepth 1 | sort | grep -e java-21-     -e jdk-21
   jdk08=$(readlink -f $(find ${jvm_dir} -maxdepth 1 | sort | grep -e java-1.8.0-  -e jdk-8   | head -n 1))
   jdk17=$(readlink -f $(find ${jvm_dir} -maxdepth 1 | sort | grep -e java-17-     -e jdk-17  | head -n 1))
   jdk21=$(readlink -f $(find ${jvm_dir} -maxdepth 1 | sort | grep -e java-21-     -e jdk-21  | head -n 1))


### PR DESCRIPTION
In https://github.com/adoptium/ci-jenkins-pipelines/pull/1232, jdk21 printing escaped my eye.

I would probably not bothr with this addition,  but it seems the pipeline is stillnot fixed. From what I see, it still pulls the old code. Merging this info will prove that.  It still dies in master, with same code/source level exception. I'm moreover sure,  but as the scritp is run without -x (by order),  It is jsut 99%