### PR TITLE
Disable linter file duplicate checker

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -66,3 +66,5 @@ jobs:
           VALIDATE_CHECKOV: false
           # ignore shell formatting checker
           VALIDATE_SHELL_SHFMT: false
+          # ignore file duplicate checker
+          VALIDATE_JSCPD: false


### PR DESCRIPTION
Because many of our files are minutely-changed duplicates.