### PR TITLE
Pipeline regen fails if jenkins queryAPI is not available

### DIFF
--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -640,11 +640,12 @@ class Regeneration implements Serializable {
                     // Get all pipelines
                     def getPipelines = queryAPI("${jenkinsBuildRoot}/api/json?tree=jobs[name]&pretty=true&depth1")
 
-if (getPipelines == null) {
-    context.println "Unable to query ${jenkinsBuildRoot}/api/json?tree=jobs[name]&pretty=true&depth1"
-} else {
-                    // Parse api response to only extract the relevant pipeline
-                    getPipelines.jobs.name.each { pipeline ->
+                    if (getPipelines == null) {
+                      // ${jenkinsBuildRoot}/api cannot be queried by API
+                      context.println "Unable to query ${jenkinsBuildRoot}/api/json?tree=jobs[name]&pretty=true&depth1"
+                    } else {
+                      // Parse api response to only extract the relevant pipeline
+                      getPipelines.jobs.name.each { pipeline ->
                         def pipelineName = (jobType != "evaluation" ? "openjdk${versionNumbers[0]}-pipeline" : "evaluation-openjdk${versionNumbers[0]}-pipeline")
                         if (pipeline == pipelineName) {
                             Boolean inProgress = true
@@ -680,8 +681,8 @@ if (getPipelines == null) {
 
                             context.println "[SUCCESS] ${pipeline} is idle. Running regeneration job..."
                         }
+                      }
                     }
-}
                 }
             } // end check stage
 


### PR DESCRIPTION
Pipeline regen fails if jenkins queryAPI is not available, resulting in NullPointerException

If queryAPI not available, then simply go ahead and regen, there is no particular reason why a job cannot be regen'd when jobs are running.

Successful Test:
```
[Pipeline] stage
[Pipeline] { (Check jdk25u pipeline status)
[Pipeline] echo
00:00:05.390  Unable to query https://JENKINS/job/build-scripts//api/json?tree=jobs[name]&pretty=true&depth1
[Pipeline] }
[Pipeline] // stage
[Pipeline] stage
[Pipeline] { (Regenerate jdk25u pipeline jobs)
```
