### PR TITLE
Remove x32Windows from pipeline configuration

### DIFF
--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -3,7 +3,6 @@ targetConfigurations = [
         'x64Linux'      : [    'temurin',    'hotspot',    'dragonwell',    'corretto',    'bisheng',    'fast_startup'],
         'x64AlpineLinux': [    'temurin'                            ],
         'x64Windows'    : [    'temurin',    'openj9',    'dragonwell'            ],
-        'x32Windows'    : [    'temurin'                            ],
         'ppc64Aix'      : [    'temurin',    'hotspot'                   ],
         'ppc64leLinux'  : [    'temurin',    'openj9'                    ],
         's390xLinux'    : [    'temurin',    'hotspot'                   ],

--- a/pipelines/jobs/configurations/jdk11u_release.groovy
+++ b/pipelines/jobs/configurations/jdk11u_release.groovy
@@ -11,9 +11,6 @@ targetConfigurations = [
         'x64Windows'    : [
                 'temurin'
         ],
-        'x32Windows'    : [
-                'temurin'
-        ],
         'ppc64Aix'      : [
                 'temurin'
         ],

--- a/pipelines/jobs/configurations/jdk17u.groovy
+++ b/pipelines/jobs/configurations/jdk17u.groovy
@@ -14,9 +14,6 @@ targetConfigurations = [
                 'temurin',
                 'openj9'
         ],
-        'x32Windows'  : [
-                'temurin'
-        ],
         'ppc64Aix'    : [
                 'temurin',
                 'hotspot'

--- a/pipelines/jobs/configurations/jdk17u_release.groovy
+++ b/pipelines/jobs/configurations/jdk17u_release.groovy
@@ -11,9 +11,6 @@ targetConfigurations = [
         'x64Windows'  : [
                 'temurin'
         ],
-        'x32Windows'  : [
-                'temurin'
-        ],
         'ppc64leLinux': [
                 'temurin'
         ],

--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -13,10 +13,6 @@ targetConfigurations = [
         'x64AlpineLinux' : [
                 'temurin'
         ],
-        'x32Windows'    : [
-                'temurin',
-                'openj9'
-        ],
         'x64Windows'    : [
                 'temurin',
                 'openj9',

--- a/pipelines/jobs/configurations/jdk8u_release.groovy
+++ b/pipelines/jobs/configurations/jdk8u_release.groovy
@@ -8,9 +8,6 @@ targetConfigurations = [
         'x64AlpineLinux' : [
                 'temurin'
         ],
-        'x32Windows'    : [
-                'temurin'
-        ],
         'x64Windows'    : [
                 'temurin'
         ],


### PR DESCRIPTION
As per PMC decision, remove x32Windows from build config: https://github.com/adoptium/temurin-build/issues/4319
