### PR TITLE
Retry logic for Test_Job_Auto_Gen

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -478,10 +478,10 @@ class Build {
                                 }
                                 context.println "Use Test_Job_Auto_Gen to generate AQA test job with parameters: ${updatedParams}"
                                 context.catchError {
-                                    context.retry(count: 2) {
+                                    context.retry(count: 3) {
 									    try {
                                             context.build job: 'Test_Job_Auto_Gen_typo', propagate: false, parameters: updatedParams
-                                        } catch(e) {
+                                        } catch(Error e) {
 										    sleep(300)
 										    throw e
 									    }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -478,14 +478,26 @@ class Build {
                                 }
                                 context.println "Use Test_Job_Auto_Gen to generate AQA test job with parameters: ${updatedParams}"
                                 context.catchError {
-                                    context.retry(count: 3) {
-									    try {
-                                            context.build job: 'Test_Job_Auto_Gen_typo', propagate: false, parameters: updatedParams
-                                        } catch(Error e) {
-										    sleep(300)
-										    throw e
-									    }
-                                    }
+                                    int x = 3
+                                    while ( x > 0 ) {
+										x--
+										def autogen_result = "BLANK"
+										try {
+                                            def testJob = context.build job: 'Test_Job_Auto_Gen_typo', propagate: false, parameters: updatedParams
+                                            autogen_result = testJob.getResult()
+                                        } catch ( Error e ) {
+											if (x == 0) {
+												throw e
+											}
+										    autogen_result = "Error"
+										    context.println e.toString()
+									    } finally {
+											if ( !autogen_result.equals("SUCCESS") && x > 0 ) {
+												context.println "This script will now pause for 5 minutes before retrying."
+												sleep(300)
+											}
+										}
+									}
                                 }
                             } else {
                                 context.node('worker') {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -481,7 +481,7 @@ class Build {
                                 context.catchError {
                                     retry(count: 2) {
 									    try {
-                                            context.build job: 'Test_Job_Auto_Gen', propagate: false, parameters: updatedParams
+                                            context.build job: 'Test_Job_Auto_Gen_typo', propagate: false, parameters: updatedParams
                                         } catch(e) {
 										    sleep(300)
 										    throw e

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -459,7 +459,6 @@ class Build {
                             vendorTestBranches = buildConfig.BUILD_REF ?: vendorTestBranches
                         }
 
-
                         String helperRef = buildConfig.HELPER_REF ?: DEFAULTS_JSON['repository']['helper_ref']
                         def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${helperRef}").JobHelper
 
@@ -479,7 +478,7 @@ class Build {
                                 }
                                 context.println "Use Test_Job_Auto_Gen to generate AQA test job with parameters: ${updatedParams}"
                                 context.catchError {
-                                    retry(count: 2) {
+                                    context.retry(count: 2) {
 									    try {
                                             context.build job: 'Test_Job_Auto_Gen_typo', propagate: false, parameters: updatedParams
                                         } catch(e) {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -477,27 +477,20 @@ class Build {
                                     }
                                 }
                                 context.println "Use Test_Job_Auto_Gen to generate AQA test job with parameters: ${updatedParams}"
-                                context.catchError {
-                                    int x = 3
-                                    while ( x > 0 ) {
-										x--
-										def autogen_result = "BLANK"
-										try {
-                                            def testJob = context.build job: 'Test_Job_Auto_Gen_typo', propagate: false, parameters: updatedParams
-                                            autogen_result = testJob.getResult()
-                                        } catch ( Error e ) {
-											if (x == 0) {
-												throw e
-											}
-										    autogen_result = "Error"
-										    context.println e.toString()
-									    } finally {
-											if ( !autogen_result.equals("SUCCESS") && x > 0 ) {
-												context.println "This script will now pause for 5 minutes before retrying."
-												sleep(5*60*1000)
-											}
-										}
-									}
+                                int x = 3
+                                while ( x > 0 ) {
+                                    x--
+                                    def autogen_result = "BLANK"
+                                    context.catchError {
+                                        def testJob = context.build job: 'Test_Job_Auto_Gen_typo', propagate: false, parameters: updatedParams
+                                        autogen_result = testJob.getResult()
+                                    }
+                                    if ( !autogen_result.equals("SUCCESS") && x > 0 ) {
+                                        context.println "This script will now pause for 5 minutes before retrying."
+                                        sleep(5*60*1000)
+                                    } else {
+                                        break
+                                    }
                                 }
                             } else {
                                 context.node('worker') {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -479,7 +479,14 @@ class Build {
                                 }
                                 context.println "Use Test_Job_Auto_Gen to generate AQA test job with parameters: ${updatedParams}"
                                 context.catchError {
-                                    context.build job: 'Test_Job_Auto_Gen', propagate: false, parameters: updatedParams
+                                    retry(count: 2) {
+									    try {
+                                            context.build job: 'Test_Job_Auto_Gen', propagate: false, parameters: updatedParams
+                                        } catch(e) {
+										    sleep(300)
+										    throw e
+									    }
+                                    }
                                 }
                             } else {
                                 context.node('worker') {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -477,17 +477,18 @@ class Build {
                                     }
                                 }
                                 context.println "Use Test_Job_Auto_Gen to generate AQA test job with parameters: ${updatedParams}"
-                                int x = 3
-                                while ( x > 0 ) {
-                                    x--
-                                    def autogen_result = "BLANK"
+                                int autogenBuildAttempts = 3
+                                int autogenRetryDelayInMins = 5
+                                while ( autogenBuildAttempts > 0 ) {
+                                    autogenBuildAttempts--
+                                    def autogenResult = "BLANK"
                                     context.catchError {
                                         def testJob = context.build job: 'Test_Job_Auto_Gen', propagate: false, parameters: updatedParams
-                                        autogen_result = testJob.getResult()
+                                        autogenResult = testJob.getResult()
                                     }
-                                    if ( !autogen_result.equals("SUCCESS") && x > 0 ) {
-                                        context.println "This script will now pause for 5 minutes before retrying."
-                                        sleep(5*60*1000)
+                                    if ( !autogenResult.equals("SUCCESS") && autogenBuildAttempts > 0 ) {
+                                        context.println "This script will now pause for ${autogenRetryDelayInMins} minutes before retrying."
+                                        sleep(autogenRetryDelayInMins*60*1000)
                                     } else {
                                         break
                                     }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -494,7 +494,7 @@ class Build {
 									    } finally {
 											if ( !autogen_result.equals("SUCCESS") && x > 0 ) {
 												context.println "This script will now pause for 5 minutes before retrying."
-												sleep(300)
+												sleep(5*60*1000)
 											}
 										}
 									}

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -482,7 +482,7 @@ class Build {
                                     x--
                                     def autogen_result = "BLANK"
                                     context.catchError {
-                                        def testJob = context.build job: 'Test_Job_Auto_Gen_typo', propagate: false, parameters: updatedParams
+                                        def testJob = context.build job: 'Test_Job_Auto_Gen', propagate: false, parameters: updatedParams
                                         autogen_result = testJob.getResult()
                                     }
                                     if ( !autogen_result.equals("SUCCESS") && x > 0 ) {


### PR DESCRIPTION
Latest test: https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-windows-x64-temurin/297

Note: I added a deliberate typo to the Test_Job_Auto_Gen job name (in the code tested above) to force the retry logic. 

Must remove the typo prior to merging. - Done