### PR TITLE
Allow pipeline release tag check to handle dryrun-ga of a previous -ga level build tag

### DIFF
--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -95,7 +95,8 @@ def resolveGaTag(String jdkVersion, String jdkBranch) {
         def annotatedTagFilter = (annotatedTag ? "| grep '\\^{}'" : "| grep -v '\\^{}'")
         def foundRepo = resolveGaCommit.get(0)
         def foundSHA  = resolveGaCommit.get(1)
-        def upstreamTag = sh(returnStdout: true, script:"git ls-remote --tags ${foundRepo} ${annotatedTagFilter} | grep \"${foundSHA}\" | grep -v \"${jdkBranch}\" | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | sed \"s,\\^{},,\" | tr -d '\\n'")
+        // Find upstream target actual tag, ignore any other "-ga" tags, must be a real build tag
+        def upstreamTag = sh(returnStdout: true, script:"git ls-remote --tags ${foundRepo} ${annotatedTagFilter} | grep \"${foundSHA}\" | grep -v \"${jdkBranch}\" | grep -v '\\-ga' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | sed \"s,\\^{},,\" | tr -d '\\n'")
         if (upstreamTag != "") {
             println "[INFO] Resolved ${jdkBranch} to upstream build tag ${upstreamTag}"
             resolvedTag = upstreamTag


### PR DESCRIPTION
For jdk25u trying to dryrun a previous -ga tag (jdk-25+36 jdk-25-ga), fails as the tag check logic does not expect another "-ga" tag to exist on the actual build tag, so in this case we have:
- jdk-25+36 tagged with : jdk-25-ga and jdk-25-dryrun-ga

We need to ignore any "-ga" tag and only return real build tags when we resolve the git tag check.

Tested here: https://ci.adoptium.net/job/build-scripts/job/release-openjdk25-pipeline/18/console
```
[INFO] Resolved jdk-25-dryrun-ga to upstream build tag jdk-25+36
[Pipeline] echo
[INFO] scmReference=jdk-25+36 matches with JDK25_BRANCH=jdk-25+36 in testenv.properties in aqa-tests release branch.
```
