### PR TITLE
WIP: Overriding the default labels for xmac smoke tests

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -148,7 +148,7 @@ class Build {
         jobParams.put('GROUPS', 'functional')
         jobParams.put('TEST_JOB_NAME', "${env.JOB_NAME}_SmokeTests")
         if ( "${jobParams.ARCH_OS_LIST}" == "x86-64_mac") {
-            jobParams.put('LABEL', 'ci.role.test&&hw.arch.x86&&sw.os.osx&&macos14')
+            jobParams.put('LABEL', 'ci.role.test&&hw.arch.x86&&sw.os.osx&&macos15')
         }
         jobParams.put('BUILD_LIST', 'functional/buildAndPackage')
         def vendorTestRepos = ((String)ADOPT_DEFAULTS_JSON['repository']['build_url']) - ('.git')


### PR DESCRIPTION
Because the Orka plugin doesn't accept labels with "or" logic in them, which is the default.