### PR TITLE
Avoid corrupt upstreamTag when CSPU release shares GA commit

### DIFF
--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -96,7 +96,10 @@ def resolveGaTag(String jdkVersion, String jdkBranch) {
         def foundRepo = resolveGaCommit.get(0)
         def foundSHA  = resolveGaCommit.get(1)
         // Find upstream target actual tag, ignore any other "-ga" tags, must be a real build tag
-        def upstreamTag = sh(returnStdout: true, script:"git ls-remote --tags ${foundRepo} ${annotatedTagFilter} | grep \"${foundSHA}\" | grep -v \"${jdkBranch}\" | grep -v '\\-ga' | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | sed \"s,\\^{},,\" | tr -d '\\n'")
+        // Use version prefix with "+" (e.g. "jdk-17.0.20+" from "jdk-17.0.20-ga") to avoid matching
+        // sibling tags on the same commit (e.g. jdk-17.0.20.1+0 shares the same commit as jdk-17.0.20+8)
+        def versionPrefix = jdkBranch.replaceAll('-ga$', '')
+        def upstreamTag = sh(returnStdout: true, script:"git ls-remote --tags ${foundRepo} ${annotatedTagFilter} | grep \"${foundSHA}\" | grep -v \"${jdkBranch}\" | grep -v '\\-ga' | grep \"${versionPrefix}+\" | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | sed \"s,\\^{},,\" | tr -d '\\n'")
         if (upstreamTag != "") {
             println "[INFO] Resolved ${jdkBranch} to upstream build tag ${upstreamTag}"
             resolvedTag = upstreamTag

--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -99,7 +99,8 @@ def resolveGaTag(String jdkVersion, String jdkBranch) {
         // Use version prefix with "+" (e.g. "jdk-17.0.20+" from "jdk-17.0.20-ga") to avoid matching
         // sibling tags on the same commit (e.g. jdk-17.0.20.1+0 shares the same commit as jdk-17.0.20+8)
         def versionPrefix = jdkBranch.replaceAll('-ga$', '')
-        def upstreamTag = sh(returnStdout: true, script:"git ls-remote --tags ${foundRepo} ${annotatedTagFilter} | grep \"${foundSHA}\" | grep -v \"${jdkBranch}\" | grep -v '\\-ga' | grep \"${versionPrefix}+\" | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | sed \"s,\\^{},,\" | tr -d '\\n'")
+        def versionFilter = (jdkVersion.toInteger() > 8) ? "| grep -F \"${versionPrefix}+\"" : ""
+        def upstreamTag = sh(returnStdout: true, script:"git ls-remote --tags ${foundRepo} ${annotatedTagFilter} | grep \"${foundSHA}\" | grep -v \"${jdkBranch}\" | grep -v '\\-ga' ${versionFilter} | tr -s '\\t ' ' ' | cut -d' ' -f2 | sed \"s,refs/tags/,,\" | sed \"s,\\^{},,\" | tr -d '\\n'")
         if (upstreamTag != "") {
             println "[INFO] Resolved ${jdkBranch} to upstream build tag ${upstreamTag}"
             resolvedTag = upstreamTag


### PR DESCRIPTION
Fix #1492 

Adding `grep "${versionPrefix}+"` to restrict the result to only tags of the exact same version, excluding sibling CPU
release tags that happen to share the same commit.


Assist with BOB