### PR TITLE
Add support for configuring build workspace clean options to the pipeline/defaults.json config

### DIFF
--- a/docs/UsingOurScripts.md
+++ b/docs/UsingOurScripts.md
@@ -133,7 +133,15 @@ This file contains the default constants and paths used in the build scripts for
     // Whether to enable creation of the "installers" for the pipeline job
     "enableInstallers"       : true,
     // Whether to enable the signing of binaries for the pipeline job
-    "enableSigner"           : true
+    "enableSigner"           : true,
+    // Whether to clean the build workspace before a "standard" build
+    "cleanWorkspaceBeforeBuild" : false,
+    // Whether to clean the build workspace after a "standard" build
+    "cleanWorkspaceAfterBuild"  : false,
+    // Whether to clean the build workspace before a "release" build
+    "cleanReleaseWorkspaceBeforeBuild" : true,
+    // Whether to clean the build workspace after a "release" build
+    "cleanReleaseWorkspaceAfterBuild"  : false
 }
 ```
 

--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -56,7 +56,9 @@ class PullRequestTestPipeline implements Serializable {
                 enableTestDynamicParallel : false,
                 releaseType         : "pr-tester",
                 enableInstallers    : true,
-                enableSigner        : true
+                enableSigner        : true,
+                cleanWorkspaceBeforeBuild   : true,
+                cleanWorkspaceAfterBuild    : true
         ]
     }
 

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -171,7 +171,9 @@ node('worker') {
                     adoptScripts        : false,
                     releaseType         : 'Nightly Without Publish',
                     enableInstallers    : true,
-                    enableSigner        : true
+                    enableSigner        : true,
+                    cleanWorkspaceBeforeBuild   : true,
+                    cleanWorkspaceAfterBuild    : true
                 ]
 
                 def target
@@ -232,6 +234,12 @@ node('worker') {
                 }
                 if (DEFAULTS_JSON.containsKey('enableSigner')) {
                     config.put('enableSigner', DEFAULTS_JSON['enableSigner'] as Boolean)
+                }
+                if (DEFAULTS_JSON.containsKey('cleanWorkspaceBeforeBuild')) {
+                    config.put('cleanWorkspaceBeforeBuild', DEFAULTS_JSON['cleanWorkspaceBeforeBuild'] as Boolean)
+                }
+                if (DEFAULTS_JSON.containsKey('cleanWorkspaceAfterBuild')) {
+                    config.put('cleanWorkspaceAfterBuild', DEFAULTS_JSON['cleanWorkspaceAfterBuild'] as Boolean)
                 }
 
                 println "[INFO] JDK${javaVersion}: nightly pipelineSchedule = ${config.pipelineSchedule}"

--- a/pipelines/build/regeneration/evaluation_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/evaluation_pipeline_generator.groovy
@@ -165,7 +165,9 @@ node('worker') {
                         adoptScripts        : false,
                         releaseType         : 'Nightly Without Publish',
                         enableInstallers    : true,
-                        enableSigner        : true
+                        enableSigner        : true,
+                        cleanWorkspaceBeforeBuild   : true,
+                        cleanWorkspaceAfterBuild    : true
                     ]
                 
                     /* logic of creating evaluation pipeline start*/
@@ -233,6 +235,12 @@ node('worker') {
                     }
                     if (DEFAULTS_JSON.containsKey('enableSigner')) {
                         config.put('enableSigner', DEFAULTS_JSON['enableSigner'] as Boolean)
+                    }
+                    if (DEFAULTS_JSON.containsKey('cleanWorkspaceBeforeBuild')) {
+                        config.put('cleanWorkspaceBeforeBuild', DEFAULTS_JSON['cleanWorkspaceBeforeBuild'] as Boolean)
+                    }
+                    if (DEFAULTS_JSON.containsKey('cleanWorkspaceAfterBuild')) {
+                        config.put('cleanWorkspaceAfterBuild', DEFAULTS_JSON['cleanWorkspaceAfterBuild'] as Boolean)
                     }
 
                     // genereate pipeline

--- a/pipelines/build/regeneration/release_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/release_pipeline_generator.groovy
@@ -79,7 +79,9 @@ node('worker') {
                     SCRIPT                      : "${scriptFolderPath}/openjdk_pipeline.groovy",
                     adoptScripts                : true, // USE_ADOPT_SHELL_SCRIPTS
                     enableInstallers            : true,
-                    enableSigner                : true
+                    enableSigner                : true,
+                    cleanWorkspaceBeforeBuild   : true,
+                    cleanWorkspaceAfterBuild    : true
                 ]
 
                 def target
@@ -108,6 +110,12 @@ node('worker') {
                 }
                 if (DEFAULTS_JSON.containsKey('enableSigner')) {
                     config.put('enableSigner', DEFAULTS_JSON['enableSigner'] as Boolean)
+                }
+                if (DEFAULTS_JSON.containsKey('cleanReleaseWorkspaceBeforeBuild')) {
+                    config.put('cleanWorkspaceBeforeBuild', DEFAULTS_JSON['cleanReleaseWorkspaceBeforeBuild'] as Boolean)
+                }
+                if (DEFAULTS_JSON.containsKey('cleanReleaseWorkspaceAfterBuild')) {
+                    config.put('cleanWorkspaceAfterBuild', DEFAULTS_JSON['cleanReleaseWorkspaceAfterBuild'] as Boolean)
                 }
 
                 config.put('defaultsJson', DEFAULTS_JSON)

--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -79,5 +79,9 @@
     },
     "defaultsUrl"            : "https://raw.githubusercontent.com/adoptium/ci-jenkins-pipelines/master/pipelines/defaults.json",
     "enableInstallers"       : true,
-    "enableSigner"           : true
+    "enableSigner"           : true,
+    "cleanWorkspaceBeforeBuild" : false,
+    "cleanWorkspaceAfterBuild"  : false,
+    "cleanReleaseWorkspaceBeforeBuild" : true,
+    "cleanReleaseWorkspaceAfterBuild"  : false
 }

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -7,6 +7,8 @@ runTests = enableTests
 runParallel = enableTestDynamicParallel
 runInstaller = enableInstallers
 runSigner = enableSigner
+cleanWorkspaceBeforeBuild = cleanWorkspaceBeforeBuild
+cleanWorkspaceAfterBuild  = cleanWorkspaceAfterBuild
 cleanWsBuildOutput = true
 jdkVersion = "${JAVA_VERSION}"
 isLightweight = true
@@ -165,8 +167,8 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
         stringParam('additionalBuildArgs', '', 'Additional arguments to be passed to <code>makejdk-any-platform.sh</code>')
         stringParam('overrideFileNameVersion', '', "When forming the filename, ignore the part of the filename derived from the publishName or timestamp and override it.<br/>For instance if you set this to 'FOO' the final file name will be of the form: <code>OpenJDK8U-jre_ppc64le_linux_openj9_FOO.tar.gz</code>")
         booleanParam('useAdoptBashScripts', adoptScripts, "If enabled, the downstream job will pull and execute <code>make-adopt-build-farm.sh</code> from adoptium/temurin-build. If disabled, it will use whatever the job is running inside of at the time, usually it's the default repository in the configuration.")
-        booleanParam('cleanWorkspaceBeforeBuild', false, 'Clean out the workspace before the build')
-        booleanParam('cleanWorkspaceAfterBuild', false, 'Clean out the workspace after the build')
+        booleanParam('cleanWorkspaceBeforeBuild', cleanWorkspaceBeforeBuild, 'Clean out the workspace before the build')
+        booleanParam('cleanWorkspaceAfterBuild', cleanWorkspaceAfterBuild, 'Clean out the workspace after the build')
         booleanParam('cleanWorkspaceBuildOutputAfterBuild', cleanWsBuildOutput, 'Clean out the workspace/build/src/build and workspace/target output only, after the build')
         booleanParam('propagateFailures', propagateFailures, 'If true, a failure of <b>ANY</b> downstream build will cause the whole build to fail')
         booleanParam('keepTestReportDir', false, 'If true, test report dir (including core files where generated) will be kept even when the testcase passes, failed testcases always keep the report dir. Does not apply to JUnit jobs which are always kept, eg.openjdk.')

--- a/pipelines/jobs/release_pipeline_job_template.groovy
+++ b/pipelines/jobs/release_pipeline_job_template.groovy
@@ -5,8 +5,10 @@ Boolean propagateFailures = true
 Boolean runReproducibleCompare = false
 Boolean runTests = true
 Boolean runParallel = true
-Boolean runInstaller = true
-Boolean runSigner = true
+Boolean runInstaller = enableInstallers
+Boolean runSigner = enableSigner
+Boolean cleanWorkspaceBeforeBuild = cleanWorkspaceBeforeBuild
+Boolean cleanWorkspaceAfterBuild  = cleanWorkspaceAfterBuild
 Boolean cleanWsBuildOutput = true
 Boolean isLightweight = false  // since this is to checkout on a releaseTag, better to use false or might not found tag/SHA1 on the tip
 
@@ -140,8 +142,8 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
         booleanParam('enableSigner', runSigner, 'If set to true the signer pipeline will be executed')
         stringParam('additionalBuildArgs', '', 'Additional arguments to be passed to <code>makejdk-any-platform.sh</code>')
         stringParam('overrideFileNameVersion', '', "When forming the filename, ignore the part of the filename derived from the publishName or timestamp and override it.<br/>For instance if you set this to 'FOO' the final file name will be of the form: <code>OpenJDK8U-jre_ppc64le_linux_openj9_FOO.tar.gz</code>")
-        booleanParam('cleanWorkspaceBeforeBuild', true, 'Clean out the workspace before the build')
-        booleanParam('cleanWorkspaceAfterBuild', false, 'Clean out the workspace after the build')
+        booleanParam('cleanWorkspaceBeforeBuild', cleanWorkspaceBeforeBuild, 'Clean out the workspace before the build')
+        booleanParam('cleanWorkspaceAfterBuild', cleanWorkspaceAfterBuild, 'Clean out the workspace after the build')
         booleanParam('cleanWorkspaceBuildOutputAfterBuild', cleanWsBuildOutput, 'Clean out the workspace/build/src/build and workspace/target output only, after the build')
         booleanParam('propagateFailures', propagateFailures, 'If true, a failure of <b>ANY</b> downstream build will cause the whole build to fail')
         booleanParam('keepTestReportDir', false, 'If true, test report dir (including core files where generated) will be kept even when the testcase passes, failed testcases always keep the report dir. Does not apply to JUnit jobs which are always kept, eg.openjdk.')


### PR DESCRIPTION
- Add support for configuring build workspace clean options to the pipeline/defaults.json config, so that "User" jenkins instances can configure these defaults appropriately for their environments.
Default "Adoptium" defaults.json values will be as before : 
```
    "cleanWorkspaceBeforeBuild" : false,
    "cleanWorkspaceAfterBuild"  : false,
    "cleanReleaseWorkspaceBeforeBuild" : true,
    "cleanReleaseWorkspaceAfterBuild"  : false
```

- Add accidently missed enableSigner/Installers setting to release job template