### PR TITLE
Update hotspot builds to create sbom and use devkit

### DIFF
--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -134,7 +134,8 @@ class Config21 {
                         'temurin'   : '--enable-dtrace --with-jobs=4'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03',
+                        'hotspot'   : '--create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'
                 ]
         ],
 

--- a/pipelines/jobs/configurations/jdk25u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk25u_pipeline_config.groovy
@@ -135,7 +135,8 @@ class Config25 {
                         'temurin'   : '--enable-dtrace --with-jobs=4'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-14.2.0-Centos7.6.1810-b00'
+                        'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-14.2.0-Centos7.6.1810-b00',
+                        'hotspot'   : '--create-jre-image --create-sbom --use-adoptium-devkit gcc-14.2.0-Centos7.6.1810-b00'
                 ]
         ],
 


### PR DESCRIPTION
jdk21u/jdk25u linux aarch64 "hotspot" builds failing jsf_sign_sbom, because hotspot builds are not creating sbom... https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk25u/job/jdk25u-linux-aarch64-hotspot/1/

- We should create sbom for the test hotspot build
- Also use DevKit

Test build: https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk25u/job/jdk25u-linux-aarch64-hotspot/3 - SUCCESS
