### PR TITLE
Enable HEAD build of Oracle managed versions using beta trigger script

### DIFF
--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -232,7 +232,7 @@ node('worker') {
         triggerMainBuild = params.FORCE_MAIN
         triggerEvaluationBuild = params.FORCE_EVALUATION
         if (params.BUILD_HEAD) {
-            echo "FORCE building HEAD"
+            echo "FORCE building HEAD rather than latest tag"
             latestAdoptTag = ""
             publishJobTag = ""
         } 
@@ -344,10 +344,9 @@ if (triggerMainBuild || triggerEvaluationBuild) {
                         jobParams.add(text(name: 'targetConfigurations',   value: JsonOutput.prettyPrint(evaluationTargetConfigurations)))
                     }
 
-                    //#######def job = build job: "${pipeline}", propagate: true, parameters: jobParams
+                    def job = build job: "${pipeline}", propagate: true, parameters: jobParams
 
-                    //######echo "Triggered ${pipeline} build result = "+ job.getResult()
-echo "TRIGGER: build job: ${pipeline}, propagate: true, parameters: ${jobParams}"
+                    echo "Triggered ${pipeline} build result = "+ job.getResult()
                 }
             }
         }

--- a/pipelines/jobs/configurations/jdk25u.groovy
+++ b/pipelines/jobs/configurations/jdk25u.groovy
@@ -52,9 +52,6 @@ targetConfigurations = [
         ]
 ]
 
-// 12:05 Sat - Weekend schedule for Oracle managed version that has no published tags
-triggerSchedule_weekly  = 'TZ=UTC\n05 12 * * 6'
-
 // scmReferences to use for weekly release build
 weekly_release_scmReferences = [
         'hotspot'        : '',


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1357

Update beta trigger script to add "BUILD_HEAD" option for "FORCE" triggers, so that a [beta_Oracle_Managed_Version_Trigger](https://ci.adoptium.net/job/build-scripts/job/utils/job/beta_Oracle_Managed_Version_Trigger/) trigger job can be defined to FORCE build HEAD on a weekend schedule, but incorporating the disabled tests logic that is already done for triggers during a release period.
