### PR TITLE
Passing AQA_AUTO_GEN to AQA_Test_Pipeline_JCK job

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -359,7 +359,7 @@ class Build {
         if (Boolean.valueOf(buildConfig.RELEASE)) {
             build_type = 'release'
         }
-        def aqaAutoGen = buildConfig.AQA_AUTO_GEN ?: false
+def aqaAutoGen = Boolean.valueOf(buildConfig.AQA_AUTO_GEN as String)
         try {
 
             def displayName = "jdk${jobParams.JDK_VERSIONS} : ${buildConfig.SCM_REF} : ${build_type} : ${jobParams.ARCH_OS_LIST}"

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -359,6 +359,7 @@ class Build {
         if (Boolean.valueOf(buildConfig.RELEASE)) {
             build_type = 'release'
         }
+        def aqaAutoGen = buildConfig.AQA_AUTO_GEN ?: false
         try {
 
             def displayName = "jdk${jobParams.JDK_VERSIONS} : ${buildConfig.SCM_REF} : ${build_type} : ${jobParams.ARCH_OS_LIST}"
@@ -371,6 +372,7 @@ class Build {
                     context.string(name: 'JDK_VERSIONS', value: "${jobParams.JDK_VERSIONS}"),
                     context.string(name: 'PLATFORMS', value: "${jobParams.ARCH_OS_LIST}"),
                     context.string(name: 'PIPELINE_DISPLAY_NAME', value: "${displayName}"),
+                    context.booleanParam(name: 'AQA_AUTO_GEN', value: aqaAutoGen),
                     context.string(name: 'BUILD_TYPE', value: "${build_type}")
                 ],
                 wait: false,


### PR DESCRIPTION
This ensures weekly or release run force regen remote jck tests jobs. If job templates updates test jobs will also be updated.

Related with https://github.com/adoptium/aqa-tests/issues/7629