### PR TITLE
Update Docker Build With SHA logic

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2505,7 +2505,7 @@ def buildScriptsAssemble(
                                                 source_tag = "@${imageDigest}"
                                                 // docker_image target contains a digest(sha) which cannot be a target tag
                                                 // create a new target tag name based on syntax: <imageName>_<sha256>
-                                                docker_image_target = imageName + "_" + imageDigest.replaceAll(":","")
+                                                docker_image_target = imageName + "_" + imageDigest.replaceAll(":","_")
                                                 context.println "Mapped ${buildConfig.DOCKER_IMAGE} to target tag ${docker_image_target}, as it contains a digest"
                                             } else {
                                                 // ":latest"
@@ -2530,6 +2530,7 @@ def buildScriptsAssemble(
                             } else {
                                 dockerImageDigest = context.sh(script: "docker inspect --format='{{.RepoDigests}}' ${docker_image_target}", returnStdout:true)
                             }
+                            context.println "Target docker image digest = ${dockerImageDigest}"
 
                             // Use our dockerfile if DOCKER_FILE is defined
                             if (buildConfig.DOCKER_FILE) {


### PR DESCRIPTION
Cherry pick https://github.com/adoptium/ci-jenkins-pipelines/pull/1293/commits/79b18bad89ace3c7fad7e75fe8e6c66949a37ebe

few more commit fixes:
- docker tag source target, cannot specify a "target" containing a sha digest. So instead when a digest is specified, create a target of syntax "\<imageName\>\_sha256\_\<sha256\>"

Tests:
- jdk8u using @sha256.. : https://ci.adoptium.net/job/build-scripts-pr-tester/job/build-test/job/jobs/job/jdk8u/job/jdk8u-windows-x64-temurin/20/
- jdk21u using just imageName.. : https://ci.adoptium.net/job/build-scripts-pr-tester/job/build-test/job/jobs/job/jdk21u/job/jdk21u-windows-x64-temurin/18/
- 