### PR TITLE
Add SBOM artifact to pass to AQA_Test_Pipeline

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -272,6 +272,18 @@ class Build {
         def testImageName = jdkFileName.replace('-jdk_', '-testimage_')
        // def staticLibName = jdkFileName.replace('-jdk_', '-static-libs_')
         def sdkUrl = "${env.BUILD_URL}/artifact/workspace/target/${jdkFileName} ${env.BUILD_URL}/artifact/workspace/target/${testImageName}"
+
+        // If SBOM created then need to pass to aqa-tests for special.system reproducible verification test
+        if (buildConfig.BUILD_ARGS?.contains('--create-sbom')) {
+            def sbomName = jdkFileName.replace('-jdk_', '-sbom_')
+            if (buildConfig.TARGET_OS == 'windows') {
+                sbomName = sbomName.replace('.zip', '.json')
+            } else {
+                sbomName = sbomName.replace('.tar.gz', '.json')
+            }
+            sdkUrl += " ${env.BUILD_URL}/artifact/workspace/target/${sbomName}"
+        }
+
         def aqaTestPipelineJobName = "AQA_Test_Pipeline"
         def releaseAppendix = ''
         if (buildConfig.SCM_REF && buildConfig.AQA_REF) {


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1446

Add SBOM to AQA-tests sdkUrl, if --create-sbom specified.

Test: https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-linux-x64-temurin/448/ - SUCCESS sbom on SDK url list
