### PR TITLE
Place all waiting for targets in waitForXStatus into one stage

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2294,11 +2294,11 @@ def buildScriptsAssemble(
     }
 
     def waitForJckStatus(remoteTriggeredBuilds) {
+      context.stage("${remoteTriggeredBuilds}") {
         def waitingForRemoteJck = true
         while( waitingForRemoteJck ) {
             waitingForRemoteJck = false
             remoteTriggeredBuilds.each{ testTargets, jobHandle ->
-                context.stage("${testTargets}") {
                     def remoteJobStatus = ""
                     if ( jobHandle == null ) {
                         context.println "Failed, remote job ${testTargets} was not triggered"
@@ -2320,7 +2320,6 @@ def buildScriptsAssemble(
                     if ( remoteJobStatus != "" ) {
                         setStageResult("${testTargets}", remoteJobStatus);
                     }
-                }
             }
             if (waitingForRemoteJck) {
                 def sleepTimeMins = 20
@@ -2328,6 +2327,7 @@ def buildScriptsAssemble(
                 sleep (sleepTimeMins * 60 * 1000)
             }
         }
+      }
     }
 
     /*


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1247

Place all jck targets in waitForJckStatus into one stage.

Test: https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-linux-x64-temurin-andrew/2/ - GOOD

