### PR TITLE
Remove string indicating no scm tag

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2372,7 +2372,7 @@ def buildScriptsAssemble(
 
                 // Gather parameters.
                 String jdk_Version = getJavaVersionNumber() as String
-                String source_tag = "scm_not_specified"
+                String source_tag = ""
                 if (!buildConfig.SCM_REF.isEmpty()){
                     source_tag = buildConfig.SCM_REF
                 }


### PR DESCRIPTION
Because the sbom validation code doesn't parse it correctly. It instead expects "null", which is being removed in favor of an empty string [here](https://github.com/adoptium/temurin-build/pull/4304/files#diff-479de0bbd23850873cf19a0dc3bb5f23e5c78ecf457bf6f19747d038930f9a7e).