### PR TITLE
Add PUBLISH param to trigger_beta_build.groovy

### DIFF
--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -302,15 +302,27 @@ if (triggerMainBuild || triggerEvaluationBuild) {
 
                     def jobParams
                     if (solarisBuildJob) {
+                        def dryRun
+                        if (params.PUBLISH) {
+                            dryRun = false
+                        } else {
+                            dryRun = true
+                        }
                         jobParams = [
                             booleanParam(name: 'RELEASE',           value: false),
                             string(name: 'SCM_REF',                 value: "$latestAdoptTag"),
                             booleanParam(name: 'ENABLE_TESTS',      value: enableTesting),
-                            booleanParam(name: 'DRY_RUN',           value: false)
+                            booleanParam(name: 'DRY_RUN',           value: dryRun)
                         ]
                     } else {
+                        def releaseType
+                        if (params.PUBLISH) {
+                            releaseType = "Weekly"
+                        } else {
+                            releaseType = "Weekly Without Publish"
+                        }
                         jobParams = [
-                            string(name: 'releaseType',             value: "Weekly"),
+                            string(name: 'releaseType',             value: releaseType),
                             string(name: 'scmReference',            value: "$latestAdoptTag"),
                             string(name: 'overridePublishName',     value: "$publishJobTag"),
                             booleanParam(name: 'aqaAutoGen',        value: true),


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1306

jdk-25.0.1+8 "hotspot" aarch64 build failed as tried to publish to temurin25-binaries! https://ci.adoptium.net/job/build-scripts/job/openjdk25-pipeline/80/
We shouldn't be trying to publish native "hotspot" builds, added PUBLISH param to beta trigger job.
