### PR TITLE
Accommodate suffixes in aarch64 windows openjdk-build dir name

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1834,7 +1834,12 @@ def buildScriptsAssemble(
       try {
         // This would ideally not be required but it's due to lack of UID mapping in windows containers
         if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE) {
-            context.bat('chmod -R a+rwX ' + '/cygdrive/c/workspace/openjdk-build*/workspace/build/src/build/*')
+			def cygwin_workspace = context.WORKSPACE
+			if ( !cygwin_workspace.startsWith("/cygdrive") ) {
+				cygwin_workspace = "/cygdrive/c" + cygwin_workspace.substring(2)
+			}
+			
+            context.bat('chmod -R a+rwX ' + cygwin_workspace + '/workspace/build/src/build/*')
         }
         // Restore signed JMODs
         context.unstash 'signed_jmods'

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1834,7 +1834,7 @@ def buildScriptsAssemble(
       try {
         // This would ideally not be required but it's due to lack of UID mapping in windows containers
         if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE) {
-            context.bat('chmod -R a+rwX ' + '/cygdrive/c/workspace/openjdk-build/workspace/build/src/build/*')
+            context.bat('chmod -R a+rwX ' + '/cygdrive/c/workspace/openjdk-build*/workspace/build/src/build/*')
         }
         // Restore signed JMODs
         context.unstash 'signed_jmods'

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1838,7 +1838,6 @@ def buildScriptsAssemble(
 			if ( !cygwin_workspace.startsWith("/cygdrive") ) {
 				cygwin_workspace = "/cygdrive/c" + cygwin_workspace.substring(2)
 			}
-			
             context.bat('chmod -R a+rwX ' + cygwin_workspace + '/workspace/build/src/build/*')
         }
         // Restore signed JMODs

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1834,10 +1834,11 @@ def buildScriptsAssemble(
       try {
         // This would ideally not be required but it's due to lack of UID mapping in windows containers
         if ( buildConfig.TARGET_OS == 'windows' && buildConfig.DOCKER_IMAGE) {
-			def cygwin_workspace = context.WORKSPACE
-			if ( !cygwin_workspace.startsWith("/cygdrive") ) {
-				cygwin_workspace = "/cygdrive/c" + cygwin_workspace.substring(2)
-			}
+            def cygwin_workspace = context.WORKSPACE
+            if ( !cygwin_workspace.startsWith("/cygdrive") ) {
+                // Where cygwin_workspace is expected to be something like: C:/workspace/openjdk-build
+                cygwin_workspace = "/cygdrive/" + cygwin_workspace.toLowerCase().charAt(0) + cygwin_workspace.substring(2)
+            }
             context.bat('chmod -R a+rwX ' + cygwin_workspace + '/workspace/build/src/build/*')
         }
         // Restore signed JMODs


### PR DESCRIPTION
This platform can include @2 in that dir name, and I wouldn't rule out other ints, so this covers all possibilities.

Testing: https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-windows-aarch64-temurin/78/