### PR TITLE
Pin JDK11 Windows Builds To Image SHA

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -70,7 +70,7 @@ class Config11 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
-                dockerImage         : 'windows2022_build_image',
+                dockerImage         : 'windows2022_build_image@sha256:0d0a3afb998c34df0277d6a5ed97c2d8d705012e6a93d358af25af638963ef6f',
                 dockerRegistry      : 'https://adoptium.azurecr.io',
                 dockerCredential    : 'bbb9fa70-a1de-4853-b564-5f02193329ac',
                 additionalNodeLabels: [
@@ -90,7 +90,7 @@ class Config11 {
         x32Windows: [
                 os                  : 'windows',
                 arch                : 'x86-32',
-                dockerImage         : 'windows2022_build_image',
+                dockerImage         : 'windows2022_build_image@sha256:0d0a3afb998c34df0277d6a5ed97c2d8d705012e6a93d358af25af638963ef6f',
                 dockerRegistry      : 'https://adoptium.azurecr.io',
                 dockerCredential    : 'bbb9fa70-a1de-4853-b564-5f02193329ac',
                 additionalNodeLabels: 'win2022&&vs2022',


### PR DESCRIPTION
Due to the new windows docker build image having a more upto date CYGWIN, the JDK11 build needs to use the older image, due to an upstream bug, that prevents building JDK11.

See : https://bugs.openjdk.org/browse/JDK-8357657?focusedId=14792554&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel

This is due to be fixed in Jan 2026 Release Cycle.