### PR TITLE
Enable Use Of Dynamic Azure Nodes for Windows on aarch64 (#1485)

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -731,7 +731,11 @@ class Build {
                 // Determine suitable node to run on
                 def verifyNode
                 if (buildConfig.TARGET_OS == "windows") {
-                    verifyNode = "((ci.role.test&&sw.os.windows)||(ci.agent.dynamic&&sw.os.windows.2022))"
+                    if (buildConfig.ARCHITECTURE == "aarch64") {
+                        verifyNode = "((ci.role.test&&sw.os.windows)||(ci.agent.dynamic&&sw.os.windows.11))"
+                    } else {
+                        verifyNode = "((ci.role.test&&sw.os.windows)||(ci.agent.dynamic&&sw.os.windows.2022))"
+                    }
                 } else {
                     verifyNode = "ci.role.test&&(sw.os.osx||sw.os.mac)"
                 }

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -267,6 +267,9 @@ class Config11 {
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test                : 'default',
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'azure']
+                ],
                 configureArgs       : [
                         'temurin'   : '--disable-ccache'
                 ], 

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -197,6 +197,9 @@ class Config17 {
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test                : 'default',
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'azure']
+                ],
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile --use-adoptium-devkit vs2022_redist_14.40.33807_10.0.26100.1742'
                 ]

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -185,6 +185,9 @@ class Config21 {
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test                : 'default',
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'azure']
+                ],
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile --use-adoptium-devkit vs2022_redist_14.40.33807_10.0.26100.1742'
                 ]

--- a/pipelines/jobs/configurations/jdk25u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk25u_pipeline_config.groovy
@@ -188,6 +188,9 @@ class Config25 {
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test                : 'default',
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'azure']
+                ],
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile --use-adoptium-devkit vs2022_redist_14.40.33807_10.0.26100.1742'
                 ]

--- a/pipelines/jobs/configurations/jdk26u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk26u_pipeline_config.groovy
@@ -186,6 +186,9 @@ class Config26 {
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test                : 'default',
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'azure']
+                ],
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile --use-adoptium-devkit vs2022_redist_14.40.33807_10.0.26100.1742'
                 ]

--- a/pipelines/jobs/configurations/jdk27_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk27_pipeline_config.groovy
@@ -186,6 +186,9 @@ class Config27 {
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test                : 'default',
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'azure']
+                ],
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile --use-adoptium-devkit vs2022_redist_14.40.33807_10.0.26100.1742'
                 ]

--- a/pipelines/jobs/configurations/jdk28_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk28_pipeline_config.groovy
@@ -186,6 +186,9 @@ class Config28 {
                 crossCompile        : 'x64',
                 additionalNodeLabels: 'win2022&&vs2022',
                 test                : 'default',
+                additionalTestParams: [
+                        temurin     : [CLOUD_PROVIDER: 'azure']
+                ],
                 buildArgs       : [
                         'temurin'   : '--create-jre-image --create-sbom --cross-compile --use-adoptium-devkit vs2022_redist_14.40.33807_10.0.26100.1742'
                 ]


### PR DESCRIPTION
Cherry pick of #1485 

* Enable Dynamic Nodes For Windows On Arm64

* Enable Dynamic OS Selection Based On Arch.

* Add cloud provider for redundant JDK11 / windows / aarch64