### PR TITLE
Put remote test job trigger into same parallel as aqa-tests, to avoid loss of remote job status

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2392,7 +2392,7 @@ def buildScriptsAssemble(
                     completedJckJobCount++
                 }
             }
-            // Issue current status every 6 polls (18 mins) or when all finished, so as not to clutter the console..
+            // Issue current status every 6 polls (24 mins) or when all finished, so as not to clutter the console..
             if ( (poll_count % 6) == 0 || completedJckJobCount == remoteTriggeredBuilds.size() ) {
                 for (int testIndex = 0; testIndex < remoteJobTargets.length; testIndex++) {
                     context.println "Current " + remoteJobTargets[testIndex] + " Status: " + currentStatus[remoteJobTargets[testIndex]] + " Build result: " + currentResult[remoteJobTargets[testIndex]] + " Remote build URL: " + remoteBuildUrl[remoteJobTargets[testIndex]];


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1369

I believe the problem is the time between the jck job trigger and the start of the waitForJck logic is several hours, as the AQA tests have to complete before the waitForJck starts... In this time the remote jck job may still be in waiting, or possibly already traversed into the "Queued" status at the point of trigger, so that several hours later the remoteTriggerPlugin will have lost state of the remote job as it will be far beyond the "5 mins" at which queued jobs status is purged.

- This PR combines the waitForJck into the same parallel context as the AQA tests, so it is run in parallel from immediately after the remote Jck trigger.
=> This also provides the advantage now of knowing the jck job results before all the AQA tests have completed.

- I have also now forced any remote jck job updateStatus failure to FAILURE and abort waiting for that jck stage, as when this exception occurs it never seems to resolve causing hung build jobs. So best to fail.

Test: https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk25u/job/jdk25u-linux-x64-temurin/29/ - SUCCESS, worked very well.

Note, one side affect of using CPS-aware "sleep" is it is verbose (printing Sleeping for...), it is not possible to sleep quietly and still run in a Flyweight Executor context. We don't want to allocate a node, otherwise too many node allocations will be needed by all waiting test jobs...
