### PR TITLE
Allow dryruns against adopt-only ga candidate build source clones

### DIFF
--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -145,7 +145,9 @@ node('worker') {
         }
 
         // If testenv tag is a "-ga" tag, then resolve to the actual openjdk build tag it's tagging
-        if (jdkBranch.contains("-ga")) {
+        // Skip this if we're running a dryrun, as 'jdk-XX-dryrun-ga' can be created as copies of 
+        // release candidate tag levels which can be mistaken for this tag due to matching commit shas.
+        if (jdkBranch.contains("-ga") && !jdkBranch.contains("dryrun")) {
             jdkBranch = resolveGaTag("${params.jdkVersion}", jdkBranch)
         }
 


### PR DESCRIPTION
A cherry-pick of this change: https://github.com/adoptium/ci-jenkins-pipelines/pull/1269

Tested here: https://ci.adoptium.net/job/build-scripts/job/release-openjdk25-pipeline/4/console

Appears to work well.
