### PR TITLE
Enable jdk25u weekly builds and hotspot builds

### DIFF
--- a/pipelines/build/common/weekly_release_pipeline.groovy
+++ b/pipelines/build/common/weekly_release_pipeline.groovy
@@ -51,9 +51,16 @@ stage('Submit Release Pipelines') {
             echo("Creating ${params.buildPipeline} - ${variantName}")
             jobs[variantName] = {
                 stage("Build - ${params.buildPipeline} - ${variantName}") {
+                    def releaseType = "${params.releaseType}"
+
+                    // Only Temurin can Publish
+                    if ("${variantName}" != "temurin" && !releaseType.contains("Without Publish")) {
+                      releaseType = "${releaseType} Without Publish"
+                    }
+
                     result = build job: "${params.buildPipeline}",
                             parameters: [
-                                string(name: 'releaseType',        value: "${params.releaseType}"),
+                                string(name: 'releaseType',        value: releaseType),
                                 string(name: 'scmReference',       value: scmRef),
                                 booleanParam(name: 'aqaAutoGen', value: aqaAutoGen),
                                 text(name: 'targetConfigurations', value: JsonOutput.prettyPrint(JsonOutput.toJson(targetConfig))),

--- a/pipelines/jobs/configurations/jdk25u.groovy
+++ b/pipelines/jobs/configurations/jdk25u.groovy
@@ -38,6 +38,9 @@ targetConfigurations = [
         ]
 ]
 
+// 12:05 Sat - Weekend schedule for Oracle managed version that has no published tags
+triggerSchedule_weekly  = 'TZ=UTC\n05 12 * * 6'
+
 // scmReferences to use for weekly release build
 weekly_release_scmReferences = [
         'hotspot'        : '',


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1282

- Add weekly jdk25u build, as jdk-25u is currently internal Oracle ie.no tags published
- Fix up weekly pipeline script to not try to Publish hotspot builds...