### PR TITLE
Produce standard format child job status output to aid triage

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2359,6 +2359,7 @@ def buildScriptsAssemble(
                     context.stage("${testTarget}") {
                         setStageResult("${testTarget}", remoteJobStatus)
                     }
+                    context.println "Build ${testTarget} completed: ${remoteJobStatus}"
                     completedJckJobs += ",${testTarget}"
                     completedJckJobCount++
                 }


### PR DESCRIPTION
This allows triagers to search through the output for a standard "completed: F" string to identify child jobs which have had problems.

Resolves: https://github.com/adoptium/ci-jenkins-pipelines/issues/1338