### PR TITLE
Also build jtreg version 8.3+1

### DIFF
--- a/tools/code-tools/jtreg.sh
+++ b/tools/code-tools/jtreg.sh
@@ -22,6 +22,7 @@ readonly JTREG_7_5_2='jtreg-7.5.2+1'
 readonly JTREG_8='jtreg-8+2'
 readonly JTREG_8_1='jtreg-8.1+1'
 readonly JTREG_8_2_1='jtreg-8.2.1+1'
+readonly JTREG_8_3='jtreg-8.3+1'
 
 function checkJdks() {
   jvm_dir="/usr/lib/jvm/"
@@ -113,6 +114,10 @@ buildJTReg()
       export JTREG_BUILD_NUMBER="1"
       export BUILD_VERSION="8.2.1"
       export JAVA_HOME=/usr/lib/jvm/jdk17
+    elif [ "$1" == "$JTREG_8_3" ]; then
+      export JTREG_BUILD_NUMBER="1"
+      export BUILD_VERSION="8.3"
+      export JAVA_HOME=/usr/lib/jvm/jdk17
     fi
     git checkout $version
   else
@@ -197,5 +202,6 @@ buildJTReg "$JTREG_7_5_2"
 buildJTReg "$JTREG_8"
 buildJTReg "$JTREG_8_1"
 buildJTReg "$JTREG_8_2_1"
+buildJTReg "$JTREG_8_3"
 buildJTReg
 echo '...finished with build process.'


### PR DESCRIPTION
Required by openjdk change:
* [8386844: Update to use jtreg 8.3](https://github.com/openjdk/jdk/commit/b735de6d7190afde0fb056d7c439938439744576)