### PR TITLE
Allow Windows Sign Verification To Run On Dynamic Nodes

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -699,7 +699,7 @@ class Build {
                 // Determine suitable node to run on
                 def verifyNode
                 if (buildConfig.TARGET_OS == "windows") {
-                    verifyNode = "ci.role.test&&sw.os.windows"
+                    verifyNode = "((ci.role.test&&sw.os.windows)||(ci.agent.dynamic&&sw.os.windows.2022))"
                 } else {
                     verifyNode = "ci.role.test&&(sw.os.osx||sw.os.mac)"
                 }


### PR DESCRIPTION
Fixes #1440 

Update the sign verification job to allow running on windows nodes..

Tested here: https://ci.adoptium.net/job/build-scripts/job/release/job/sign_verification/4200/

#Assisted by IBM Bob