### PR TITLE
Don't trigger --disable-headful arctic jobs

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -622,7 +622,7 @@ class Build {
         }
 
         def appOptions="customJtx=${excludeRoot}/jenkins/jck_run/jdk${jdkVersion}/${excludePlat}/temurin.jtx"
-        if (configureArguments.contains('--enable-headless-only=yes')) {
+        if (configureArguments.contains('--enable-headless-only=yes') || configureArguments.contains('--disable-headful')) {
             // Headless platforms have no auto-manuals, so do not exclude any tests
             appOptions=""
         }
@@ -636,7 +636,8 @@ class Build {
         if ("${platform}" == 'ppc64_aix'
                 || "${platform}" == 'sparcv9_solaris'
                 || "${platform}" == 'x86-64_solaris'
-                || configureArguments.contains('--enable-headless-only=yes')) {
+                || configureArguments.contains('--enable-headless-only=yes')
+                || configureArguments.contains('--disable-headful')) {
             targets.replace("dev.jck", "disabled")
         }
 


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1363

Add check for --disable-headful.

Test build: https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk8u/job/andrew-jdk8u-alpine-linux-x64-temurin/1/console

