### PR TITLE
Fix typo causing dev.jck remote trigger to fail on Windows

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -706,7 +706,7 @@ class Build {
                         SETUP_JCK_RUN: "${setupJCKRun}"
                     ]
                     if ("${platform}" == 'x86-64_windows' && "${targetTests}" == 'dev.jck') {
-                        paramlist["LABEL"] = 'ci.role.test.interactive'
+                        paramList["LABEL"] = 'ci.role.test.interactive'
                     }
                     def queryString = paramList.collect { k, v -> "${URLEncoder.encode(k, 'UTF-8')}=${URLEncoder.encode(v, 'UTF-8')}"}.join('&')
                     def aqa_test_pipeline_FullURL = "${aqa_test_pipeline_BaseURL}?${queryString}&MODE=RELAY"


### PR DESCRIPTION
This is a port of #1245 to the release branch.
This typo caused the remote trigger for the dev.jck job to fail, which apparently blocks the entire AQA suite from running, so this urgently needs to get in so we can start the pipelines again from scratch.

e.g. 
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/release/job/jobs/job/jdk21u/job/jdk21u-release-windows-x64-temurin/24/

Although I note that the Windows/arm pipelines appear to be progressing ok and has initiated the JCK jobs:
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/release/job/jobs/job/jdk24u/job/jdk24u-release-windows-aarch64-temurin/4/
