### PR TITLE
Run SBOM validation whenever a build completes

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2376,7 +2376,7 @@ def buildScriptsAssemble(
 
         try {
             context.println 'Validating SBOM/s'
-            context.stage('validate sbom') {
+            context.stage('validate SBOM') {
                 // Check sbom validation job exists.
                 String helperRef = buildConfig.HELPER_REF ?: DEFAULTS_JSON['repository']['helper_ref']
                 def JobHelper = context.library(identifier: "openjdk-jenkins-helper@${helperRef}").JobHelper


### PR DESCRIPTION
As per the work in a [separate PR](https://github.com/adoptium/temurin-build/pull/4299), we can now run SBOM validation on a specific build's sboms via this [jenkins job](https://ci.adoptium.net/job/sbom_validator_job/).

This PR makes this sbom vaalidation automatic at the end of a build, as long as --create-sboms was specified as a build arg.

Testing here: https://ci.adoptium.net/job/build-scripts/job/openjdk8-pipeline/3039/ - Passed.

Resolves https://github.com/adoptium/ci-jenkins-pipelines/issues/1252