### PR TITLE
Fix s390x repro status and correct obtaining the latest pipeline reproduciblity when more than one rerun

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -567,6 +567,12 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
                 continue platformIterator
             }
 
+            // If this platform already has a reproducibility test result, then we already have the "latest" result.
+            if (!results[jdkVersion][1][onePlatform].equals("?")) {
+                // We have the latest result, skip to the next platform.
+                continue platformIterator
+            }
+
             def pipelineLink = "${trssURL}/api/getAllChildBuilds?parentId=${trssId}\\&buildNameRegex=^${jdkVersion}\\-${platformConversionMap[onePlatform][0]}\\-temurin\$"
 
             def trssBuildJobNames = callWgetSafely("${pipelineLink}", cookieJar)

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -545,7 +545,7 @@ def extractVersNum(String jdkVers) {
 
 // For a given pipeline, tell us how reproducible the builds were.
 // Note: Will limit itself to jdk versions and platforms in the results Map.
-def getReproducibilityPercentage(String jdkVersion, String trssId, String trssURL, String srcTag, Map results, String cookieJar) {
+def getReproducibilityPercentage(String jdkVersion, String trssId, String trssURL, Map results, String cookieJar) {
     echo "Called repro method with trssID:"+trssId
 
     def platformConversionMap = getPlatformConversionMap()
@@ -1175,7 +1175,7 @@ node('worker') {
                                 echo "Checking for reproducibility results in pipeline: ${reproBuildUrl}"
                                 echo "This pipeline's current status is ${reproBuildStatus}"
 
-                                getReproducibilityPercentage(featureRelease, reproBuildTrss, trssUrl, releaseName, reproducibleBuilds, cookieJar)
+                                getReproducibilityPercentage(featureRelease, reproBuildTrss, trssUrl, reproducibleBuilds, cookieJar)
                             }
 
                             if ( ! reproducibleBuilds[featureRelease][0].startsWith("100") ) {

--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -54,7 +54,7 @@ def getPlatformReproTestMap() {
                                 x64Mac:             ["special.system", "Rebuild_Same_JDK_Reproducibility_Test_Mac"],
                                 ppc64leLinux:       ["special.system", "Rebuild_Same_JDK_Reproducibility_Test"],
                                 aarch64Linux:       ["special.system", "Rebuild_Same_JDK_Reproducibility_Test"],
-                                s390xLinux:         ["special.system", "Rebuild_Same_JDK_Reproducibility_Test_s390x"],
+                                s390xLinux:         ["special.system", "Rebuild_Same_JDK_Reproducibility_Test"],
                                 aarch64Mac:         ["special.system", "Rebuild_Same_JDK_Reproducibility_Test_Mac"]
                                ]
     return platformReproTestMap
@@ -554,14 +554,6 @@ def getReproducibilityPercentage(String jdkVersion, String trssId, String trssUR
     // We are only looking for reproducible percentages for the relevant jdk versions...
     if ( trssId != "" && results.containsKey(jdkVersion) ) {
 
-        // See if we can find a more recent build ID for each platform.
-        def mapOfMoreRecentBuildIDs = [:]
-        results[jdkVersion][1].each { onePlatform, valueNotUsed ->
-            mapOfMoreRecentBuildIDs[onePlatform] = ""
-        }
-getBuildIDsByPlatform(trssURL, jdkVersion, srcTag, mapOfMoreRecentBuildIDs, cookieJar)
-
-
         def jdkVersionInt = jdkVersion.replaceAll("[a-z]", "")
 
         platformIterator:
@@ -576,15 +568,8 @@ getBuildIDsByPlatform(trssURL, jdkVersion, srcTag, mapOfMoreRecentBuildIDs, cook
             }
 
             def pipelineLink = "${trssURL}/api/getAllChildBuilds?parentId=${trssId}\\&buildNameRegex=^${jdkVersion}\\-${platformConversionMap[onePlatform][0]}\\-temurin\$"
-            if (mapOfMoreRecentBuildIDs.containsKey(onePlatform) && !mapOfMoreRecentBuildIDs[onePlatform].equals("")) {
-                echo "Overriding the TRSS build ID for ${jdkVersion}, platform ${onePlatform}, tag ${srcTag}"
-                echo "Original TRSS pipeline link: ${pipelineLink}"
-                echo "New link: ${trssURL}/api/getData?_id=${mapOfMoreRecentBuildIDs[onePlatform]}"
-                pipelineLink = "${trssURL}/api/getData?_id=${mapOfMoreRecentBuildIDs[onePlatform]}"
-            }
 
             def trssBuildJobNames = callWgetSafely("${pipelineLink}", cookieJar)
-            results[jdkVersion][1][onePlatform] = "???% - Build not found. Pipeline link: " + pipelineLink
 
             // Does this platform have a build in this pipeline? If not, skip to next platform.
             if ( trssBuildJobNames.length() <= 2 ) {
@@ -597,7 +582,7 @@ getBuildIDsByPlatform(trssURL, jdkVersion, srcTag, mapOfMoreRecentBuildIDs, cook
             assert buildJobNamesJson instanceof List
             buildIterator:
             for ( Map buildJob in buildJobNamesJson ) {
-                results[jdkVersion][1][onePlatform] = "???% - Build found, but no reproducibility tests. Build link: " + buildJob.buildUrl
+                echo "$jdkVersion : $onePlatform : Checking build for reproducibility tests. Build link: " + buildJob.buildUrl
                 def testPlatform = platformConversionMap[onePlatform][1]
                 def reproTestName=platformReproTestMap[onePlatform][1]+"_0"
                 def reproTestBucket=platformReproTestMap[onePlatform][0]
@@ -608,7 +593,7 @@ getBuildIDsByPlatform(trssURL, jdkVersion, srcTag, mapOfMoreRecentBuildIDs, cook
                     continue buildIterator
                 }
 
-                results[jdkVersion][1][onePlatform] = "???% - Found ${reproTestBucket}, but did not find ${reproTestName}. Build Link: " + buildJob.buildUrl
+                echo "$jdkVersion : $onePlatform : Checking ${reproTestBucket} for ${reproTestName}. Build link: " + buildJob.buildUrl
                 def testJobNamesJson = new JsonSlurper().parseText(trssTestJobNames)
 
                 // For each test job (including testList subjobs), we now search for the reproducibility test.
@@ -625,8 +610,7 @@ getBuildIDsByPlatform(trssURL, jdkVersion, srcTag, mapOfMoreRecentBuildIDs, cook
                             wgetUrl = "${trssURL}/api/getOutputById?id=${testTarget.testOutputId}"
                         }
                     }
-def testOutput = callWgetSafely(wgetUrl, cookieJar)
-
+                    def testOutput = callWgetSafely(wgetUrl, cookieJar)
 
                     // If we can find it, then we look for the anticipated percentage.
                     if ( !testOutput.contains("Running test "+reproTestName) ) {
@@ -634,7 +618,7 @@ def testOutput = callWgetSafely(wgetUrl, cookieJar)
                         continue testIterator
                     }
 
-                    results[jdkVersion][1][onePlatform] = "???% - ${reproTestName} ran but failed to produce a percentage. Test Link: " + testJob.buildUrl
+                    echo "$jdkVersion : $onePlatform : ${reproTestName} ran, checking for reproducibility percentage. Test Link: " + testJob.buildUrl
                     // Now we know the test ran:
                     def matcherObject = testOutput =~ /ReproduciblePercent = (100|[0-9][0-9]?\.?[0-9]?[0-9]?) %/
                     if ( matcherObject ) {


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1408

- For s390x the reproducibility target had changed from using a bespoke s390x target to sharing the common linux one, so just had to correct that in the status tool.
- The jdk21u incorrect reporting was because there was a re-run of the jdk-21.0.12+5 pipeline, the reproducibility check correctly found the rerun results which were mostly 100%, but then it continued to iterate over the previous build and over-wrote the correct status with "???" not found result, which is what got reported... Changed this to report the latest result, and not overwrite if a result has already been found while iterating the matching pipelines.

Tests:
- jdk21u : See https://adoptium.slack.com/archives/C09NW3L2J/p1781011937562609
- jdk25u : See https://adoptium.slack.com/archives/C09NW3L2J/p1781011966775259
- 