### PR TITLE
Also build jtreg version 8+2

### DIFF
--- a/tools/code-tools/jtreg.sh
+++ b/tools/code-tools/jtreg.sh
@@ -20,6 +20,7 @@ readonly JTREG_7_3_1='jtreg-7.3.1+1'
 readonly JTREG_7_4='jtreg-7.4+1'
 readonly JTREG_7_5_1='jtreg-7.5.1+1'
 readonly JTREG_7_5_2='jtreg-7.5.2+1'
+readonly JTREG_8='jtreg-8+2'
 
 function checkJdks() {
   jvm_dir="/usr/lib/jvm/"
@@ -98,6 +99,10 @@ buildJTReg()
     elif [ "$1" == "$JTREG_7_5_2" ]; then
       export JTREG_BUILD_NUMBER="1"
       export BUILD_VERSION="7.5.2"
+      export JAVA_HOME=/usr/lib/jvm/jdk11
+    elif [ "$1" == "$JTREG_8" ]; then
+      export JTREG_BUILD_NUMBER="2"
+      export BUILD_VERSION="8"
       export JAVA_HOME=/usr/lib/jvm/jdk11
     fi
     git checkout $version
@@ -180,5 +185,6 @@ buildJTReg "$JTREG_7_3_1"
 buildJTReg "$JTREG_7_4"
 buildJTReg "$JTREG_7_5_1"
 buildJTReg "$JTREG_7_5_2"
+buildJTReg "$JTREG_8"
 buildJTReg
 echo '...finished with build process.'


### PR DESCRIPTION
Necessitated by openjdk change
* [8361950: Update to use jtreg 8](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/4a0d26958b19acdd8cf2d29d3d8283aeedabf399)