### PR TITLE
Use JDK 17 to build jtreg-8+2

### DIFF
--- a/tools/code-tools/jtreg.sh
+++ b/tools/code-tools/jtreg.sh
@@ -103,7 +103,7 @@ buildJTReg()
     elif [ "$1" == "$JTREG_8" ]; then
       export JTREG_BUILD_NUMBER="2"
       export BUILD_VERSION="8"
-      export JAVA_HOME=/usr/lib/jvm/jdk11
+      export JAVA_HOME=/usr/lib/jvm/jdk17
     fi
     git checkout $version
   else


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1275.