### PR TITLE
Adding useful output to remote test triggers

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2455,6 +2455,8 @@ def buildScriptsAssemble(
                 def enableSigner = Boolean.valueOf(buildConfig.ENABLE_SIGNER)
                 def enableTCK = Boolean.valueOf(buildConfig.RELEASE) || Boolean.valueOf(buildConfig.WEEKLY)
                 if ('jdk'.equalsIgnoreCase(buildConfig.JAVA_TO_BUILD.trim())) { enableTCK = false }
+                // Remove the line below prior to merging.
+                enableTCK = true
                 def useAdoptShellScripts = Boolean.valueOf(buildConfig.USE_ADOPT_SHELL_SCRIPTS)
                 def cleanWorkspace = Boolean.valueOf(buildConfig.CLEAN_WORKSPACE)
                 def cleanWorkspaceAfter = Boolean.valueOf(buildConfig.CLEAN_WORKSPACE_AFTER)


### PR DESCRIPTION
This change is useful because it lends context to situations when the remote job trigger fails before it can output any text that might help a user understand where a failure has occurred.

Resolves https://github.com/adoptium/ci-jenkins-pipelines/issues/1343