### PR TITLE
Adding "NotDone" as a valid TRSS status for incomplete pipelines

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -1124,7 +1124,7 @@ node('worker') {
                                 health = "Unhealthy"
                                 errorMsg = "\nLatest Adoptium publish binaries "+status['releaseName']+" != latest upstream openjdk build "+status['upstreamTag']+" published ${upstreamTagAge} days ago. *No build is in progress*."
                             } else {
-                                if (probableBuildStatus == "Streaming") {
+                                if ( (probableBuildStatus == "Streaming") || (probableBuildStatus == "NotDone") ) {
                                     errorMsg = "\nLatest upstream openjdk build "+status['upstreamTag']+" published ${upstreamTagAge} days ago. <" + probableBuildUrl + "|Build is in progress>."
                                 } else {
                                     errorMsg = "\nLatest upstream openjdk build "+status['upstreamTag']+" published ${upstreamTagAge} days ago. *Build is awaiting 'trigger'*."
@@ -1189,7 +1189,7 @@ node('worker') {
                         slackColor = 'danger'
                         health = "Unhealthy"
                         errorMsg += "\nArtifact status: "+status['assets']
-                        if (probableBuildStatus == "Streaming") {
+                        if ( (probableBuildStatus == "Streaming") || (probableBuildStatus == "NotDone") ) {
                             errorMsg += ", <" + probableBuildUrl + "|Build is in progress>"
                         } else {
                             errorMsg += ", *No build is in progress*"


### PR DESCRIPTION
As TRSS seems to be using NotDone status for in-progress pipelines instead of Streaming status.

Testing here: https://ci.adoptium.net/job/nightlyBuildAndTestStats_temurin/2163