### PR TITLE
Add `hotspot` variants to AIX/xlinux/zlinux for regular job generation

### DIFF
--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -1,12 +1,12 @@
 targetConfigurations = [
         'x64Mac'        : [    'temurin',    'openj9'                    ],
-        'x64Linux'      : [    'temurin',    'openj9',    'dragonwell',    'corretto',    'bisheng',    'fast_startup'],
+        'x64Linux'      : [    'temurin',    'hotspot',    'dragonwell',    'corretto',    'bisheng',    'fast_startup'],
         'x64AlpineLinux': [    'temurin'                            ],
         'x64Windows'    : [    'temurin',    'openj9',    'dragonwell'            ],
         'x32Windows'    : [    'temurin'                            ],
-        'ppc64Aix'      : [    'temurin',    'openj9'                    ],
+        'ppc64Aix'      : [    'temurin',    'hotspot'                   ],
         'ppc64leLinux'  : [    'temurin',    'openj9'                    ],
-        's390xLinux'    : [    'temurin',    'openj9'                    ],
+        's390xLinux'    : [    'temurin',    'hotspot'                   ],
         'aarch64Linux'  : [    'temurin',    'openj9',    'dragonwell',                   'bisheng'    ],
         'aarch64Mac'    : [    'temurin',                           ],
         'arm32Linux'    : [    'temurin'                            ]

--- a/pipelines/jobs/configurations/jdk17u.groovy
+++ b/pipelines/jobs/configurations/jdk17u.groovy
@@ -5,8 +5,7 @@ targetConfigurations = [
         ],
         'x64Linux'    : [
                 'temurin',
-                'openj9',
-                'bisheng'
+                'hotspot'
         ],
         'x64AlpineLinux' : [
                 'temurin'
@@ -20,7 +19,7 @@ targetConfigurations = [
         ],
         'ppc64Aix'    : [
                 'temurin',
-                'openj9'
+                'hotspot'
         ],
         'ppc64leLinux': [
                 'temurin',
@@ -28,7 +27,7 @@ targetConfigurations = [
         ],
         's390xLinux'  : [
                 'temurin',
-                'openj9'
+                'hotspot'
         ],
         'aarch64Linux': [
                 'temurin',

--- a/pipelines/jobs/configurations/jdk21u.groovy
+++ b/pipelines/jobs/configurations/jdk21u.groovy
@@ -3,7 +3,8 @@ targetConfigurations = [
                 'temurin'
         ],
         'x64Linux'    : [
-                'temurin'
+                'temurin',
+                'hotspot'
         ],
         'x64AlpineLinux' : [
                 'temurin'
@@ -18,13 +19,15 @@ targetConfigurations = [
                 'temurin'
         ],
         'ppc64Aix'    : [
-                'temurin'
+                'temurin',
+                'hotspot'
         ],
         'ppc64leLinux': [
                 'temurin'
         ],
         's390xLinux'  : [
-                'temurin'
+                'temurin',
+                'hotspot'
         ],
         'aarch64Linux': [
                 'hotspot',

--- a/pipelines/jobs/configurations/jdk25u.groovy
+++ b/pipelines/jobs/configurations/jdk25u.groovy
@@ -3,7 +3,8 @@ targetConfigurations = [
                 'temurin'
         ],
         'x64Linux'    : [
-                'temurin'
+                'temurin',
+                'hotspot'
         ],
         'x64AlpineLinux' : [
                 'temurin'
@@ -18,13 +19,15 @@ targetConfigurations = [
                 'temurin'
         ],
         'ppc64Aix'    : [
-                'temurin'
+                'temurin',
+                'hotspot'
         ],
         'ppc64leLinux': [
                 'temurin'
         ],
         's390xLinux'  : [
-                'temurin'
+                'temurin',
+                'hotspot'
         ],
         'aarch64Linux': [
                 'hotspot',

--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -7,7 +7,8 @@ targetConfigurations = [
                 'openj9',
                 'corretto',
                 'dragonwell',
-                'bisheng'
+                'bisheng',
+                'hotspot'
         ],
         'x64AlpineLinux' : [
                 'temurin'
@@ -23,7 +24,7 @@ targetConfigurations = [
         ],
         'ppc64Aix'      : [
                 'temurin',
-                'openj9'
+                'hotspot'
         ],
         'ppc64leLinux'  : [
                 'temurin',


### PR DESCRIPTION
In support of [Project Trestle](https://github.com/adoptium/adoptium/issues/265).
First test of https://github.com/adoptium/ci-jenkins-pipelines/issues/1299
Noting that we are regenerating jobs for other variants that are no longer built by us on a regular cadence so we should look at removing everything other than `temurin` and `hotspot` going forward. For now this is replacing the openj9 generation on these platforms as I don't believe OpenJ9 themselves utilise the pipeline configuration in this repository (FYA @AdamBrousseau).