### PR TITLE
Adding jdk25 to reproducibility healthcheck

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -47,7 +47,7 @@ def getPlatformReproTestMap() {
     // A map to return the test bucket and test name for the repducibile platforms
     def platformReproTestMap = [x64Linux:           ["special.system", "Rebuild_Same_JDK_Reproducibility_Test"],
                                 x64Windows:         ["special.system", "Rebuild_Same_JDK_Reproducibility_Test_win"],
-                                x64Mac:             ["NA", ""],
+                                x64Mac:             ["special.system", "Rebuild_Same_JDK_Reproducibility_Test_Mac"],
                                 ppc64leLinux:       ["special.system", "Rebuild_Same_JDK_Reproducibility_Test"],
                                 aarch64Linux:       ["special.system", "Rebuild_Same_JDK_Reproducibility_Test"],
                                 aarch64Mac:         ["special.system", "Rebuild_Same_JDK_Reproducibility_Test_Mac"]
@@ -807,7 +807,19 @@ node('worker') {
         // Specifies what JDK versions and platforms are expected to be reproducible.
         // The "?" symbols will soon be replaced by reproducibility percentages.
         // Layout: [jdkVersion: [Overall-reproducibility, [By-platform reproducibility breakdown]]]
-        def reproducibleBuilds = ["jdk21u": [ "?", ["x64Linux": "?", "aarch64Linux": "?", "ppc64leLinux": "?", "x64Windows": "?", "x64Mac": "?", "aarch64Mac": "?"]]]
+        def reproducibleBuilds = ["jdk21u": [ "?", ["x64Linux":     "?",
+                                                    "aarch64Linux": "?",
+                                                    "ppc64leLinux": "?",
+                                                    "x64Windows":   "?",
+                                                    "x64Mac":       "?",
+                                                    "aarch64Mac":   "?"]],
+                                  "jdk25":  [ "?", ["x64Linux":     "?",
+                                                    "aarch64Linux": "?",
+                                                    "ppc64leLinux": "?",
+                                                    "x64Windows":   "?",
+                                                    "x64Mac":       "?",
+                                                    "aarch64Mac":   "?"]]
+                                  ]
 
         stage('getPipelineStatus') {
             def apiVariant = variant


### PR DESCRIPTION
Testing here: https://ci.adoptium.net/job/adam_temp_job_4/3

Job passed and output shows this change doesn't break anything.

However the output lacks the reproducibility percentage because no aqa tests were run against the latest jdk25 build.

The dry runs should give us the needed db entries, so I propose that we merge this now and review the results after the dry run runs.