### PR TITLE
Ensure smoke tests are available to use Dynamic nodes

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -237,21 +237,40 @@ class Build {
                     }
                 }
 
+                def testJobParamsMap = [
+                    UPSTREAM_JOB_NUMBER: "${env.BUILD_NUMBER}",
+                    UPSTREAM_JOB_NAME: "${env.JOB_NAME}",
+                    SDK_RESOURCE: 'upstream',
+                    JDK_VERSION: "${jobParams.JDK_VERSIONS}",
+                    LABEL_ADDITION: "${additionalTestLabel}",
+                    KEEP_REPORTDIR: "${buildConfig.KEEP_TEST_REPORTDIR}",
+                    ACTIVE_NODE_TIMEOUT: "${buildConfig.ACTIVE_NODE_TIMEOUT}",
+                    DYNAMIC_COMPILE: "true",
+                    VENDOR_TEST_REPOS: "${vendorTestRepos}",
+                    VENDOR_TEST_BRANCHES: "${vendorTestBranches}",
+                    TIME_LIMIT: '1'
+                ]
+
+                def additionalTestParams = buildConfig.ADDITIONAL_TEST_PARAMS
+                if (Map.isInstance(additionalTestParams)) {
+                    additionalTestParams.each { additionalParam, additionalParamValue ->
+                        testJobParamsMap[(additionalParam)] = additionalParamValue.toString()
+                    }
+                }
+                
+                def testJobParams = []
+                testJobParamsMap.each { paramKey, paramValue ->
+                    if (paramValue == 'true' || paramValue == 'false') {
+                        testJobParams << context.booleanParam(name: paramKey, value: paramValue.toBoolean())
+                    } else {
+                        testJobParams << context.string(name: paramKey, value: paramValue)
+                    }
+                }
+
                 def testJob = context.build job: jobName,
                     propagate: false,
-                    parameters: [
-                            context.string(name: 'SDK_RESOURCE', value: 'upstream'),
-                            context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
-                            context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
-                            context.string(name: 'JDK_VERSION', value: "${jobParams.JDK_VERSIONS}"),
-                            context.string(name: 'LABEL_ADDITION', value: additionalTestLabel),
-                            context.booleanParam(name: 'KEEP_REPORTDIR', value: buildConfig.KEEP_TEST_REPORTDIR),
-                            context.string(name: 'ACTIVE_NODE_TIMEOUT', value: "${buildConfig.ACTIVE_NODE_TIMEOUT}"),
-                            context.booleanParam(name: 'DYNAMIC_COMPILE', value: true),
-                            context.string(name: 'VENDOR_TEST_REPOS', value: vendorTestRepos),
-                            context.string(name: 'VENDOR_TEST_BRANCHES', value: vendorTestBranches),
-                            context.string(name: 'TIME_LIMIT', value: '1')
-                    ]
+                    parameters: testJobParams
+                    
                 currentBuild.result = testJob.getResult()
                 setStageResult("smoke test", testJob.getResult())
                 return testJob.getResult()

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -6,6 +6,9 @@ class Config11 {
                 arch                : 'x64',
                 test                : 'default',
                 additionalNodeLabels: 'xcode15.0.1',
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'gha']
+                ],
                 configureArgs       : [
                         'openj9'      : '--enable-dtrace=auto --with-cmake',
                         'temurin'     : '--enable-dtrace=auto --disable-ccache'
@@ -80,6 +83,9 @@ class Config11 {
                         temurin:    'win2022&&vs2022',
                         openj9:     'win2012&&vs2017',
                         dragonwell: 'win2012'
+                ],
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'azure']
                 ],
                 configureArgs       : [
                         'temurin'   : '--disable-ccache'

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -9,6 +9,9 @@ class Config17 {
                         openj9      : '!sw.os.osx.10_11'
                 ],
                 test                : 'default',
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'gha']
+                ],
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
@@ -76,6 +79,9 @@ class Config17 {
                 dockerCredential    : 'bbb9fa70-a1de-4853-b564-5f02193329ac',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test                : 'default',
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'azure']
+                ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit vs2022_redist_14.40.33807_10.0.26100.1742'
                 ]

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -11,6 +11,9 @@ class Config21 {
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
                 ],
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'gha']
+                ],
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
@@ -78,6 +81,9 @@ class Config21 {
                 additionalNodeLabels: 'win2022&&vs2022',
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
+                ],
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'azure']
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit vs2022_redist_14.40.33807_10.0.26100.1742'

--- a/pipelines/jobs/configurations/jdk25u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk25u_pipeline_config.groovy
@@ -11,6 +11,9 @@ class Config25 {
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
                 ],
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'gha']
+                ],
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
@@ -78,6 +81,9 @@ class Config25 {
                 additionalNodeLabels: 'win2022&&vs2022',
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
+                ],
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'azure']
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit vs2022_redist_14.40.33807_10.0.26100.1742'

--- a/pipelines/jobs/configurations/jdk26u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk26u_pipeline_config.groovy
@@ -11,6 +11,9 @@ class Config26 {
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
                 ],
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'gha']
+                ],
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
@@ -78,6 +81,9 @@ class Config26 {
                 additionalNodeLabels: 'win2022&&vs2022',
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
+                ],
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'azure']
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit vs2022_redist_14.40.33807_10.0.26100.1742'

--- a/pipelines/jobs/configurations/jdk27_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk27_pipeline_config.groovy
@@ -11,6 +11,9 @@ class Config27 {
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
                 ],
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'gha']
+                ],
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
@@ -78,6 +81,9 @@ class Config27 {
                 additionalNodeLabels: 'win2022&&vs2022',
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
+                ],
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'azure']
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit vs2022_redist_14.40.33807_10.0.26100.1742'

--- a/pipelines/jobs/configurations/jdk28_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk28_pipeline_config.groovy
@@ -11,6 +11,9 @@ class Config28 {
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
                 ],
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'gha']
+                ],
                 configureArgs       : '--enable-dtrace',
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom'
@@ -78,6 +81,9 @@ class Config28 {
                 additionalNodeLabels: 'win2022&&vs2022',
                 test: [
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system', 'special.system']
+                ],
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'azure']
                 ],
                 buildArgs           : [
                         'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit vs2022_redist_14.40.33807_10.0.26100.1742'

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -9,6 +9,9 @@ class Config8 {
                         openj9  : 'macos10.14'
                 ],
                 test                 : 'default',
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'gha']
+                ],
                 configureArgs       : [
                         'temurin'   : '--disable-ccache'
                 ],
@@ -76,6 +79,9 @@ class Config8 {
                 dockerCredential    : 'bbb9fa70-a1de-4853-b564-5f02193329ac',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test                 : 'default',
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'azure']
+                ],
                 configureArgs       : [
                         'temurin'   : '--disable-ccache'
                 ],


### PR DESCRIPTION
Close #1448 

Test pipeline (note pr-tester doesn't gen build_configurations correctly)
https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-windows-x64-temurin/376/ - SUCCESS, used Azure Windows dynamic agent
