### PR TITLE
Change cleanWorkspace DEFAULTS.json to true

### DIFF
--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -80,8 +80,8 @@
     "defaultsUrl"            : "https://raw.githubusercontent.com/adoptium/ci-jenkins-pipelines/master/pipelines/defaults.json",
     "enableInstallers"       : true,
     "enableSigner"           : true,
-    "cleanWorkspaceBeforeBuild" : false,
-    "cleanWorkspaceAfterBuild"  : false,
+    "cleanWorkspaceBeforeBuild" : true,
+    "cleanWorkspaceAfterBuild"  : true,
     "cleanReleaseWorkspaceBeforeBuild" : true,
-    "cleanReleaseWorkspaceAfterBuild"  : false
+    "cleanReleaseWorkspaceAfterBuild"  : true
 }


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1413

Change all the cleanWorkspace values in DEFAULTS.json to "true", to ensure standard scheduled builds clean up before and afterwards to avoid excess workspace disk usage.
