### PR TITLE
Update remote job trigger wait to poll more frequently

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2395,6 +2395,9 @@ def buildScriptsAssemble(
                 for (int testIndex = 0; testIndex < remoteJobTargets.length; testIndex++) {
                     context.println "Current " + remoteJobTargets[testIndex] + " Status: " + currentStatus[remoteJobTargets[testIndex]] + " Build result: " + currentResult[remoteJobTargets[testIndex]] + " Remote build URL: " + remoteBuildUrl[remoteJobTargets[testIndex]];
                 }
+                if ( completedJckJobCount < remoteTriggeredBuilds.size() ) {
+                    context.println "Waiting for remote jck jobs to complete..."
+                }
             }
             if (remoteTriggeredBuilds.size() > completedJckJobCount) {
                 def sleepTimeMins = 4 // Must not be longer due to Jenkins design issue https://github.com/jenkinsci/jenkins/issues/21493


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1360

- Reduce remote triggered job poll to 4mins to avoid issue https://github.com/jenkinsci/jenkins/issues/21493
- Change Current status output logic to print every 6 polls to avoid too much console output

Test build job: https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/andrew_jdk21u-linux-x64-temurin/2/
