### PR TITLE
Remote trigger property logic typo

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -706,7 +706,7 @@ class Build {
                         EXTRA_OPTIONS: "${extra_options}",
                         SETUP_JCK_RUN: "${setupJCKRun}"
                     ]
-                    if (("${platform}" == 'x86-64_windows' || "${platform}" == 'x86-32_windows') && "${targetTests}" == 'dev.jck') {
+                    if (("${platform}" == 'x86-64_windows' || "${platform}" == 'x86-32_windows') && "${targetTest}" == 'dev.jck') {
                         paramList["LABEL"] = 'ci.role.test.interactive'
                     }
                     def queryString = paramList.collect { k, v -> "${URLEncoder.encode(k, 'UTF-8')}=${URLEncoder.encode(v, 'UTF-8')}"}.join('&')


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1335

Typo in remoteTriggerJckTests causes Windows remote triggers to fail