### PR TITLE
Set configureArgs for temurin on Mac to use GNU make 3.8.1 for jdk8->24

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -8,7 +8,7 @@ class Config11 {
                 additionalNodeLabels: 'xcode15.0.1',
                 configureArgs       : [
                         'openj9'      : '--enable-dtrace=auto --with-cmake',
-                        'temurin'     : '--enable-dtrace=auto --disable-ccache'
+                        'temurin'     : '--enable-dtrace=auto --disable-ccache MAKE=/usr/bin/make'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom'
@@ -165,7 +165,10 @@ class Config11 {
                 arch                : 'aarch64',
                 test                : 'default',
                 additionalNodeLabels: 'xcode15.0.1',
-                configureArgs       : '--disable-ccache',
+                configureArgs       : [
+                        'openj9'      : '--disable-ccache',
+                        'temurin'     : '--disable-ccache MAKE=/usr/bin/make'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom'
                 ]

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -9,7 +9,10 @@ class Config17 {
                         openj9      : '!sw.os.osx.10_11'
                 ],
                 test                : 'default',
-                configureArgs       : '--enable-dtrace',
+                configureArgs       : [
+                        'openj9'      : '--enable-dtrace',
+                        'temurin'     : '--enable-dtrace MAKE=/usr/bin/make'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
@@ -144,6 +147,9 @@ class Config17 {
                 arch                : 'aarch64',
                 additionalNodeLabels: 'xcode15.0.1',
                 test                : 'default',
+                configureArgs       : [
+                        'temurin'     : 'MAKE=/usr/bin/make'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -11,7 +11,10 @@ class Config21 {
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
                 ],
-                configureArgs       : '--enable-dtrace',
+                configureArgs       : [
+                        'openj9'      : '--enable-dtrace',
+                        'temurin'     : '--enable-dtrace MAKE=/usr/bin/make'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
@@ -144,6 +147,9 @@ class Config21 {
                 additionalNodeLabels: 'xcode15.0.1',
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
+                ],
+                configureArgs       : [
+                        'temurin'     : 'MAKE=/usr/bin/make'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'

--- a/pipelines/jobs/configurations/jdk24u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk24u_pipeline_config.groovy
@@ -12,7 +12,10 @@ class Config24 {
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
                 ],
-                configureArgs       : '--enable-dtrace',
+                configureArgs       : [
+                        'openj9'      : '--enable-dtrace',
+                        'temurin'     : '--enable-dtrace MAKE=/usr/bin/make'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
@@ -145,6 +148,9 @@ class Config24 {
                 additionalNodeLabels: 'xcode15.0.1',
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
+                ],
+                configureArgs       : [
+                        'temurin'     : 'MAKE=/usr/bin/make'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'

--- a/pipelines/jobs/configurations/jdk25_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk25_pipeline_config.groovy
@@ -12,7 +12,10 @@ class Config25 {
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
                 ],
-                configureArgs       : '--enable-dtrace',
+                configureArgs       : [
+                        'openj9'      : '--enable-dtrace',
+                        'temurin'     : '--enable-dtrace MAKE=/usr/bin/make'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
@@ -145,6 +148,9 @@ class Config25 {
                 additionalNodeLabels: 'xcode15.0.1',
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
+                ],
+                configureArgs       : [
+                        'temurin'     : 'MAKE=/usr/bin/make'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'

--- a/pipelines/jobs/configurations/jdk26_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk26_pipeline_config.groovy
@@ -12,7 +12,10 @@ class Config26 {
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
                 ],
-                configureArgs       : '--enable-dtrace',
+                configureArgs       : [
+                        'openj9'      : '--enable-dtrace',
+                        'temurin'     : '--enable-dtrace MAKE=/usr/bin/make'
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
@@ -145,6 +148,9 @@ class Config26 {
                 additionalNodeLabels: 'xcode15.0.1',
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
+                ],
+                configureArgs       : [
+                        'temurin'     : 'MAKE=/usr/bin/make'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -10,7 +10,7 @@ class Config8 {
                 ],
                 test                 : 'default',
                 configureArgs       : [
-                        'temurin'   : '--disable-ccache'
+                        'temurin'   : '--disable-ccache MAKE=/usr/bin/make'
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-sbom'


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/4205

Update temurin configureArgs for jdk8u->24u to use MAKE=/usr/bin/make (GNU make 3.8.1)