### PR TITLE
EA build replace GitHub issue release check with date-based release period detection and limit weekly TCK to primary platforms

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -84,7 +84,7 @@ class Build {
     /*
     Returns true if the given architecture and OS combination is a primary platform for TCK testing
     */
-    boolean isPrimaryPlatform(String javaToBuild, String architecture, String targetOs) {
+    boolean isPrimaryPlatform(String architecture, String targetOs) {
         return PRIMARY_PLATFORMS.contains("${architecture}_${targetOs}".toLowerCase())
     }
 
@@ -2011,7 +2011,7 @@ def buildScriptsAssemble(
                 def enableInstallers = Boolean.valueOf(buildConfig.ENABLE_INSTALLERS)
                 def enableSigner = Boolean.valueOf(buildConfig.ENABLE_SIGNER)
                 def enableTCK = Boolean.valueOf(buildConfig.RELEASE) ||
-                    (Boolean.valueOf(buildConfig.WEEKLY) && isPrimaryPlatform(buildConfig.JAVA_TO_BUILD, buildConfig.ARCHITECTURE, buildConfig.TARGET_OS))
+                    (Boolean.valueOf(buildConfig.WEEKLY) && isPrimaryPlatform(buildConfig.ARCHITECTURE, buildConfig.TARGET_OS))
                 if ('jdk'.equalsIgnoreCase(buildConfig.JAVA_TO_BUILD.trim())) { enableTCK = false }
                 def useAdoptShellScripts = Boolean.valueOf(buildConfig.USE_ADOPT_SHELL_SCRIPTS)
                 def cleanWorkspace = Boolean.valueOf(buildConfig.CLEAN_WORKSPACE)

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -72,7 +72,7 @@ class Build {
     String crossCompileVersionPath = ''
     Map variantVersion = [:]
 
-    // Primary platforms for TCK testing: arch_os combinations that are considered primary
+    // Primary platforms for Temurin TCK testing: arch_os combinations that are considered primary
     static final Set<String> PRIMARY_PLATFORMS = [
         'x64_linux',
         'x64_windows',

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -72,6 +72,22 @@ class Build {
     String crossCompileVersionPath = ''
     Map variantVersion = [:]
 
+    // Primary platforms for TCK testing: arch_os combinations that are considered primary
+    static final Set<String> PRIMARY_PLATFORMS = [
+        'x64_linux',
+        'x64_windows',
+        'x64_mac',
+        'aarch64_linux',
+        'aarch64_mac'
+    ] as Set
+
+    /*
+    Returns true if the given architecture and OS combination is a primary platform for TCK testing
+    */
+    boolean isPrimaryPlatform(String javaToBuild, String architecture, String targetOs) {
+        return PRIMARY_PLATFORMS.contains("${architecture}_${targetOs}".toLowerCase())
+    }
+
     // Declare timeouts for each critical stage (unit is HOURS)
     Map buildTimeouts = [
         API_REQUEST_TIMEOUT : 1,
@@ -1994,7 +2010,8 @@ def buildScriptsAssemble(
                 def enableTests = Boolean.valueOf(buildConfig.ENABLE_TESTS)
                 def enableInstallers = Boolean.valueOf(buildConfig.ENABLE_INSTALLERS)
                 def enableSigner = Boolean.valueOf(buildConfig.ENABLE_SIGNER)
-                def enableTCK = Boolean.valueOf(buildConfig.RELEASE) || Boolean.valueOf(buildConfig.WEEKLY)
+                def enableTCK = Boolean.valueOf(buildConfig.RELEASE) ||
+                    (Boolean.valueOf(buildConfig.WEEKLY) && isPrimaryPlatform(buildConfig.JAVA_TO_BUILD, buildConfig.ARCHITECTURE, buildConfig.TARGET_OS))
                 if ('jdk'.equalsIgnoreCase(buildConfig.JAVA_TO_BUILD.trim())) { enableTCK = false }
                 def useAdoptShellScripts = Boolean.valueOf(buildConfig.USE_ADOPT_SHELL_SCRIPTS)
                 def cleanWorkspace = Boolean.valueOf(buildConfig.CLEAN_WORKSPACE)

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -17,7 +17,6 @@ import java.nio.file.NoSuchFileException
 import groovy.json.JsonOutput
 import java.time.ZoneId
 import java.time.ZonedDateTime
-import java.time.Month
 import java.time.DayOfWeek
 import java.time.temporal.ChronoUnit
 import java.time.temporal.TemporalAdjusters
@@ -47,29 +46,22 @@ def evaluationTargetConfigurations = overrideEvaluationTargetConfigurations
 def latestAdoptTag
 def publishJobTag
 
-// Is the current day within the release period of from the previous Saturday to the following Sunday
-// from the release Tuesday ?
-// Release Tuesday is now the 3rd Tuesday of the month
+// Is the current day within the release period from release Tuesday to 7 days after?
+// Release Tuesday is the 3rd Tuesday of the month.
+// Checked every month to account for CSPUs which can release in any month.
 def isDuringReleasePeriod() {
     def releasePeriod = false
     def now = ZonedDateTime.now(ZoneId.of('UTC'))
-    def month = now.getMonth()
 
-    // Is it a release month? CPU updates in Jan, Apr, Jul, Oct
-    // New major versions are released in Mar and Sept
-    if (month == Month.JANUARY || month == Month.MARCH || month == Month.APRIL || month == Month.JULY || month == Month.SEPTEMBER || month == Month.OCTOBER) {
-        // Yes, calculate release Tuesday, which is the 3rd Tuesday of the month
-        def day1st = now.withDayOfMonth(1)
-        def releaseTuesday = day1st.with(TemporalAdjusters.dayOfWeekInMonth(3, DayOfWeek.TUESDAY))
-        echo "Release Tuesday for this month is: "+releaseTuesday
+    // Calculate the 3rd Tuesday of the current month
+    def day1st = now.withDayOfMonth(1)
+    def releaseTuesday = day1st.with(TemporalAdjusters.dayOfWeekInMonth(3, DayOfWeek.TUESDAY))
+    echo "Release Tuesday for this month is: "+releaseTuesday
 
-        // Release period no "testing" trigger, from release tuesday to 7 days after
-        def days = ChronoUnit.DAYS.between(releaseTuesday, now)
-        if (days >= 0 && days <= 7) {
-            releasePeriod = true
-        }
-    } else {
-        echo "No releases this month"
+    // Release period no "testing" trigger, from release tuesday to 7 days after
+    def days = ChronoUnit.DAYS.between(releaseTuesday, now)
+    if (days >= 0 && days <= 7) {
+        releasePeriod = true
     }
 
     echo "Is within release period? "+releasePeriod

--- a/pipelines/build/common/trigger_beta_build.groovy
+++ b/pipelines/build/common/trigger_beta_build.groovy
@@ -15,6 +15,12 @@ limitations under the License.
 
 import java.nio.file.NoSuchFileException
 import groovy.json.JsonOutput
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.Month
+import java.time.DayOfWeek
+import java.time.temporal.ChronoUnit
+import java.time.temporal.TemporalAdjusters
 
 /*
   Detect new upstream OpenJDK source build tag, and trigger a "beta" pipeline build
@@ -27,10 +33,6 @@ def variant="${params.VARIANT}"
 def mirrorRepo="${params.MIRROR_REPO}"
 def version="${params.JDK_VERSION}".toInteger()
 def binariesRepo="${params.BINARIES_REPO}"
-
-// GitHub issue configuration for release status checking
-def releaseStatusGithubRepo = "adoptium/temurin"
-def releaseStatusSearchPhrase = "Release Status per Platform"
 
 def triggerMainBuild = false
 def triggerEvaluationBuild = false
@@ -45,112 +47,34 @@ def evaluationTargetConfigurations = overrideEvaluationTargetConfigurations
 def latestAdoptTag
 def publishJobTag
 
-// Check if a GitHub issue containing the configured search phrase is open
-// and was created by an authorized user from release-managers.json
-// Returns true if such an issue is open (release ongoing), false otherwise
-// NOTE: On any error or failure, assumes release IS ongoing (fail-safe to disable tests)
-def isReleaseOngoing(String githubRepo, String searchPhrase) {
-    def releaseOngoing = false
+// Is the current day within the release period of from the previous Saturday to the following Sunday
+// from the release Tuesday ?
+// Release Tuesday is now the 3rd Tuesday of the month
+def isDuringReleasePeriod() {
+    def releasePeriod = false
+    def now = ZonedDateTime.now(ZoneId.of('UTC'))
+    def month = now.getMonth()
 
-    try {
-        echo "Checking GitHub ${githubRepo} for open issue containing: '${searchPhrase}'"
+    // Is it a release month? CPU updates in Jan, Apr, Jul, Oct
+    // New major versions are released in Mar and Sept
+    if (month == Month.JANUARY || month == Month.MARCH || month == Month.APRIL || month == Month.JULY || month == Month.SEPTEMBER || month == Month.OCTOBER) {
+        // Yes, calculate release Tuesday, which is the 3rd Tuesday of the month
+        def day1st = now.withDayOfMonth(1)
+        def releaseTuesday = day1st.with(TemporalAdjusters.dayOfWeekInMonth(3, DayOfWeek.TUESDAY))
+        echo "Release Tuesday for this month is: "+releaseTuesday
 
-        // First, fetch the list of authorized users from release-managers.json
-        def authUsersUrl = "https://raw.githubusercontent.com/adoptium/temurin/main/.github/workflows/release-managers.json"
-        def rcAuth = sh(script: "curl -s -o release-managers.json '${authUsersUrl}'", returnStatus: true)
-
-        if (rcAuth != 0) {
-            echo "ERROR: Failed to fetch authorized users list. Assuming release IS ongoing (fail-safe)."
-            return true
+        // Release period no "testing" trigger, from release tuesday to 7 days after
+        def days = ChronoUnit.DAYS.between(releaseTuesday, now)
+        if (days >= 0 && days <= 7) {
+            releasePeriod = true
         }
-
-        // Extract the authorized_users array from the JSON using jq
-        def authorizedUsers = sh(script: "jq -r '.authorized_users[]' release-managers.json | tr '\\n' ' '", returnStdout: true).trim()
-
-        if (authorizedUsers == "") {
-            echo "ERROR: No authorized users found in release-managers.json. Assuming release IS ongoing (fail-safe)."
-            return true
-        }
-
-        echo "Authorized users: ${authorizedUsers}"
-
-        // Use GitHub Issues API directly (better rate limits than Search API)
-        // List open issues and filter by title locally
-        def issuesUrl = "https://api.github.com/repos/${githubRepo}/issues?state=open&per_page=100"
-
-        // Fetch the open issues
-        def rc = sh(script: "curl -s -o issue_search.json '${issuesUrl}'", returnStatus: true)
-
-        if (rc == 0) {
-            // Filter issues by title containing the search phrase using jq
-            // Save to file to avoid shell variable issues with control characters in JSON
-            def rcFilter = sh(script: "jq '[.[] | select(.title | contains(\"${searchPhrase}\"))]' issue_search.json > matching_issues.json", returnStatus: true)
-            
-            if (rcFilter != 0) {
-                echo "ERROR: Failed to filter issues. Assuming release IS ongoing (fail-safe)."
-                return true
-            }
-
-            // Count matching issues from the file
-            def issueCount = sh(script: "jq 'length' matching_issues.json", returnStdout: true).trim()
-
-            // Check if issueCount is valid (not null, not empty, and is a number)
-            if (issueCount == "" || issueCount == "null" || !issueCount.isInteger()) {
-                echo "ERROR: Could not parse issue count from filtered results. Assuming release IS ongoing (fail-safe)."
-                return true
-            }
-
-            if (issueCount.toInteger() > 0) {
-                echo "Found ${issueCount} open issue(s) containing '${searchPhrase}' in ${githubRepo}"
-
-                // Check all matching issues to see if any were created by an authorized user
-                // Extract all issue creators using jq from the file
-                def allCreators = sh(script: "jq -r '.[].user.login' matching_issues.json", returnStdout: true).trim()
-
-                if (allCreators != "") {
-                    def creators = allCreators.split('\n')
-                    echo "Checking ${creators.size()} issue(s) for authorized creators..."
-
-                    for (int i = 0; i < creators.size(); i++) {
-                        def issueCreator = creators[i].trim()
-                        def issueTitle = sh(script: "jq -r '.[${i}].title' matching_issues.json", returnStdout: true).trim()
-
-                        echo "Issue ${i + 1}: '${issueTitle}' created by '${issueCreator}'"
-
-                        // Check if the creator is in the authorized users list
-                        def isAuthorized = sh(script: "echo '${authorizedUsers}' | grep -w '${issueCreator}'", returnStatus: true)
-
-                        if (isAuthorized == 0) {
-                            echo "Issue creator '${issueCreator}' is authorized. Release is ongoing."
-                            releaseOngoing = true
-                            break  // Found an authorized issue, no need to check further
-                        } else {
-                            echo "Issue creator '${issueCreator}' is NOT in the authorized users list."
-                        }
-                    }
-
-                    if (!releaseOngoing) {
-                        echo "None of the matching issues were created by authorized users. Release is NOT ongoing."
-                    }
-                } else {
-                    echo "ERROR: Could not determine issue creators. Assuming release IS ongoing (fail-safe)."
-                    return true
-                }
-            } else {
-                echo "No open issues found containing '${searchPhrase}' in ${githubRepo}"
-            }
-        } else {
-            echo "ERROR: Failed to query GitHub API for issue status. Assuming release IS ongoing (fail-safe)."
-            return true
-        }
-    } catch (Exception e) {
-        echo "ERROR: Exception checking GitHub issue status: ${e.message}"
-        echo "Assuming release IS ongoing due to error (fail-safe)."
-        return true
+    } else {
+        echo "No releases this month"
     }
 
-    echo "Is release ongoing (based on GitHub issue and authorized user)? ${releaseOngoing}"
-    return releaseOngoing
+    echo "Is within release period? "+releasePeriod
+
+    return releasePeriod
 }
 
 // Load the given targetConfigurations from the pipeline config
@@ -263,9 +187,8 @@ node('worker') {
     // binariesRepoTag is the resulting published github binaries release tag created by the Adoptium "publish job"
     def binariesRepoTag = publishJobTag + "-beta"
 
-    // Check if release is ongoing by querying for GitHub issue
-    if (isReleaseOngoing(releaseStatusGithubRepo, releaseStatusSearchPhrase)) {
-        echo "Release is ongoing (GitHub issue containing '${releaseStatusSearchPhrase}' is open in ${releaseStatusGithubRepo}), so testing is disabled."
+    if (isDuringReleasePeriod()) {
+        echo "We are within a release period (prior week previous Saturday to the following Sunday around the release Tuesday), so testing is disabled."
         enableTesting = false
     }
 


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1499

- EA Beta Weekly builds now trigger with testing as long as outside 7 days after the 3rd Tuesday of the month (does not know if there is a CSPU or not..)
- EA Beta Weekly builds that trigger with testing enabled, will only "Enable TCK" for Temurin primary platforms
- 