### PR TITLE
Revert "Undo parallel remote test job wait orchestration"

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2915,26 +2915,19 @@ def buildScriptsAssemble(
                                     }
                                 }
 
-                                def aqaTestStages = [:]
+                                def testStages = [:]
                                 if (buildConfig.TEST_LIST.size() > 0) {
-                                    aqaTestStages = runAQATests(aqaTestStages)
+                                    testStages = runAQATests(testStages)
                                 }
 
-                                // Create jckWaitTestStages to get the remote JCK job status and set as the stage status.
-                                def jckWaitTestStages = [:]
+                                // Asynchronously get the remote JCK job status and set as the stage status.
                                 if (buildConfig.VARIANT == 'temurin' && enableTCK && remoteTriggeredBuilds.asBoolean()) {
-                                    jckWaitTestStages = waitForJckStatus(remoteTriggeredBuilds, jckWaitTestStages)
+                                    testStages = waitForJckStatus(remoteTriggeredBuilds, testStages)
                                 }
 
-                                // Run the aqaTestStages in parallel
-                                if (!aqaTestStages.isEmpty()) {
-                                    context.parallel aqaTestStages
-                                }
-
-                                // Now run jckWaitTestStages
-                                // We cannot run this in parallel with aqaTestStages as it likely blows Jenkins CPS orchestration JVM Heap Memory
-                                if (!jckWaitTestStages.isEmpty()) {
-                                    context.parallel jckWaitTestStages
+                                // Run the testStages in parallel
+                                if (!testStages.isEmpty()) {
+                                    context.parallel testStages
                                 }
                             } else {
                                 context.println('[ERROR]Smoke tests are not successful! AQA and Tck tests are blocked ')


### PR DESCRIPTION
Reverts adoptium/ci-jenkins-pipelines#1400

The Jenkins JVM Heap analysis highlights this was not the problem https://github.com/adoptium/infrastructure/issues/4364

We need this feature to get remote tck results quicker, so reverting removal.
