### PR TITLE
Amend node labels for mac builds requiring OSX.10.15 or later (JDK22+)

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1132,7 +1132,7 @@ class Build {
                     verifyNode = "ci.role.test&&sw.os.windows"
                 } else {
                     // Must run on Orka node to workaround issue https://github.com/adoptium/infrastructure/issues/3957
-                    verifyNode = "ci.role.test&&(sw.os.osx||sw.os.mac)&&!sw.os.osx.10_14&&orka"
+                    verifyNode = "ci.role.test&&(sw.os.osx||sw.os.mac)&&sw.os.osx.10_15_plus&&orka"
                 }
                 if (buildConfig.ARCHITECTURE == "aarch64") {
                     verifyNode = verifyNode + "&&hw.arch.aarch64"

--- a/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
@@ -7,7 +7,7 @@ class Config22 {
                 additionalNodeLabels: 'xcode15.0.1',
                 additionalTestLabels: [
                         openj9      : '!sw.os.osx.10_11',
-                        temurin     : '!sw.os.osx.10_14'
+                        temurin     : 'sw.os.osx.10_15_plus'
                 ],
                 test                : 'default',
                 configureArgs       : '--enable-dtrace',
@@ -58,7 +58,7 @@ class Config22 {
                 configureArgs       : [
                         'openj9'    : '--enable-headless-only=yes',
                         'temurin'   : '--enable-headless-only=yes --with-jobs=4'
-                ],  
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]
@@ -125,7 +125,7 @@ class Config22 {
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace',
                         'temurin'   : '--enable-dtrace --with-jobs=4'
-                ],  
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b03'
                 ]

--- a/pipelines/jobs/configurations/jdk23u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk23u_pipeline_config.groovy
@@ -7,7 +7,7 @@ class Config23 {
                 additionalNodeLabels: 'xcode15.0.1',
                 additionalTestLabels: [
                         openj9      : '!sw.os.osx.10_11',
-                        temurin     : '!sw.os.osx.10_14'
+                        temurin     : 'sw.os.osx.10_15_plus'
                 ],
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
@@ -60,7 +60,7 @@ class Config23 {
                 configureArgs       : [
                         'openj9'    : '--enable-headless-only=yes',
                         'temurin'   : '--enable-headless-only=yes --with-jobs=4'
-                ], 
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]

--- a/pipelines/jobs/configurations/jdk24u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk24u_pipeline_config.groovy
@@ -7,7 +7,7 @@ class Config24 {
                 additionalNodeLabels: 'xcode15.0.1',
                 additionalTestLabels: [
                         openj9      : '!sw.os.osx.10_11',
-                        temurin     : '!sw.os.osx.10_14'
+                        temurin     : 'sw.os.osx.10_15_plus'
                 ],
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']

--- a/pipelines/jobs/configurations/jdk25u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk25u_pipeline_config.groovy
@@ -7,7 +7,7 @@ class Config25 {
                 additionalNodeLabels: 'xcode15.0.1',
                 additionalTestLabels: [
                         openj9      : '!sw.os.osx.10_11',
-                        temurin     : '!sw.os.osx.10_14'
+                        temurin     : 'sw.os.osx.10_15_plus'
                 ],
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']

--- a/pipelines/jobs/configurations/jdk26_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk26_pipeline_config.groovy
@@ -7,7 +7,7 @@ class Config26 {
                 additionalNodeLabels: 'xcode15.0.1',
                 additionalTestLabels: [
                         openj9      : '!sw.os.osx.10_11',
-                        temurin     : '!sw.os.osx.10_14'
+                        temurin     : 'sw.os.osx.10_15_plus'
                 ],
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']


### PR DESCRIPTION
Fixes #1214 

Change the additional labels used in mac builds to ensure dynamic nodes can be spun up and arent blocked by the negative logic switch.

For the jenkins cloud plugins negative logic in labels, in this case !sw.os.osx.10_14   blocks orka provisioning.

I've changed the relevant nodes and cloud templates to have positive logic using the 

sw.osx.10_15_plus 

label and attached it to the relevant vm nodes and dynamic templates.