### PR TITLE
Removing Solaris from the jdk8 build pipeline

### DIFF
--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -41,12 +41,6 @@ targetConfigurations = [
         ],
         'arm32Linux'  : [
                 'temurin'
-        ],
-        'x64Solaris': [
-                'temurin'
-        ],
-        'sparcv9Solaris': [
-                'temurin'
         ]
 ]
 

--- a/pipelines/jobs/configurations/jdk8u_release.groovy
+++ b/pipelines/jobs/configurations/jdk8u_release.groovy
@@ -25,12 +25,6 @@ targetConfigurations = [
         ],
         'arm32Linux'  : [
                 'temurin'
-        ],
-        'x64Solaris': [
-                'temurin'
-        ],
-        'sparcv9Solaris': [
-                'temurin'
         ]
 ]
 


### PR DESCRIPTION
JDK8 Solaris should still be built as part of the simplepipe jobs, but the traditional Solaris jobs don't work and will continue to fail if these entries are left in.

Change made as per the recent retrospective: https://github.com/adoptium/temurin/issues/90#issuecomment-3456677438