### PR TITLE
use GCC 14 devkit for JDK25+

### DIFF
--- a/pipelines/jobs/configurations/jdk25_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk25_pipeline_config.groovy
@@ -37,7 +37,7 @@ class Config25 {
                         'temurin'   : '--enable-dtrace'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-source-archive --create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
+                        'temurin'   : '--create-source-archive --create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-14.2.0-Centos7.9.2009-b00'
                 ]
         ],
 
@@ -104,7 +104,7 @@ class Config25 {
                 dockerImage         : 'rhel7_build_image',
                 test                : 'default',
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-14.2.0-Centos7.9.2009-b00'
                 ]
         ],
 
@@ -119,7 +119,7 @@ class Config25 {
                         'openj9'      : '--enable-dtrace'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-14.2.0-Centos7.9.2009-b00'
                 ]
         ],
 
@@ -135,7 +135,7 @@ class Config25 {
                         'temurin'   : '--enable-dtrace --with-jobs=4'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-14.2.0-Centos7.6.1810-b00'
                 ]
         ],
 

--- a/pipelines/jobs/configurations/jdk26_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk26_pipeline_config.groovy
@@ -37,7 +37,7 @@ class Config26 {
                         'temurin'   : '--enable-dtrace'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-source-archive --create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
+                        'temurin'   : '--create-source-archive --create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-14.2.0-Centos7.9.2009-b00'
                 ]
         ],
 
@@ -104,7 +104,7 @@ class Config26 {
                 dockerImage         : 'rhel7_build_image',
                 test                : 'default',
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-14.2.0-Centos7.9.2009-b00'
                 ]
         ],
 
@@ -119,7 +119,8 @@ class Config26 {
                         'openj9'      : '--enable-dtrace'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-14.2.0-Centos7.9.2009-b00
+                        '
                 ]
         ],
 
@@ -135,7 +136,7 @@ class Config26 {
                         'temurin'   : '--enable-dtrace --with-jobs=4'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-14.2.0-Centos7.6.1810-b00'
                 ]
         ],
 

--- a/pipelines/jobs/configurations/jdk26_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk26_pipeline_config.groovy
@@ -119,8 +119,7 @@ class Config26 {
                         'openj9'      : '--enable-dtrace'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-14.2.0-Centos7.9.2009-b00
-                        '
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-14.2.0-Centos7.9.2009-b00'
                 ]
         ],
 


### PR DESCRIPTION
Final part in updating the devkit for JDK25+: https://github.com/adoptium/temurin-build/issues/4110
Noting that the riscv64 builds are already using a GCC14/Fedora28-based devkit as per https://github.com/adoptium/ci-jenkins-pipelines/pull/1227 - this covers all the other Linux platforms.

Tagging Andrew as a reviewer as an "FYI" for a retrospective look as I know he won't be able to approve this today :-)
